### PR TITLE
Introduce object v-table

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -267,46 +267,39 @@ enum ag_object_cmp {
 
 
 /*
- *      The ag_object_payload type represents the payload of an object [DM:??].
- */
-typedef void ag_object_payload;
-
-
-/*
  *      The ag_object_vtable_copy type is the callback used to make a deep copy
  *      of the payload of an object [DM:??].
  */
-typedef ag_object_payload *(ag_object_method_copy)(
-        const ag_object_payload *ctx);
+typedef void *(ag_object_method_copy)(const void *payload);
 
 
 /*
  *      The ag_object_vtable_free type is the callback used to release the
  *      resources allocated to the payload of an object [DM:??].
  */
-typedef void (ag_object_method_free)(ag_object_payload *ctx);
+typedef void (ag_object_method_free)(void *payload);
 
 
 /*
  *      The ag_object_vtable_len type is the callback used to determine the
  *      length of the payload of an object [DM:??].
  */
-typedef size_t (ag_object_method_len)(const ag_object_payload *ctx);
+typedef size_t (ag_object_method_len)(const void *payload);
 
 
 /*
  *      The ag_object_vtable_cmp type is the callback used to compare two object
  *      instances [DM:??].
  */
-typedef enum ag_object_cmp (ag_object_method_cmp)(const ag_object *ctx,
-        const ag_object *cmp);
+typedef enum ag_object_cmp (ag_object_method_cmp)(const ag_object *lhs,
+        const ag_object *rhs);
 
 
 /*
  *      The ag_object_vtable_str type is the callback used to generate the
  *      string representation of an object [DM:??].
  */
-typedef const char *(ag_object_method_str)(const ag_object *ctx);
+typedef const char *(ag_object_method_str)(const ag_object *obj);
 
 
 /*
@@ -326,7 +319,7 @@ struct ag_object_method {
  *      The ag_object_new() interface function creates a new instance of an
  *      object [DM:??].
  */
-extern ag_hot ag_object *ag_object_new(unsigned id, ag_object_payload *ld,
+extern ag_hot ag_object *ag_object_new(unsigned id, void *payload,
         const struct ag_object_method *vt);
 
 
@@ -334,7 +327,7 @@ extern ag_hot ag_object *ag_object_new(unsigned id, ag_object_payload *ld,
  *      The ag_object_new_noid() interface function creates a new instance of an
  *      object without an object ID [DM:??].
  */
-extern ag_hot ag_object *ag_object_new_noid(ag_object_payload *ld,
+extern ag_hot ag_object *ag_object_new_noid(void *payload,
         const struct ag_object_method *vt);
 
 
@@ -410,8 +403,8 @@ inline ag_pure bool ag_object_eq(const ag_object *ctx, const ag_object *cmp)
 
 
 /*
- *      The ag_object_gt() interface function check is an object is greater than
- *      another [DM:??].
+ *      The ag_object_gt() interface function checks if an object is greater 
+ *      than another [DM:??].
  */
 inline ag_pure bool ag_object_gt(const ag_object *ctx, const ag_object *cmp)
 {
@@ -421,18 +414,17 @@ inline ag_pure bool ag_object_gt(const ag_object *ctx, const ag_object *cmp)
 
 
 /*
- *      The ag_object_payload_hnd() interface function gets a read-only handle
+ *      The ag_object_payload() interface function gets a read-only handle
  *      to the payload of an object [DM:??].
  */
-extern ag_hot ag_pure const ag_object_payload *ag_object_payload_hnd(
-        const ag_object *ctx);
+extern ag_hot ag_pure const void *ag_object_payload(const ag_object *ctx);
 
 
 /*
- *      The ag_object_payload_hnd_mutable() interface function gets a read-write
+ *      The ag_object_payload_mutable() interface function gets a read-write
  *      handle to the payload of an object [DM:??].
  */
-extern ag_hot ag_object_payload *ag_object_payload_hnd_mutable(ag_object **ctx);
+extern ag_hot void *ag_object_payload_mutable(ag_object **ctx);
 
 
 /*

--- a/src/api.h
+++ b/src/api.h
@@ -271,6 +271,9 @@ typedef size_t (ag_object_method_sz)(const void *payload);
 typedef size_t (ag_object_method_len)(const void *payload);
 
 
+                                    /* method to get hash of object [AgDM:??] */
+typedef size_t (ag_object_method_hash)(const ag_object *obj);
+
                                    /* method to compare two objects [AgDM:??] */
 typedef enum ag_object_cmp (ag_object_method_cmp)(const ag_object *lhs,
         const ag_object *rhs);
@@ -286,6 +289,7 @@ struct ag_object_method {
     ag_object_method_dispose *dispose;
     ag_object_method_sz *sz;
     ag_object_method_len *len;
+    ag_object_method_hash *hash;
     ag_object_method_cmp *cmp;
     ag_object_method_str *str;
 };
@@ -318,7 +322,7 @@ extern ag_cold void ag_object_id_set(ag_object **ctx, unsigned id);
 
 
                                              /* gets hash of object [AgDM:??] */
-extern ag_pure unsigned ag_object_hash(const ag_object *ctx, size_t len);
+extern ag_pure unsigned ag_object_hash(const ag_object *ctx);
 
 
                                                 /* gets object size [AgDM:??] */

--- a/src/api.h
+++ b/src/api.h
@@ -294,6 +294,12 @@ struct ag_object_method {
     ag_object_method_str *str;
 };
 
+extern void ag_object_vtable_init(void);
+extern void ag_object_vtable_exit(void);
+extern const struct ag_object_method *ag_object_vtable_get(unsigned type);
+extern void ag_object_vtable_set(unsigned type, 
+        const struct ag_object_method *meth);
+
 
                                               /* creates new object [AgDM:??] */
 extern ag_hot ag_object *ag_object_new(unsigned type, unsigned id, 

--- a/src/api.h
+++ b/src/api.h
@@ -294,11 +294,25 @@ struct ag_object_method {
     ag_object_method_str *str;
 };
 
+
+                                      /* initialises object v-table [AgDM:??] */
 extern void ag_object_vtable_init(void);
+
+
+                                       /* shuts down object v-table [AgDM:??] */
 extern void ag_object_vtable_exit(void);
+
+
+                         /* checks if methods for object type exist [AgDM:??] */
 extern ag_pure bool ag_object_vtable_exists(unsigned type);
+
+
+                                     /* gets methods of object type [AgDM:??] */
 extern ag_pure ag_hot const struct ag_object_method *ag_object_vtable_get(
         unsigned type);
+
+
+                                     /* sets methods of object type [AgDM:??] */
 extern void ag_object_vtable_set(unsigned type, 
         const struct ag_object_method *meth);
 

--- a/src/api.h
+++ b/src/api.h
@@ -234,19 +234,11 @@ extern void ag_mempool_free(void **bfr);
  */
 
 
-/*
- *      The ag_object abstract data type represents a reference-counted
- *      polymorphic object that is the base for all other ADTs of the Argent 
- *      Library [DM:??].
- */
+                                        /* base object for all ADTs [AgDM:??] */
 typedef struct ag_object ag_object;
 
 
-/*
- *      The ag_object_smart macro represents a smart version of an ag_object ADT
- *      that is able to automatically release the heap memory allocated to it
- *      once it goes out of scope [DM:??].
- */
+                                      /* smart version of ag_object [AgDM:??] */
 #if (defined __GNUC__ || defined __clang__)
 #   define ag_object_smart __attribute__((cleanup(ag_object_free))) ag_object
 #else
@@ -255,10 +247,7 @@ typedef struct ag_object ag_object;
 #endif
 
 
-/*
- *      The ag_object_cmp enumeration is a tristate representation of the result
- *      of comparing to object instances [DM:??].
- */
+                        /* tristate result of comparing two objects [AgDM:??] */
 enum ag_object_cmp {
     AG_OBJECT_CMP_LT = -1,
     AG_OBJECT_CMP_EQ = 0,
@@ -266,46 +255,28 @@ enum ag_object_cmp {
 };
 
 
-/*
- *      The ag_object_vtable_copy type is the callback used to make a deep copy
- *      of the payload of an object [DM:??].
- */
+                                   /* method to copy object payload [AgDM:??] */
 typedef void *(ag_object_method_copy)(const void *payload);
 
 
-/*
- *      The ag_object_vtable_free type is the callback used to release the
- *      resources allocated to the payload of an object [DM:??].
- */
+                                /* method to dispose object payload [AgDM:??] */
 typedef void (ag_object_method_free)(void *payload);
 
 
-/*
- *      The ag_object_vtable_len type is the callback used to determine the
- *      length of the payload of an object [DM:??].
- */
+                          /* method to get length of object payload [AgDM:??] */
 typedef size_t (ag_object_method_len)(const void *payload);
 
 
-/*
- *      The ag_object_vtable_cmp type is the callback used to compare two object
- *      instances [DM:??].
- */
+                                   /* method to compare two objects [AgDM:??] */
 typedef enum ag_object_cmp (ag_object_method_cmp)(const ag_object *lhs,
         const ag_object *rhs);
 
 
-/*
- *      The ag_object_vtable_str type is the callback used to generate the
- *      string representation of an object [DM:??].
- */
+                   /* method to get string representation of object [AgDM:??] */
 typedef const char *(ag_object_method_str)(const ag_object *obj);
 
 
-/*
- *      The ag_object_vtable structure is the virtual table of polymorphic
- *      methods of an object [DM:??].
- */
+                                              /* methods of object [AgDM::??] */
 struct ag_object_method {
     ag_object_method_copy *copy;
     ag_object_method_free *free;
@@ -315,75 +286,46 @@ struct ag_object_method {
 };
 
 
-/*
- *      The ag_object_new() interface function creates a new instance of an
- *      object [DM:??].
- */
+                                              /* creates new object [AgDM:??] */
 extern ag_hot ag_object *ag_object_new(unsigned id, void *payload,
         const struct ag_object_method *vt);
 
 
-/*
- *      The ag_object_new_noid() interface function creates a new instance of an
- *      object without an object ID [DM:??].
- */
+                                   /* creates new object without ID [AgDM:??] */
 extern ag_hot ag_object *ag_object_new_noid(void *payload,
         const struct ag_object_method *vt);
 
 
-/*
- *      The ag_object_copy() interface function creates a lazy copy of an object
- *      [DM:??].
- */
+                                                  /* copies object [AgDM:??] */
 extern ag_hot ag_object *ag_object_copy(const ag_object *ctx);
 
 
-/*
- *      The ag_object_free() interface function releases the resources allocated
- *      to an object [DM:??].
- */
+                                                 /* disposes object [AgDM:??] */
 extern ag_hot void ag_object_free(ag_object **ctx);
 
 
-/*
- *      The ag_object_id() interface function gets the ID of an object [DM:??].
- */
+                                                  /* gets object ID [AgDM:??] */
 extern ag_pure unsigned ag_object_id(const ag_object *ctx);
 
 
-/*
- *      The ag_object_id_set() interface function sets the ID of an object
- *      [DM:??].
- */
+                                                  /* sets object ID [AgDM:??] */
 extern ag_cold void ag_object_id_set(ag_object **ctx, unsigned id);
 
 
-/*
- *      The ag_object_hash() interface function gets the hash of an object
- *      [DM:??].
- */
+                                             /* gets hash of object [AgDM:??] */
 extern ag_pure unsigned ag_object_hash(const ag_object *ctx, size_t len);
 
 
-/*
- *      The ag_object_len() interface function gets the length of an object
- *      [DM:??].
- */
+                                              /* gets object length [AgDM:??] */
 extern ag_pure size_t ag_object_len(const ag_object *ctx);
 
 
-/*
- *      The ag_object_cmp() interface function compares one object against
- *      another [DM:??].
- */
+                                            /* compares two objects [AgDM:??] */
 extern ag_pure enum ag_object_cmp ag_object_cmp(const ag_object *ctx, 
         const ag_object *cmp);
 
 
-/*
- *      The ag_object_lt() interface function checks if an object is less than
- *      another [DM:??].
- */
+                           /* checks if object is less than another [AgDM:??] */
 inline ag_pure bool ag_object_lt(const ag_object *ctx, const ag_object *cmp)
 {
     ag_assert (ctx && cmp);
@@ -391,10 +333,7 @@ inline ag_pure bool ag_object_lt(const ag_object *ctx, const ag_object *cmp)
 }
 
 
-/*
- *      The ag_object_eq() interface function checks if an object is equivalent
- *      to another [DM:??].
- */
+                       /* checks if object is equivalent to another [AgDM:??] */
 inline ag_pure bool ag_object_eq(const ag_object *ctx, const ag_object *cmp)
 {
     ag_assert (ctx && cmp);
@@ -402,10 +341,7 @@ inline ag_pure bool ag_object_eq(const ag_object *ctx, const ag_object *cmp)
 }
 
 
-/*
- *      The ag_object_gt() interface function checks if an object is greater 
- *      than another [DM:??].
- */
+                        /* checks if object is greater than another [AgDM:??] */
 inline ag_pure bool ag_object_gt(const ag_object *ctx, const ag_object *cmp)
 {
     ag_assert (ctx && cmp);
@@ -413,23 +349,14 @@ inline ag_pure bool ag_object_gt(const ag_object *ctx, const ag_object *cmp)
 }
 
 
-/*
- *      The ag_object_payload() interface function gets a read-only handle
- *      to the payload of an object [DM:??].
- */
+                         /* gets read-only handle to object payload [AgDM:??] */
 extern ag_hot ag_pure const void *ag_object_payload(const ag_object *ctx);
 
 
-/*
- *      The ag_object_payload_mutable() interface function gets a read-write
- *      handle to the payload of an object [DM:??].
- */
+                        /* gets read-write handle to object payload [AgDM:??] */
 extern ag_hot void *ag_object_payload_mutable(ag_object **ctx);
 
 
-/*
- *      The ag_object_str() interface function generates the string
- *      representation of an object [DM:??].
- */
+                            /* gets string representation of object [AgDM:??] */
 extern ag_pure const char *ag_object_str(const ag_object *ctx);
 

--- a/src/api.h
+++ b/src/api.h
@@ -263,6 +263,10 @@ typedef void *(ag_object_method_copy)(const void *payload);
 typedef void (ag_object_method_dispose)(void *payload);
 
 
+                            /* method to get size of object payload [AgDM:??] */
+typedef size_t (ag_object_method_sz)(const void *payload);
+
+
                           /* method to get length of object payload [AgDM:??] */
 typedef size_t (ag_object_method_len)(const void *payload);
 
@@ -280,6 +284,7 @@ typedef const char *(ag_object_method_str)(const ag_object *obj);
 struct ag_object_method {
     ag_object_method_copy *copy;
     ag_object_method_dispose *dispose;
+    ag_object_method_sz *sz;
     ag_object_method_len *len;
     ag_object_method_cmp *cmp;
     ag_object_method_str *str;
@@ -314,6 +319,10 @@ extern ag_cold void ag_object_id_set(ag_object **ctx, unsigned id);
 
                                              /* gets hash of object [AgDM:??] */
 extern ag_pure unsigned ag_object_hash(const ag_object *ctx, size_t len);
+
+
+                                                /* gets object size [AgDM:??] */
+extern ag_pure size_t ag_object_sz(const ag_object *ctx);
 
 
                                               /* gets object length [AgDM:??] */

--- a/src/api.h
+++ b/src/api.h
@@ -283,7 +283,7 @@ typedef enum ag_object_cmp (ag_object_method_cmp)(const ag_object *lhs,
 typedef const char *(ag_object_method_str)(const ag_object *obj);
 
 
-                                              /* methods of object [AgDM::??] */
+                                              /* methods of object [AgDM:??] */
 struct ag_object_method {
     ag_object_method_copy *copy;
     ag_object_method_dispose *dispose;
@@ -296,12 +296,12 @@ struct ag_object_method {
 
 
                                               /* creates new object [AgDM:??] */
-extern ag_hot ag_object *ag_object_new(unsigned id, void *payload,
-        const struct ag_object_method *vt);
+extern ag_hot ag_object *ag_object_new(unsigned type, unsigned id, 
+        void *payload, const struct ag_object_method *vt);
 
 
                                    /* creates new object without ID [AgDM:??] */
-extern ag_hot ag_object *ag_object_new_noid(void *payload,
+extern ag_hot ag_object *ag_object_new_noid(unsigned type, void *payload,
         const struct ag_object_method *vt);
 
 
@@ -311,6 +311,10 @@ extern ag_hot ag_object *ag_object_copy(const ag_object *ctx);
 
                                                  /* disposes object [AgDM:??] */
 extern ag_hot void ag_object_dispose(ag_object **ctx);
+
+
+                                                /* gets object type [AgDM:??] */
+extern ag_pure unsigned ag_object_type(const ag_object *ctx);
 
 
                                                   /* gets object ID [AgDM:??] */

--- a/src/api.h
+++ b/src/api.h
@@ -296,7 +296,7 @@ struct ag_object_method {
 
 
                                       /* initialises object v-table [AgDM:??] */
-extern void ag_object_vtable_init(void);
+extern void ag_object_vtable_init(size_t len);
 
 
                                        /* shuts down object v-table [AgDM:??] */

--- a/src/api.h
+++ b/src/api.h
@@ -260,7 +260,7 @@ typedef void *(ag_object_method_copy)(const void *payload);
 
 
                                 /* method to dispose object payload [AgDM:??] */
-typedef void (ag_object_method_free)(void *payload);
+typedef void (ag_object_method_dispose)(void *payload);
 
 
                           /* method to get length of object payload [AgDM:??] */
@@ -279,7 +279,7 @@ typedef const char *(ag_object_method_str)(const ag_object *obj);
                                               /* methods of object [AgDM::??] */
 struct ag_object_method {
     ag_object_method_copy *copy;
-    ag_object_method_free *free;
+    ag_object_method_dispose *dispose;
     ag_object_method_len *len;
     ag_object_method_cmp *cmp;
     ag_object_method_str *str;
@@ -301,7 +301,7 @@ extern ag_hot ag_object *ag_object_copy(const ag_object *ctx);
 
 
                                                  /* disposes object [AgDM:??] */
-extern ag_hot void ag_object_free(ag_object **ctx);
+extern ag_hot void ag_object_dispose(ag_object **ctx);
 
 
                                                   /* gets object ID [AgDM:??] */

--- a/src/api.h
+++ b/src/api.h
@@ -276,7 +276,7 @@ typedef void ag_object_payload;
  *      The ag_object_vtable_copy type is the callback used to make a deep copy
  *      of the payload of an object [DM:??].
  */
-typedef ag_object_payload *(ag_object_vtable_copy)(
+typedef ag_object_payload *(ag_object_method_copy)(
         const ag_object_payload *ctx);
 
 
@@ -284,21 +284,21 @@ typedef ag_object_payload *(ag_object_vtable_copy)(
  *      The ag_object_vtable_free type is the callback used to release the
  *      resources allocated to the payload of an object [DM:??].
  */
-typedef void (ag_object_vtable_free)(ag_object_payload *ctx);
+typedef void (ag_object_method_free)(ag_object_payload *ctx);
 
 
 /*
  *      The ag_object_vtable_len type is the callback used to determine the
  *      length of the payload of an object [DM:??].
  */
-typedef size_t (ag_object_vtable_len)(const ag_object_payload *ctx);
+typedef size_t (ag_object_method_len)(const ag_object_payload *ctx);
 
 
 /*
  *      The ag_object_vtable_cmp type is the callback used to compare two object
  *      instances [DM:??].
  */
-typedef enum ag_object_cmp (ag_object_vtable_cmp)(const ag_object *ctx,
+typedef enum ag_object_cmp (ag_object_method_cmp)(const ag_object *ctx,
         const ag_object *cmp);
 
 
@@ -306,19 +306,19 @@ typedef enum ag_object_cmp (ag_object_vtable_cmp)(const ag_object *ctx,
  *      The ag_object_vtable_str type is the callback used to generate the
  *      string representation of an object [DM:??].
  */
-typedef const char *(ag_object_vtable_str)(const ag_object *ctx);
+typedef const char *(ag_object_method_str)(const ag_object *ctx);
 
 
 /*
  *      The ag_object_vtable structure is the virtual table of polymorphic
  *      methods of an object [DM:??].
  */
-struct ag_object_vtable {
-    ag_object_vtable_copy *copy;
-    ag_object_vtable_free *free;
-    ag_object_vtable_len *len;
-    ag_object_vtable_cmp *cmp;
-    ag_object_vtable_str *str;
+struct ag_object_method {
+    ag_object_method_copy *copy;
+    ag_object_method_free *free;
+    ag_object_method_len *len;
+    ag_object_method_cmp *cmp;
+    ag_object_method_str *str;
 };
 
 
@@ -327,7 +327,7 @@ struct ag_object_vtable {
  *      object [DM:??].
  */
 extern ag_hot ag_object *ag_object_new(unsigned id, ag_object_payload *ld,
-        const struct ag_object_vtable *vt);
+        const struct ag_object_method *vt);
 
 
 /*
@@ -335,7 +335,7 @@ extern ag_hot ag_object *ag_object_new(unsigned id, ag_object_payload *ld,
  *      object without an object ID [DM:??].
  */
 extern ag_hot ag_object *ag_object_new_noid(ag_object_payload *ld,
-        const struct ag_object_vtable *vt);
+        const struct ag_object_method *vt);
 
 
 /*

--- a/src/api.h
+++ b/src/api.h
@@ -296,6 +296,7 @@ struct ag_object_method {
 
 extern void ag_object_vtable_init(void);
 extern void ag_object_vtable_exit(void);
+extern ag_pure bool ag_object_vtable_exists(unsigned type);
 extern ag_pure ag_hot const struct ag_object_method *ag_object_vtable_get(
         unsigned type);
 extern void ag_object_vtable_set(unsigned type, 

--- a/src/api.h
+++ b/src/api.h
@@ -296,19 +296,24 @@ struct ag_object_method {
 
 extern void ag_object_vtable_init(void);
 extern void ag_object_vtable_exit(void);
-extern const struct ag_object_method *ag_object_vtable_get(unsigned type);
+extern ag_pure ag_hot const struct ag_object_method *ag_object_vtable_get(
+        unsigned type);
 extern void ag_object_vtable_set(unsigned type, 
+        const struct ag_object_method *meth);
+
+
+                                                /* registers object [AgDM:??] */
+extern void ag_object_register(unsigned type, 
         const struct ag_object_method *meth);
 
 
                                               /* creates new object [AgDM:??] */
 extern ag_hot ag_object *ag_object_new(unsigned type, unsigned id, 
-        void *payload, const struct ag_object_method *vt);
+        void *payload);
 
 
                                    /* creates new object without ID [AgDM:??] */
-extern ag_hot ag_object *ag_object_new_noid(unsigned type, void *payload,
-        const struct ag_object_method *vt);
+extern ag_hot ag_object *ag_object_new_noid(unsigned type, void *payload);
 
 
                                                   /* copies object [AgDM:??] */

--- a/src/object-vtable.c
+++ b/src/object-vtable.c
@@ -1,6 +1,35 @@
+/*******************************************************************************
+ *                        __   ____   ___  ____  __ _  ____ 
+ *                       / _\ (  _ \ / __)(  __)(  ( \(_  _)
+ *                      /    \ )   /( (_ \ ) _) /    /  )(  
+ *                      \_/\_/(__\_) \___/(____)\_)__) (__)                     
+ *
+ * Argent Library
+ * Copyright (c) 2020 Abhishek Chakravarti <abhishek@taranjali.org>
+ *
+ * This file is part of the Argent Library. It implements the object v-table
+ * interface of the Argent Library.
+ *
+ * The contents of this file are released under the GPLv3 License. See the
+ * accompanying LICENSE file or the generated Developer Manual (section I:?) for 
+ * complete licensing details.
+ *
+ * BY CONTINUING TO USE AND/OR DISTRIBUTE THIS FILE, YOU ACKNOWLEDGE THAT YOU
+ * HAVE UNDERSTOOD THESE LICENSE TERMS AND ACCEPT TO BE LEGALLY BOUND BY THEM.
+ ******************************************************************************/
+
+
 #include "./api.h"
 
 
+
+
+/*******************************************************************************
+ *                               TYPE DEFINITIONS
+ */
+
+
+                                             /* v-table bucket node [AgDM:??] */
 struct node {
     unsigned key;
     struct ag_object_method *val;
@@ -8,12 +37,29 @@ struct node {
 };
 
 
+
+
+/*******************************************************************************
+ *                                   GLOBALS
+ */
+
+
+                                    /* number of buckets in v-table [AgDM:??] */
 #define VTABLE_BUCKETS 64
 
 
+                                       /* v-table of object methods [AgDM:??] */
 ag_threadlocal struct node **vtable = NULL;
 
 
+
+
+/*******************************************************************************
+ *                            HELPER IMPLEMENTATION
+ */
+
+
+                                                /* creates new node [AgDM:??] */
 static inline struct node *node_new(unsigned key, 
         const struct ag_object_method *val, struct node *nxt)
 {
@@ -34,13 +80,22 @@ static inline struct node *node_new(unsigned key,
 }
 
 
-static inline void node_free(struct node *n)
+                                                 /* disposes a node [AgDM:??] */
+static inline void node_dispose(struct node *n)
 {
     ag_mempool_free((void **) &n->val);
     ag_mempool_free((void **) &n);
 }
 
 
+
+
+/*******************************************************************************
+ *                           INTERFACE IMPLEMENTATION
+ */
+
+
+                       /* implementation of ag_object_vtable_init() [AgDM:??] */
 extern void ag_object_vtable_init(void)
 {
     if (ag_likely (!vtable))
@@ -48,6 +103,7 @@ extern void ag_object_vtable_init(void)
 }
 
 
+                       /* implementation of ag_object_vtable_exit() [AgDM:??] */
 extern void ag_object_vtable_exit(void)
 {
     struct node *n, *nxt;
@@ -56,7 +112,7 @@ extern void ag_object_vtable_exit(void)
         if ((n = vtable[i])) {
             do {
                 nxt = n->nxt;
-                node_free(n);
+                node_dispose(n);
                 n = nxt;
             } while (n);
         }
@@ -64,6 +120,7 @@ extern void ag_object_vtable_exit(void)
 }
 
 
+                     /* implementation of ag_object_vtable_exists() [AgDM:??] */
 extern bool ag_object_vtable_exists(unsigned type)
 {
     ag_assert (type);
@@ -83,6 +140,7 @@ extern bool ag_object_vtable_exists(unsigned type)
 }
 
 
+                        /* implementation of ag_object_vtable_get() [AgDM:??] */
 extern const struct ag_object_method *ag_object_vtable_get(unsigned type)
 {
     ag_assert (type);
@@ -103,6 +161,7 @@ extern const struct ag_object_method *ag_object_vtable_get(unsigned type)
 }
 
 
+                        /* implementation of ag_object_vtable_set() [AgDM:??] */
 extern void ag_object_vtable_set(unsigned type, 
         const struct ag_object_method *meth)
 {

--- a/src/object-vtable.c
+++ b/src/object-vtable.c
@@ -1,0 +1,116 @@
+#include "./api.h"
+
+
+struct node {
+    unsigned key;
+    struct ag_object_method *val;
+    struct node *nxt;
+};
+
+
+#define VTABLE_BUCKETS 64
+
+
+ag_threadlocal struct node **vtable = NULL;
+
+
+static inline struct node *node_new(unsigned key, 
+        const struct ag_object_method *val, struct node *nxt)
+{
+    struct node *n = ag_mempool_new(sizeof *n);
+    n->key = key;
+    n->nxt = nxt;
+
+    n->val = ag_mempool_new(sizeof *n->val);
+    n->val->copy = val->copy;
+    n->val->dispose = val->dispose;
+    n->val->sz = val->sz;
+    n->val->len = val->len;
+    n->val->hash = val->hash;
+    n->val->cmp = val->cmp;
+    n->val->str = val->str;
+
+    return n;
+}
+
+
+static inline void node_free(struct node *n)
+{
+    ag_mempool_free((void **) &n->val);
+    ag_mempool_free((void **) &n);
+}
+
+
+extern void ag_object_vtable_init(void)
+{
+    if (ag_likely (!vtable))
+        vtable = ag_mempool_new(sizeof *vtable * VTABLE_BUCKETS);
+}
+
+
+extern void ag_object_vtable_exit(void)
+{
+    struct node *n, *nxt;
+
+    for (register size_t i = 0; i < VTABLE_BUCKETS; i++) {
+        if ((n = vtable[i])) {
+            do {
+                nxt = n->nxt;
+                node_free(n);
+                n = nxt;
+            } while (n);
+        }
+    }
+}
+
+
+extern bool ag_object_vtable_exists(unsigned type)
+{
+    ag_assert (type);
+    unsigned hash = type % VTABLE_BUCKETS;
+
+    ag_assert (vtable);
+    struct node *n = vtable[hash];
+
+    while (n) {
+        if (n->key == type)
+            return true;
+
+        n = n->nxt;
+    }
+
+    return false;
+}
+
+
+extern const struct ag_object_method *ag_object_vtable_get(unsigned type)
+{
+    ag_assert (type);
+    unsigned hash = type % VTABLE_BUCKETS;
+
+    ag_assert (vtable);
+    struct node *n = vtable[hash];
+
+    while (n) {
+        if (n->key == type)
+            return n->val;
+
+        n = n->nxt;
+    }
+
+    ag_assert (n);
+    return NULL;
+}
+
+
+extern void ag_object_vtable_set(unsigned type, 
+        const struct ag_object_method *meth)
+{
+    ag_assert (type);
+    unsigned hash = type % VTABLE_BUCKETS;
+
+    ag_assert (vtable && !ag_object_vtable_exists(type));
+    struct node *n = node_new(type, meth, vtable[hash]);
+    vtable[hash] = n;
+}
+

--- a/src/object.c
+++ b/src/object.c
@@ -26,7 +26,7 @@
 
 
 /*******************************************************************************
- *                              TYPE DEFINITIONS
+ *                               TYPE DEFINITIONS
  */
 
 
@@ -45,32 +45,25 @@ struct ag_object {
 
 
 /*******************************************************************************
- *                           HELPER IMPLEMENTATION
+ *                            HELPER IMPLEMENTATION
  */
 
 
-/*
- *      The copy_default() helper function is the default callback used in case
- *      the client code does not supply a callback to copy the payload of an
- *      object instance.
- */
+                                             /* default copy method [AgDM:??] */
 static inline void *copy_default(const void *payload)
 {
     return (void *) payload;
 }
 
 
-/*
- *      The free_default() helper function is the default callback used in case
- *      the client code does not supply a callback to free the payload of an
- *      object instance [DM:??].
- */
+                                          /* default dispose method [AgDM:??] */
 static inline void dispose_default(void *payload)
 {
     (void) payload;
 }
 
 
+                                             /* default size method [AgDM:??] */
 static inline size_t sz_default(const void *payload)
 {
     (void) payload;
@@ -78,11 +71,7 @@ static inline size_t sz_default(const void *payload)
 }
 
 
-/*
- *      The len_default() helper function is the default callback used in case
- *      the client code does not supply a callback to determine the length of
- *      the payload of an object instance [DM:??].
- */
+                                           /* default length method [AgDM:??] */
 static inline size_t len_default(const void *payload)
 {
     (void) payload;
@@ -90,17 +79,14 @@ static inline size_t len_default(const void *payload)
 }
 
 
+                                             /* default hash method [AgDM:??] */
 static inline size_t hash_default(const ag_object *obj)
 {
     return ((size_t) obj->id * (size_t) 2654435761) % (size_t) pow(2, 32);
 }
 
 
-/*
- *      The cmp_default() helper function is the default callback used in case
- *      the client code does not supply a callback to compare two object
- *      instances [DM:??].
- */
+                                       /* default comparison method [AgDM:??] */
 static inline enum ag_object_cmp cmp_default(const ag_object *ctx, 
         const ag_object *cmp)
 {
@@ -114,11 +100,7 @@ static inline enum ag_object_cmp cmp_default(const ag_object *ctx,
 }
 
 
-/*
- *      The str_default() helper function is the default callback used in case
- *      the client code does not supply a callback to generate the string
- *      representation of an object [DM:??].
- */
+                                           /* default string method [AgDM:??] */
 static inline const char *str_default(const ag_object *ctx)
 {
     const char *FMT = "object: (id = %u), (len = %lu), (refc = %lu)";
@@ -132,9 +114,7 @@ static inline const char *str_default(const ag_object *ctx)
 }
 
 
-/*
- *      The object_new() helper function creates a new object instance [DM:??].
- */
+                                              /* creates new object [AgDM:??] */
 static ag_object *object_new(unsigned type, unsigned id, void *payload,
         const struct ag_object_method *vt)
 {
@@ -156,10 +136,7 @@ static ag_object *object_new(unsigned type, unsigned id, void *payload,
 }
 
 
-/*
- *      The object_copy() helper function creates a deep copy of an object
- *      instance [DM:??].
- */
+                                       /* performs deep copy object [AgDM:??] */
 static inline void object_copy(ag_object **obj)
 {
     ag_object *hnd = *obj;
@@ -176,15 +153,31 @@ static inline void object_copy(ag_object **obj)
 
 
 
+/*******************************************************************************
+ *                        INLINE INTERFACE DECLARATIONS
+ */
+
+
+                                   /* declaration of ag_object_lt() [AgDM:??] */
+extern inline bool ag_object_lt(const ag_object *ctx, const ag_object *cmp);
+
+
+                                   /* declaration of ag_object_eq() [AgDM:??] */
+extern inline bool ag_object_eq(const ag_object *ctx, const ag_object *cmp);
+
+
+                                   /* declaration of ag_object_gt() [AgDM:??] */
+extern inline bool ag_object_gt(const ag_object *ctx, const ag_object *cmp);
+
+
+
 
 /*******************************************************************************
- *                          INTERFACE IMPLEMENTATION
+ *                           INTERFACE IMPLEMENTATION
  */
 
 
-/*
- *      Implementation of the ag_object_new() interface function [DM:??].
- */
+                               /* implementation of ag_object_new() [AgDM:??] */
 extern ag_object *ag_object_new(unsigned type, unsigned id, void *payload,
         const struct ag_object_method *vt)
 {
@@ -193,9 +186,7 @@ extern ag_object *ag_object_new(unsigned type, unsigned id, void *payload,
 }
 
 
-/*
- *      Implementation of the ag_object_new_noid() interface function [DM:??].
- */
+                          /* implementation of ag_object_new_noid() [AgDM:??] */
 extern ag_object *ag_object_new_noid(unsigned type, void *payload,
         const struct ag_object_method *vt)
 {
@@ -206,9 +197,7 @@ extern ag_object *ag_object_new_noid(unsigned type, void *payload,
 }
 
 
-/*
- *      Implementation of the ag_object_copy() interface function [DM:??].
- */
+                              /* implementation of ag_object_copy() [AgDM:??] */
 extern ag_object *ag_object_copy(const ag_object *ctx)
 {
     ag_assert (ctx);
@@ -219,9 +208,7 @@ extern ag_object *ag_object_copy(const ag_object *ctx)
 }
 
 
-/*
- *      Implementation of the ag_object_free() interface function [DM:??].
- */
+                           /* implementation of ag_object_dispose() [AgDM:??] */
 extern void ag_object_dispose(ag_object **ctx)
 {
     ag_object *hnd;
@@ -236,6 +223,7 @@ extern void ag_object_dispose(ag_object **ctx)
 }
 
 
+                              /* implementation of ag_object_type() [AgDM:??] */
 extern unsigned ag_object_type(const ag_object *ctx)
 {
     ag_assert (ctx);
@@ -243,9 +231,7 @@ extern unsigned ag_object_type(const ag_object *ctx)
 }
 
 
-/*
- *      Implementation of the ag_object_id() interface function [DM:??].
- */
+                                /* implementation of ag_object_id() [AgDM:??] */
 extern unsigned ag_object_id(const ag_object *ctx)
 {
     ag_assert (ctx);
@@ -253,9 +239,7 @@ extern unsigned ag_object_id(const ag_object *ctx)
 }
 
 
-/*
- *      Implementation of the ag_object_id_set() interface function [DM:??].
- */
+                            /* implementation of ag_object_id_set() [AgDM:??] */
 extern void ag_object_id_set(ag_object **ctx, unsigned id)
 {
     ag_assert (ctx && *ctx);
@@ -266,9 +250,7 @@ extern void ag_object_id_set(ag_object **ctx, unsigned id)
 }
 
 
-/*
- *      Implementation of the ag_object_hash() interface function [DM:??].
- */
+                              /* implementation of ag_object_hash() [AgDM:??] */
 extern unsigned ag_object_hash(const ag_object *ctx)
 {
     ag_assert (ctx);
@@ -276,6 +258,7 @@ extern unsigned ag_object_hash(const ag_object *ctx)
 }
 
 
+                                /* implementation of ag_object_sz() [AgDM:??] */
 extern size_t ag_object_sz(const ag_object *ctx)
 {
     ag_assert (ctx);
@@ -283,9 +266,7 @@ extern size_t ag_object_sz(const ag_object *ctx)
 }
 
 
-/*
- *      Implementation of the ag_object_len() interface function [DM:??].
- */
+                               /* implementation of ag_object_len() [AgDM:??] */
 extern size_t ag_object_len(const ag_object *ctx)
 {
     ag_assert (ctx);
@@ -293,9 +274,7 @@ extern size_t ag_object_len(const ag_object *ctx)
 }
 
 
-/*
- *      Implementation of the ag_object_cmp() interface function [DM:??].
- */
+                               /* implementation of ag_object_cmp() [AgDM:??] */
 extern enum ag_object_cmp ag_object_cmp(const ag_object *ctx, 
         const ag_object *cmp)
 {
@@ -304,27 +283,7 @@ extern enum ag_object_cmp ag_object_cmp(const ag_object *ctx,
 }
 
 
-/*
- *      Declaration of the ag_object_lt() interface function [DM:??].
- */
-extern inline bool ag_object_lt(const ag_object *ctx, const ag_object *cmp);
-
-
-/*
- *      Declaration of the ag_object_eq() interface function [DM:??].
- */
-extern inline bool ag_object_eq(const ag_object *ctx, const ag_object *cmp);
-
-
-/*
- *      Declaration of the ag_object_gt() interface function [DM:??].
- */
-extern inline bool ag_object_gt(const ag_object *ctx, const ag_object *cmp);
-
-
-/*
- *      Implementation of the ag_object_payload() interface function [DM:??].
- */
+                           /* implementation of ag_object_payload() [AgDM:??] */
 extern const void *ag_object_payload(const ag_object *ctx)
 {
     ag_assert (ctx);
@@ -332,10 +291,7 @@ extern const void *ag_object_payload(const ag_object *ctx)
 }
 
 
-/*
- *      Implementation of the ag_object_payload_mutable() interface function
- *      [DM:??].
- */
+                   /* implementation of ag_object_payload_mutable() [AgDM:??] */
 extern void *ag_object_payload_mutable(ag_object **ctx)
 {
     ag_assert (ctx && *ctx);
@@ -345,9 +301,7 @@ extern void *ag_object_payload_mutable(ag_object **ctx)
 }
 
 
-/*
- *      Implementation of the ag_object_str() interface function [DM:??].
- */
+                               /* implementation of ag_object_str() [AgDM:??] */
 extern const char *ag_object_str(const ag_object *ctx)
 {
     ag_assert (ctx);

--- a/src/object.c
+++ b/src/object.c
@@ -19,6 +19,7 @@
  ******************************************************************************/
 
 
+#include <math.h>
 #include "./api.h"
 
 
@@ -88,6 +89,12 @@ static inline size_t len_default(const void *payload)
 }
 
 
+static inline size_t hash_default(const ag_object *obj)
+{
+    return ((size_t) obj->id * (size_t) 2654435761) % (size_t) pow(2, 32);
+}
+
+
 /*
  *      The cmp_default() helper function is the default callback used in case
  *      the client code does not supply a callback to compare two object
@@ -139,6 +146,7 @@ static ag_object *object_new(unsigned id, void *payload,
     ctx->vt.dispose = vt->dispose? vt->dispose: dispose_default;
     ctx->vt.sz = vt->sz ? vt->sz : sz_default;
     ctx->vt.len = vt->len ? vt->len : len_default;
+    ctx->vt.hash = vt->hash ? vt->hash : hash_default;
     ctx->vt.cmp = vt->cmp ? vt->cmp : cmp_default;
     ctx->vt.str = vt->str ? vt->str : str_default;
     
@@ -252,10 +260,10 @@ extern void ag_object_id_set(ag_object **ctx, unsigned id)
 /*
  *      Implementation of the ag_object_hash() interface function [DM:??].
  */
-extern unsigned ag_object_hash(const ag_object *ctx, size_t len)
+extern unsigned ag_object_hash(const ag_object *ctx)
 {
-    ag_assert (ctx && len);
-    return ctx->id / len;
+    ag_assert (ctx);
+    return ctx->vt.sz(ctx);
 }
 
 

--- a/src/object.c
+++ b/src/object.c
@@ -69,6 +69,13 @@ static inline void dispose_default(void *payload)
 }
 
 
+static inline size_t sz_default(const void *payload)
+{
+    (void) payload;
+    return 0;
+}
+
+
 /*
  *      The len_default() helper function is the default callback used in case
  *      the client code does not supply a callback to determine the length of
@@ -130,6 +137,7 @@ static ag_object *object_new(unsigned id, void *payload,
     
     ctx->vt.copy = vt->copy ? vt->copy : copy_default;
     ctx->vt.dispose = vt->dispose? vt->dispose: dispose_default;
+    ctx->vt.sz = vt->sz ? vt->sz : sz_default;
     ctx->vt.len = vt->len ? vt->len : len_default;
     ctx->vt.cmp = vt->cmp ? vt->cmp : cmp_default;
     ctx->vt.str = vt->str ? vt->str : str_default;
@@ -251,6 +259,13 @@ extern unsigned ag_object_hash(const ag_object *ctx, size_t len)
 }
 
 
+extern size_t ag_object_sz(const ag_object *ctx)
+{
+    ag_assert (ctx);
+    return ctx->vt.sz(ctx);
+}
+
+
 /*
  *      Implementation of the ag_object_len() interface function [DM:??].
  */
@@ -321,5 +336,4 @@ extern const char *ag_object_str(const ag_object *ctx)
     ag_assert (ctx);
     return ctx->vt.str(ctx);
 }
-
 

--- a/src/object.c
+++ b/src/object.c
@@ -33,7 +33,7 @@
  *      Expansion of the ag_object abstract data type [DM:??].
  */
 struct ag_object {
-    struct ag_object_vtable vt;
+    struct ag_object_method vt;
     size_t refc;
     unsigned id;
     void *ld;
@@ -51,7 +51,7 @@ struct ag_object {
  *      The object_new() helper function creates a new object instance [DM:??].
  */
 static ag_object *object_new(unsigned id, ag_object_payload *ld,
-        const struct ag_object_vtable *vt);
+        const struct ag_object_method *vt);
 
 
 /*
@@ -113,7 +113,7 @@ static const char *str_default(const ag_object *ctx);
  *      Implementation of the ag_object_new() interface function [DM:??].
  */
 extern ag_object *ag_object_new(unsigned id, ag_object_payload *ld,
-        const struct ag_object_vtable *vt)
+        const struct ag_object_method *vt)
 {
     ag_assert (id && ld && vt);
     return object_new(id, ld, vt);
@@ -124,7 +124,7 @@ extern ag_object *ag_object_new(unsigned id, ag_object_payload *ld,
  *      Implementation of the ag_object_new_noid() interface function [DM:??].
  */
 extern ag_object *ag_object_new_noid(ag_object_payload *ld,
-        const struct ag_object_vtable *vt)
+        const struct ag_object_method *vt)
 {
     const unsigned NOID = 0;
 
@@ -281,7 +281,7 @@ extern const char *ag_object_str(const ag_object *ctx)
  *      Implementation of the object_new() helper function [DM:??].
  */
 static ag_object *object_new(unsigned id, ag_object_payload *ld,
-        const struct ag_object_vtable *vt)
+        const struct ag_object_method *vt)
 {
     ag_object *ctx = ag_mempool_new(sizeof *ctx);
     ctx->refc = 1;

--- a/src/object.c
+++ b/src/object.c
@@ -63,7 +63,7 @@ static inline void *copy_default(const void *payload)
  *      the client code does not supply a callback to free the payload of an
  *      object instance [DM:??].
  */
-static inline void free_default(void *payload)
+static inline void dispose_default(void *payload)
 {
     (void) payload;
 }
@@ -129,7 +129,7 @@ static ag_object *object_new(unsigned id, void *payload,
     ctx->payload = payload;
     
     ctx->vt.copy = vt->copy ? vt->copy : copy_default;
-    ctx->vt.free = vt->free ? vt->free : free_default;
+    ctx->vt.dispose = vt->dispose? vt->dispose: dispose_default;
     ctx->vt.len = vt->len ? vt->len : len_default;
     ctx->vt.cmp = vt->cmp ? vt->cmp : cmp_default;
     ctx->vt.str = vt->str ? vt->str : str_default;
@@ -150,7 +150,7 @@ static inline void object_copy(ag_object **obj)
         ag_object *cp = ag_object_new(hnd->id, hnd->vt.copy(hnd->payload), 
                 &hnd->vt);
 
-        ag_object_free(obj);
+        ag_object_dispose(obj);
         *obj = cp;
     }
 }
@@ -204,13 +204,13 @@ extern ag_object *ag_object_copy(const ag_object *ctx)
 /*
  *      Implementation of the ag_object_free() interface function [DM:??].
  */
-extern void ag_object_free(ag_object **ctx)
+extern void ag_object_dispose(ag_object **ctx)
 {
     ag_object *hnd;
 
     if (ag_likely (ctx && (hnd = *ctx))) {
         if (!--hnd->refc) {
-            hnd->vt.free(hnd->payload);
+            hnd->vt.dispose(hnd->payload);
             ag_mempool_free(&hnd->payload);
             ag_mempool_free((void **) ctx);
         }
@@ -259,7 +259,6 @@ extern size_t ag_object_len(const ag_object *ctx)
     ag_assert (ctx);
     return ctx->vt.len(ctx);
 }
-
 
 
 /*


### PR DESCRIPTION
The interface for the object v-table has been created with the following functions:
  * `ag_object_vtable_init()`
  * `ag_object_vtable_exit()`
  * `ag_object_vtable_exists()`
  * `ag_object_vtable_get()`
  * `ag_object_vtable_set()`

The object v-table interface has been implemented as a hash table containing the methods for each registered object type. In order to support the object v-table, the following changes have been made to the object interface:
  * renamed `ag_object_vtable` struct to `ag_object_method`
  * added `ag_object_sz()`
  * added `ag_object_type()`
  * converted `ag_object_hash()` to a method

Some cosmetic changes have also been made, such the removal of the `ag_object_payload` type, the trimming down of comments and the renaming of the disposal routines.

This pull request closes #22.