### PR TITLE
Introduce string interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ dkms.conf
 *.toc
 *.xml
 
-# Build output
+# Development environment
 /bld
+tags
 

--- a/src/api.h
+++ b/src/api.h
@@ -230,6 +230,81 @@ extern void ag_memblock_free(ag_memblock_t **bfr);
 
 
 
+
+/*******************************************************************************
+ *                                   STRINGS
+ */
+
+
+                                                    /* UTF-8 string [AgDM:??] */
+typedef char ag_string_t;
+
+
+                                    /* smart version of ag_string_t [AgDM:??] */
+#if (defined __GNUC__ || defined __clang__)
+#   define ag_string_smart \
+            __attribute__((cleanup(ag_string_free))) ag_string
+#else
+#   define ag_string_smart_t ag_string_t
+#   warning "[!] ag_string_smart_t leaks memory on current compiler"
+#endif
+
+
+                                               /* create new string [AgDM:??] */
+extern ag_string_t *ag_string_new(const char *cstr);
+
+
+                                         /* create new empty string [AgDM:??] */
+extern ag_string_t *ag_string_new_empty(void);
+
+
+                                            /* copy existing string [AgDM:??] */
+extern ag_string_t *ag_string_copy(const ag_string_t *ctx);
+
+
+                                         /* dispose existing string [AgDM:??] */
+extern void ag_string_dispose(ag_string_t **ctx);
+
+
+                              /* get lexicographic length of string [AgDM:??] */
+extern size_t ag_string_len(const ag_string_t *ctx);
+
+
+                                     /* get size in bytes of string [AgDM:??] */
+extern size_t ag_string_sz(const ag_string_t *ctx);
+
+
+                                    /* compare two string instances [AgDM:??] */
+extern int ag_string_cmp(const ag_string_t *lhs, const ag_string_t *rhs);
+
+
+                            /* check if string is less than another [AgDM:??] */
+inline bool ag_string_lt(const ag_string_t *lhs, const ag_string_t *rhs)
+{
+    return ag_string_cmp(lhs, rhs) < 0;
+}
+
+
+                             /* check if string is equal to another [AgDM:??] */
+inline bool ag_string_eq(const ag_string_t *lhs, const ag_string_t *rhs)
+{
+    return !ag_string_cmp(lhs, rhs);
+}
+
+
+                         /* check if string is greater than another [AgDM:??] */
+inline bool ag_string_gt(const ag_string_t *lhs, const ag_string_t *rhs)
+{
+    return ag_string_cmp(lhs, rhs) > 0;
+}
+
+
+                                           /* add string to another [AgDM:??] */
+extern void ag_string_add(ag_string_t **ctx, const ag_string_t *cat);
+
+
+
+
 /*******************************************************************************
  *                                OBJECT MODEL
  */

--- a/src/api.h
+++ b/src/api.h
@@ -108,6 +108,13 @@
 #endif
 
 
+enum ag_tristate {
+    AG_TRISTATE_LO = -1,
+    AG_TRISTATE_GND,
+    AG_TRISTATE_HI
+};
+
+
 
 
 /*******************************************************************************
@@ -278,27 +285,28 @@ extern size_t ag_string_sz(const ag_string_t *ctx);
 
 
                                     /* compare two string instances [AgDM:??] */
-extern int ag_string_cmp(const ag_string_t *lhs, const ag_string_t *rhs);
+extern enum ag_tristate ag_string_cmp(const ag_string_t *lhs, 
+        const ag_string_t *rhs);
 
 
                             /* check if string is less than another [AgDM:??] */
 inline bool ag_string_lt(const ag_string_t *lhs, const ag_string_t *rhs)
 {
-    return ag_string_cmp(lhs, rhs) < 0;
+    return ag_string_cmp(lhs, rhs) == AG_TRISTATE_LO;
 }
 
 
                              /* check if string is equal to another [AgDM:??] */
 inline bool ag_string_eq(const ag_string_t *lhs, const ag_string_t *rhs)
 {
-    return !ag_string_cmp(lhs, rhs);
+    return ag_string_cmp(lhs, rhs) == AG_TRISTATE_GND;
 }
 
 
                          /* check if string is greater than another [AgDM:??] */
 inline bool ag_string_gt(const ag_string_t *lhs, const ag_string_t *rhs)
 {
-    return ag_string_cmp(lhs, rhs) > 0;
+    return ag_string_cmp(lhs, rhs) == AG_TRISTATE_HI;
 }
 
 
@@ -332,14 +340,6 @@ typedef struct ag_object_t ag_object_t;
 #define AG_OBJECT_TYPE_LIST ((size_t) 0x1)
 
 
-                        /* tristate result of comparing two objects [AgDM:??] */
-enum ag_object_cmp {
-    AG_OBJECT_CMP_LT = -1,
-    AG_OBJECT_CMP_EQ = 0,
-    AG_OBJECT_CMP_GT = 1
-};
-
-
                                        /* v-table of object methods [AgDM:??] */
 struct ag_object_vtable {
     ag_memblock_t *(*copy)(const ag_memblock_t *payload);
@@ -348,7 +348,7 @@ struct ag_object_vtable {
     size_t (*sz)(const ag_object_t *obj);
     size_t (*len)(const ag_object_t *obj);
     size_t (*hash)(const ag_object_t *obj);
-    enum ag_object_cmp (*cmp)(const ag_object_t *lhs, const ag_object_t *rhs);
+    enum ag_tristate (*cmp)(const ag_object_t *lhs, const ag_object_t *rhs);
     const char *(*str)(const ag_object_t *obj);
 };
 
@@ -409,28 +409,28 @@ inline bool ag_object_empty(const ag_object_t *ctx)
 
 
                                             /* compares two objects [AgDM:??] */
-extern ag_pure enum ag_object_cmp ag_object_cmp(const ag_object_t *ctx, 
+extern ag_pure enum ag_tristate ag_object_cmp(const ag_object_t *ctx, 
         const ag_object_t *cmp);
 
 
                            /* checks if object is less than another [AgDM:??] */
 inline bool ag_object_lt(const ag_object_t *ctx, const ag_object_t *cmp)
 {
-    return ag_object_cmp(ctx, cmp) == AG_OBJECT_CMP_LT;
+    return ag_object_cmp(ctx, cmp) == AG_TRISTATE_LO;
 }
 
 
                        /* checks if object is equivalent to another [AgDM:??] */
 inline bool ag_object_eq(const ag_object_t *ctx, const ag_object_t *cmp)
 {
-    return ag_object_cmp(ctx, cmp) == AG_OBJECT_CMP_EQ;
+    return ag_object_cmp(ctx, cmp) == AG_TRISTATE_GND;
 }
 
 
                         /* checks if object is greater than another [AgDM:??] */
 inline bool ag_object_gt(const ag_object_t *ctx, const ag_object_t *cmp)
 {
-    return ag_object_cmp(ctx, cmp) == AG_OBJECT_CMP_GT;
+    return ag_object_cmp(ctx, cmp) == AG_TRISTATE_HI;
 }
 
 
@@ -527,7 +527,7 @@ inline bool ag_list_empty(const ag_list_t *ctx)
 
 
                                               /* compares two lists [AgDM:??] */
-inline enum ag_object_cmp ag_list_cmp(const ag_list_t *ctx, 
+inline enum ag_tristate ag_list_cmp(const ag_list_t *ctx, 
         const ag_list_t *cmp)
 {
     return ag_object_cmp(ctx, cmp);

--- a/src/api.h
+++ b/src/api.h
@@ -242,10 +242,8 @@ extern void ag_memblock_free(ag_memblock_t **bfr);
  *                                   STRINGS
  */
 
-
                                                     /* UTF-8 string [AgDM:??] */
 typedef char ag_string_t;
-
 
                                     /* smart version of ag_string_t [AgDM:??] */
 #if (defined __GNUC__ || defined __clang__)
@@ -256,10 +254,8 @@ typedef char ag_string_t;
 #   warning "[!] ag_string_smart_t leaks memory on current compiler"
 #endif
 
-
                                                /* create new string [AgDM:??] */
 extern ag_string_t *ag_string_new(const char *cstr);
-
 
                                          /* create new empty string [AgDM:??] */
 inline ag_string_t *ag_string_new_empty(void)
@@ -267,27 +263,21 @@ inline ag_string_t *ag_string_new_empty(void)
     return ag_string_new("");
 }
 
-
                                             /* copy existing string [AgDM:??] */
 extern ag_string_t *ag_string_copy(const ag_string_t *ctx);
-
 
                                          /* dispose existing string [AgDM:??] */
 extern void ag_string_dispose(ag_string_t **ctx);
 
-
                               /* get lexicographic length of string [AgDM:??] */
 extern size_t ag_string_len(const ag_string_t *ctx);
-
 
                                      /* get size in bytes of string [AgDM:??] */
 extern size_t ag_string_sz(const ag_string_t *ctx);
 
-
                                     /* compare two string instances [AgDM:??] */
 extern enum ag_tristate ag_string_cmp(const ag_string_t *lhs, 
         const ag_string_t *rhs);
-
 
                             /* check if string is less than another [AgDM:??] */
 inline bool ag_string_lt(const ag_string_t *lhs, const ag_string_t *rhs)
@@ -295,13 +285,11 @@ inline bool ag_string_lt(const ag_string_t *lhs, const ag_string_t *rhs)
     return ag_string_cmp(lhs, rhs) == AG_TRISTATE_LO;
 }
 
-
                              /* check if string is equal to another [AgDM:??] */
 inline bool ag_string_eq(const ag_string_t *lhs, const ag_string_t *rhs)
 {
     return ag_string_cmp(lhs, rhs) == AG_TRISTATE_GND;
 }
-
 
                          /* check if string is greater than another [AgDM:??] */
 inline bool ag_string_gt(const ag_string_t *lhs, const ag_string_t *rhs)
@@ -309,11 +297,15 @@ inline bool ag_string_gt(const ag_string_t *lhs, const ag_string_t *rhs)
     return ag_string_cmp(lhs, rhs) == AG_TRISTATE_HI;
 }
 
-
                                            /* add string to another [AgDM:??] */
 extern void ag_string_add(ag_string_t **ctx, const ag_string_t *cat);
 
-
+                                 /* add C-string to string instance [AgDM:??] */
+inline void ag_string_add_cstr(ag_string_t **ctx, const char *cat)
+{
+    ag_string_smart_t *s = ag_string_new(cat);
+    ag_string_add(ctx, s);
+}
 
 
 /*******************************************************************************

--- a/src/api.h
+++ b/src/api.h
@@ -255,7 +255,10 @@ extern ag_string_t *ag_string_new(const char *cstr);
 
 
                                          /* create new empty string [AgDM:??] */
-extern ag_string_t *ag_string_new_empty(void);
+inline ag_string_t *ag_string_new_empty(void)
+{
+    return ag_string_new("");
+}
 
 
                                             /* copy existing string [AgDM:??] */

--- a/src/api.h
+++ b/src/api.h
@@ -263,6 +263,9 @@ inline ag_string_t *ag_string_new_empty(void)
     return ag_string_new("");
 }
 
+                                     /* create new formatted string [AgDM:??] */
+extern ag_string_t *ag_string_new_fmt(const char *fmt, ...);
+
                                             /* copy existing string [AgDM:??] */
 extern ag_string_t *ag_string_copy(const ag_string_t *ctx);
 
@@ -306,6 +309,7 @@ inline void ag_string_add_cstr(ag_string_t **ctx, const char *cat)
     ag_string_smart_t *s = ag_string_new(cat);
     ag_string_add(ctx, s);
 }
+
 
 
 /*******************************************************************************
@@ -437,8 +441,6 @@ extern ag_hot ag_memblock_t *ag_object_payload_mutable(ag_object_t **ctx);
 
                             /* gets string representation of object [AgDM:??] */
 extern ag_string_t *ag_object_str(const ag_object_t *ctx);
-
-
 
 
 /*******************************************************************************

--- a/src/api.h
+++ b/src/api.h
@@ -349,7 +349,7 @@ struct ag_object_vtable {
     size_t (*len)(const ag_object_t *obj);
     size_t (*hash)(const ag_object_t *obj);
     enum ag_tristate (*cmp)(const ag_object_t *lhs, const ag_object_t *rhs);
-    const char *(*str)(const ag_object_t *obj);
+    ag_string_t *(*str)(const ag_object_t *obj);
 };
 
 
@@ -444,7 +444,7 @@ extern ag_hot ag_memblock_t *ag_object_payload_mutable(ag_object_t **ctx);
 
 
                             /* gets string representation of object [AgDM:??] */
-extern ag_pure const char *ag_object_str(const ag_object_t *ctx);
+extern ag_string_t *ag_object_str(const ag_object_t *ctx);
 
 
 

--- a/src/api.h
+++ b/src/api.h
@@ -242,8 +242,8 @@ typedef char ag_string_t;
 
                                     /* smart version of ag_string_t [AgDM:??] */
 #if (defined __GNUC__ || defined __clang__)
-#   define ag_string_smart \
-            __attribute__((cleanup(ag_string_free))) ag_string
+#   define ag_string_smart_t \
+            __attribute__((cleanup(ag_string_dispose))) ag_string_t
 #else
 #   define ag_string_smart_t ag_string_t
 #   warning "[!] ag_string_smart_t leaks memory on current compiler"

--- a/src/list.c
+++ b/src/list.c
@@ -145,7 +145,7 @@ extern inline bool ag_list_empty(const ag_list_t *ctx);
 
 
                              /* declaration of ag_list_cmp() [AgDM:??] */
-extern inline enum ag_object_cmp ag_list_cmp(const ag_list_t *ctx,
+extern inline enum ag_tristate ag_list_cmp(const ag_list_t *ctx,
         const ag_list_t *cmp);
 
 

--- a/src/object.c
+++ b/src/object.c
@@ -189,16 +189,16 @@ static inline size_t object_method_hash(const ag_object_t *obj)
 
 
                                        /* default comparison method [AgDM:??] */
-static inline enum ag_object_cmp object_method_cmp(const ag_object_t *ctx, 
+static inline enum ag_tristate object_method_cmp(const ag_object_t *ctx, 
         const ag_object_t *cmp)
 {
     size_t llen = ag_object_len(ctx);
     size_t rlen = ag_object_len(cmp);
 
     if (llen == rlen)
-        return AG_OBJECT_CMP_EQ;
+        return AG_TRISTATE_GND;
 
-    return llen < rlen ? AG_OBJECT_CMP_LT : AG_OBJECT_CMP_GT;
+    return llen < rlen ? AG_TRISTATE_LO : AG_TRISTATE_HI;
 }
 
 
@@ -387,7 +387,7 @@ extern size_t ag_object_len(const ag_object_t *ctx)
 
 
                                /* implementation of ag_object_cmp() [AgDM:??] */
-extern enum ag_object_cmp ag_object_cmp(const ag_object_t *ctx, 
+extern enum ag_tristate ag_object_cmp(const ag_object_t *ctx, 
         const ag_object_t *cmp)
 {
     ag_assert (ctx && vtable && cmp 

--- a/src/object.c
+++ b/src/object.c
@@ -23,12 +23,9 @@
 #include "./api.h"
 
 
-
-
 /*******************************************************************************
  *                            V-TABLE NODE INTERNALS
  */
-
 
                                              /* v-table bucket node [AgDM:??] */
 struct vtable_node {
@@ -36,7 +33,6 @@ struct vtable_node {
     struct ag_object_vtable *val;
     struct vtable_node *nxt;
 };
-
 
                                                 /* creates new node [AgDM:??] */
 static struct vtable_node *vtable_node_new(size_t key, 
@@ -59,7 +55,6 @@ static struct vtable_node *vtable_node_new(size_t key,
     return n;
 }
 
-
                                                  /* disposes a node [AgDM:??] */
 static inline void vtable_node_dispose(struct vtable_node *n)
 {
@@ -68,12 +63,9 @@ static inline void vtable_node_dispose(struct vtable_node *n)
 }
 
 
-
-
 /*******************************************************************************
  *                              V-TABLE INTERNALS
  */
-
 
                                        /* v-table of object methods [AgDM:??] */
 static ag_threadlocal struct {
@@ -81,15 +73,11 @@ static ag_threadlocal struct {
     struct vtable_node **bkt;
 } *vtable = NULL;
 
-
-
-
                                         /* gets hash of object type [AgDM:??] */
 static inline size_t vtable_hash(size_t type)
 {
     return type % vtable->len;
 }
-
 
                          /* checks if methods for object type exist [AgDM:??] */
 static bool vtable_exists(size_t type)
@@ -105,7 +93,6 @@ static bool vtable_exists(size_t type)
     return false;
 }
 
-
                         /* gets methods of object type from v-table [AgDM:??] */
 static const struct ag_object_vtable *vtable_get(size_t type)
 {
@@ -120,7 +107,6 @@ static const struct ag_object_vtable *vtable_get(size_t type)
     return NULL;
 }
 
-
                                      /* sets methods of object type [AgDM:??] */
 static void vtable_set(size_t type, const struct ag_object_vtable *vt)
 {
@@ -130,12 +116,9 @@ static void vtable_set(size_t type, const struct ag_object_vtable *vt)
 }
 
 
-
-
 /*******************************************************************************
  *                               OBJECT INTERNALS
  */
-
 
                                           /* expansion of ag_object [AgDM:??] */
 struct ag_object_t {
@@ -144,13 +127,11 @@ struct ag_object_t {
     ag_memblock_t *payload;
 };
 
-
                                              /* default copy method [AgDM:??] */
 static inline ag_memblock_t *object_method_copy(const ag_memblock_t *payload)
 {
     return ag_memblock_copy(payload);
 }
-
 
                                           /* default dispose method [AgDM:??] */
 static inline void object_method_dispose(ag_memblock_t *payload)
@@ -158,20 +139,18 @@ static inline void object_method_dispose(ag_memblock_t *payload)
     (void) payload;
 }
 
-
+                                               /* default ID method [AgDM:??] */
 static inline size_t object_method_id(const ag_object_t *obj)
 {
     (void) obj;
     return 0;
 }
 
-
                                              /* default size method [AgDM:??] */
 static inline size_t object_method_sz(const ag_object_t *obj)
 {
     return ag_memblock_sz(obj->payload);
 }
-
 
                                            /* default length method [AgDM:??] */
 static inline size_t object_method_len(const ag_object_t *obj)
@@ -180,13 +159,11 @@ static inline size_t object_method_len(const ag_object_t *obj)
     return 1;
 }
 
-
                                              /* default hash method [AgDM:??] */
 static inline size_t object_method_hash(const ag_object_t *obj)
 {
     return (ag_object_id(obj) * (size_t) 2654435761) % (size_t) pow(2, 32);
 }
-
 
                                        /* default comparison method [AgDM:??] */
 static inline enum ag_tristate object_method_cmp(const ag_object_t *ctx, 
@@ -201,20 +178,12 @@ static inline enum ag_tristate object_method_cmp(const ag_object_t *ctx,
     return llen < rlen ? AG_TRISTATE_LO : AG_TRISTATE_HI;
 }
 
-
                                            /* default string method [AgDM:??] */
-static inline const char *object_method_str(const ag_object_t *ctx)
+static inline ag_string_t *object_method_str(const ag_object_t *ctx)
 {
-    const char *FMT = "object: (id = %u), (len = %lu), (refc = %lu)";
-#   define LEN 64
-
-    static ag_threadlocal char bfr[LEN];
-    snprintf(bfr, LEN, FMT, ag_object_id(ctx), ag_object_len(ctx), ctx->refc);
-
-    return bfr;
-#   undef LEN
+    (void) ctx;
+    return ag_string_new("object");
 }
-
 
                                               /* creates new object [AgDM:??] */
 static ag_object_t *object_new(size_t type, ag_memblock_t *payload)
@@ -228,28 +197,21 @@ static ag_object_t *object_new(size_t type, ag_memblock_t *payload)
 }
 
 
-
-
 /*******************************************************************************
  *                               OBJECT EXTERNALS
  */
 
-
                                 /* declaration of ag_object_empty() [AgDM:??] */
 extern inline bool ag_object_empty(const ag_object_t *ctx);
-
 
                                    /* declaration of ag_object_lt() [AgDM:??] */
 extern inline bool ag_object_lt(const ag_object_t *ctx, const ag_object_t *cmp);
 
-
                                    /* declaration of ag_object_eq() [AgDM:??] */
 extern inline bool ag_object_eq(const ag_object_t *ctx, const ag_object_t *cmp);
 
-
                                    /* declaration of ag_object_gt() [AgDM:??] */
 extern inline bool ag_object_gt(const ag_object_t *ctx, const ag_object_t *cmp);
-
 
                               /* implementation of ag_object_init() [AgDM:??] */
 extern void ag_object_init(size_t len)
@@ -262,7 +224,6 @@ extern void ag_object_init(size_t len)
         vtable->len = len;
     }
 }
-
 
                               /* implementation of ag_object_exit() [AgDM:??] */
 extern void ag_object_exit(void)
@@ -282,7 +243,6 @@ extern void ag_object_exit(void)
     }
 }
 
-
                           /* implementation of ag_object_register() [AgDM:??] */
 extern void ag_object_register(size_t type, const struct ag_object_vtable *vt)
 {
@@ -301,14 +261,12 @@ extern void ag_object_register(size_t type, const struct ag_object_vtable *vt)
     vtable_set(type, &vtbl);
 }
 
-
                                /* implementation of ag_object_new() [AgDM:??] */
 extern ag_object_t *ag_object_new(size_t type, ag_memblock_t *payload)
 {
     ag_assert (type && payload);
     return object_new(type, payload);
 }
-
 
                               /* implementation of ag_object_copy() [AgDM:??] */
 extern ag_object_t *ag_object_copy(const ag_object_t *ctx)
@@ -319,7 +277,6 @@ extern ag_object_t *ag_object_copy(const ag_object_t *ctx)
     cp->refc++;
     return cp;
 }
-
 
                            /* implementation of ag_object_dispose() [AgDM:??] */
 extern void ag_object_dispose(ag_object_t **ctx)
@@ -337,14 +294,12 @@ extern void ag_object_dispose(ag_object_t **ctx)
     }
 }
 
-
                               /* implementation of ag_object_type() [AgDM:??] */
 extern size_t ag_object_type(const ag_object_t *ctx)
 {
     ag_assert (ctx);
     return ctx->type;
 }
-
 
                               /* implementation of ag_object_refc() [AgDM:??] */
 extern size_t ag_object_refc(const ag_object_t *ctx)
@@ -353,14 +308,12 @@ extern size_t ag_object_refc(const ag_object_t *ctx)
     return ctx->refc;
 }
 
-
                                 /* implementation of ag_object_id() [AgDM:??] */
 extern size_t ag_object_id(const ag_object_t *ctx)
 {
     ag_assert (ctx && vtable);
     return vtable_get(ctx->type)->id(ctx);
 }
-
 
                               /* implementation of ag_object_hash() [AgDM:??] */
 extern size_t ag_object_hash(const ag_object_t *ctx)
@@ -369,7 +322,6 @@ extern size_t ag_object_hash(const ag_object_t *ctx)
     return vtable_get(ctx->type)->hash(ctx);
 }
 
-
                                 /* implementation of ag_object_sz() [AgDM:??] */
 extern size_t ag_object_sz(const ag_object_t *ctx)
 {
@@ -377,14 +329,12 @@ extern size_t ag_object_sz(const ag_object_t *ctx)
     return vtable_get(ctx->type)->sz(ctx);
 }
 
-
                                /* implementation of ag_object_len() [AgDM:??] */
 extern size_t ag_object_len(const ag_object_t *ctx)
 {
     ag_assert (ctx && vtable);
     return vtable_get(ctx->type)->len(ctx);
 }
-
 
                                /* implementation of ag_object_cmp() [AgDM:??] */
 extern enum ag_tristate ag_object_cmp(const ag_object_t *ctx, 
@@ -395,14 +345,12 @@ extern enum ag_tristate ag_object_cmp(const ag_object_t *ctx,
     return vtable_get(ctx->type)->cmp(ctx, cmp);
 }
 
-
                            /* implementation of ag_object_payload() [AgDM:??] */
 extern const ag_memblock_t *ag_object_payload(const ag_object_t *ctx)
 {
     ag_assert (ctx);
     return ctx->payload;
 }
-
 
                    /* implementation of ag_object_payload_mutable() [AgDM:??] */
 extern ag_memblock_t *ag_object_payload_mutable(ag_object_t **ctx)
@@ -418,12 +366,10 @@ extern ag_memblock_t *ag_object_payload_mutable(ag_object_t **ctx)
     return (*ctx)->payload;
 }
 
-
                                /* implementation of ag_object_str() [AgDM:??] */
-extern const char *ag_object_str(const ag_object_t *ctx)
+extern ag_string_t *ag_object_str(const ag_object_t *ctx)
 {
     ag_assert (ctx && vtable);
     return vtable_get(ctx->type)->str(ctx);
 }
-
 

--- a/src/string.c
+++ b/src/string.c
@@ -81,6 +81,9 @@ extern inline bool ag_string_eq(const ag_string_t *lhs, const ag_string_t *rhs);
                                    /* declaration of ag_string_gt() [AgDM:??] */
 extern inline bool ag_string_gt(const ag_string_t *lhs, const ag_string_t *rhs);
 
+                             /* declaration of ag_string_add_cstr() [AgDM:??] */
+extern inline void ag_string_add_cstr(ag_string_t **ctx, const char *cat);
+
                                /* implementation of ag_string_new() [AgDM:??] */
 extern ag_string_t *ag_string_new(const char *cstr)
 {

--- a/src/string.c
+++ b/src/string.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdarg.h>
 #include "./api.h"
 
 
@@ -93,6 +94,25 @@ extern ag_string_t *ag_string_new(const char *cstr)
 
     strncpy(s, cstr, sz);
     s[sz] = '\0';
+    return s;
+}
+
+                           /* implementation of ag_string_new_fmt() [AgDM:??] */
+extern ag_string_t *ag_string_new_fmt(const char *fmt, ...)
+{
+    va_list args;
+
+    ag_assert (fmt && *fmt);
+    va_start(args, fmt);
+    char *bfr = ag_memblock_new(vsnprintf(NULL, 0, fmt, args) + 1);
+    va_end(args);
+
+    va_start(args, fmt);
+    (void) vsprintf(bfr, fmt, args);
+    va_end(args);
+
+    ag_string_t *s = ag_string_new(bfr);
+    ag_memblock_free((ag_memblock_t **) &bfr);
     return s;
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -1,0 +1,105 @@
+#include <string.h>
+#include "./api.h"
+
+
+
+/*******************************************************************************
+ *                               STRING EXTERNALS
+ */
+
+
+                            /* declaration of ag_string_new_empty() [AgDM:??] */
+extern inline ag_string_t *ag_string_new_empty(void);
+
+
+                                   /* declaration of ag_string_lt() [AgDM:??] */
+extern inline bool ag_string_lt(const ag_string_t *lhs, const ag_string_t *rhs);
+
+
+                                   /* declaration of ag_string_eq() [AgDM:??] */
+extern inline bool ag_string_eq(const ag_string_t *lhs, const ag_string_t *rhs);
+
+
+                                   /* declaration of ag_string_gt() [AgDM:??] */
+extern inline bool ag_string_gt(const ag_string_t *lhs, const ag_string_t *rhs);
+
+
+                               /* implementation of ag_string_new() [AgDM:??] */
+extern ag_string_t *ag_string_new(const char *cstr)
+{
+    ag_assert (cstr);
+    size_t len = strlen(cstr);
+    char *ctx = ag_memblock_new(len + 1);
+
+    strncpy(ctx, cstr, len);
+    ctx[len] = '\0';
+
+    return ctx;
+}
+
+
+                              /* implementation of ag_string_copy() [AgDM:??] */
+extern ag_string_t *ag_string_copy(const ag_string_t *ctx)
+{
+    ag_assert (ctx);
+    return ag_string_new(ctx);
+}
+
+
+                           /* implementation of ag_string_dispose() [AgDM:??] */
+extern void ag_string_dispose(ag_string_t **ctx)
+{
+    ag_memblock_free((ag_memblock_t **) ctx);
+}
+
+
+                               /* implementation of ag_string_len() [AgDM:??] */
+extern size_t ag_string_len(const ag_string_t *ctx)
+{
+    register size_t i = 0, len = 0;
+
+    while (ctx[i]) {
+        if ((ctx[i] & 0xC0) != 0x80)
+            len++;
+        i++;
+    }
+
+    return len;
+}
+
+
+                                /* implementation of ag_string_sz() [AgDM:??] */
+extern size_t ag_string_sz(const ag_string_t *ctx)
+{
+    ag_assert (ctx);
+    return strlen(ctx);
+}
+
+
+                               /* implementation of ag_string_cmp() [AgDM:??] */
+extern int ag_string_cmp(const ag_string_t *lhs, const ag_string_t *rhs)
+{
+    ag_assert (lhs && rhs);
+    return strcmp(lhs, rhs);
+}
+
+
+                               /* implementation of ag_string_add() [AgDM:??] */
+extern void ag_string_add(ag_string_t **ctx, const ag_string_t *cat)
+{
+    ag_assert (ctx && *ctx && cat);
+    ag_string_t *oldstr = *ctx;
+
+    size_t oldlen = strlen(oldstr);
+    size_t addlen = strlen(cat);
+    size_t newlen = oldlen + addlen;
+
+    ag_string_t *newstr = ag_memblock_new(newlen + 1);
+    strncpy(newstr, oldstr, oldlen);
+    strncpy(newstr + oldlen, cat, addlen);
+    newstr[newlen] = '\0';
+
+    ag_memblock_free((ag_memblock_t **) ctx);
+    *ctx = newstr;
+}
+

--- a/src/string.c
+++ b/src/string.c
@@ -2,6 +2,24 @@
 #include "./api.h"
 
 
+/*******************************************************************************
+ *                               STRING INTERNALS
+ */
+
+                                       /* creates new padded string [AgDM:??] */
+static inline char *string_new(size_t sz)
+{
+    size_t *p = ag_memblock_new(sizeof (size_t) + sz + 1);
+    p[0] = sz;
+    return (char *) &p[1];
+}
+
+                                    /* gets size metadata of string [AgDM:??] */
+static inline size_t string_sz(const ag_string_t *ctx)
+{
+    return ((size_t *) ctx)[-1];
+}
+
 
 /*******************************************************************************
  *                               STRING EXTERNALS
@@ -11,32 +29,26 @@
                             /* declaration of ag_string_new_empty() [AgDM:??] */
 extern inline ag_string_t *ag_string_new_empty(void);
 
-
                                    /* declaration of ag_string_lt() [AgDM:??] */
 extern inline bool ag_string_lt(const ag_string_t *lhs, const ag_string_t *rhs);
-
 
                                    /* declaration of ag_string_eq() [AgDM:??] */
 extern inline bool ag_string_eq(const ag_string_t *lhs, const ag_string_t *rhs);
 
-
                                    /* declaration of ag_string_gt() [AgDM:??] */
 extern inline bool ag_string_gt(const ag_string_t *lhs, const ag_string_t *rhs);
-
 
                                /* implementation of ag_string_new() [AgDM:??] */
 extern ag_string_t *ag_string_new(const char *cstr)
 {
     ag_assert (cstr);
-    size_t len = strlen(cstr);
-    char *ctx = ag_memblock_new(len + 1);
+    size_t sz = strlen(cstr);
+    char *s = string_new(sz);
 
-    strncpy(ctx, cstr, len);
-    ctx[len] = '\0';
-
-    return ctx;
+    strncpy(s, cstr, sz);
+    s[sz] = '\0';
+    return s;
 }
-
 
                               /* implementation of ag_string_copy() [AgDM:??] */
 extern ag_string_t *ag_string_copy(const ag_string_t *ctx)
@@ -45,13 +57,16 @@ extern ag_string_t *ag_string_copy(const ag_string_t *ctx)
     return ag_string_new(ctx);
 }
 
-
                            /* implementation of ag_string_dispose() [AgDM:??] */
 extern void ag_string_dispose(ag_string_t **ctx)
 {
-    ag_memblock_free((ag_memblock_t **) ctx);
-}
+    ag_string_t *hnd;
 
+    if (ag_likely (ctx && (hnd = *ctx))) {
+        size_t *p = &((size_t *) hnd)[-1];
+        ag_memblock_free((ag_memblock_t **) &p);
+    }
+}
 
                                /* implementation of ag_string_len() [AgDM:??] */
 extern size_t ag_string_len(const ag_string_t *ctx)
@@ -67,14 +82,12 @@ extern size_t ag_string_len(const ag_string_t *ctx)
     return len;
 }
 
-
                                 /* implementation of ag_string_sz() [AgDM:??] */
 extern size_t ag_string_sz(const ag_string_t *ctx)
 {
     ag_assert (ctx);
-    return strlen(ctx);
+    return string_sz(ctx);
 }
-
 
                                /* implementation of ag_string_cmp() [AgDM:??] */
 extern enum ag_tristate ag_string_cmp(const ag_string_t *lhs, 
@@ -89,23 +102,23 @@ extern enum ag_tristate ag_string_cmp(const ag_string_t *lhs,
     return cmp > 0 ? AG_TRISTATE_HI : AG_TRISTATE_LO;
 }
 
-
                                /* implementation of ag_string_add() [AgDM:??] */
 extern void ag_string_add(ag_string_t **ctx, const ag_string_t *cat)
 {
-    ag_assert (ctx && *ctx && cat);
+    ag_assert (ctx && *ctx);
     ag_string_t *oldstr = *ctx;
+    size_t oldsz = string_sz(oldstr);
 
-    size_t oldlen = strlen(oldstr);
-    size_t addlen = strlen(cat);
-    size_t newlen = oldlen + addlen;
+    ag_assert (cat);
+    size_t addsz = string_sz(cat);
+    size_t newsz = oldsz + addsz;
 
-    ag_string_t *newstr = ag_memblock_new(newlen + 1);
-    strncpy(newstr, oldstr, oldlen);
-    strncpy(newstr + oldlen, cat, addlen);
-    newstr[newlen] = '\0';
+    char *s = string_new(newsz);
+    strncpy(s, oldstr, oldsz);
+    strncpy(s + oldsz, cat, addsz);
+    s[newsz] = '\0';
 
-    ag_memblock_free((ag_memblock_t **) ctx);
-    *ctx = newstr;
+    ag_string_dispose(ctx);
+    *ctx = s;
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -77,10 +77,16 @@ extern size_t ag_string_sz(const ag_string_t *ctx)
 
 
                                /* implementation of ag_string_cmp() [AgDM:??] */
-extern int ag_string_cmp(const ag_string_t *lhs, const ag_string_t *rhs)
+extern enum ag_tristate ag_string_cmp(const ag_string_t *lhs, 
+        const ag_string_t *rhs)
 {
     ag_assert (lhs && rhs);
-    return strcmp(lhs, rhs);
+    int cmp = strcmp(lhs, rhs);
+
+    if (!cmp)
+        return AG_TRISTATE_GND;
+
+    return cmp > 0 ? AG_TRISTATE_HI : AG_TRISTATE_LO;
 }
 
 

--- a/test/object.c
+++ b/test/object.c
@@ -229,7 +229,7 @@ static void base_test_str(void)
     printf("ag_object_str() returns a string for a base object");
 
     ag_object_smart_t *o = base_sample();
-    const char *s = ag_object_str(o);
+    ag_string_smart_t *s = ag_object_str(o);
 
     ag_require (s && *s, AG_ERNO_TEST, NULL);
     printf("...OK\n");
@@ -396,10 +396,10 @@ static inline enum ag_tristate derived_method_cmp(const ag_object_t *lhs,
 
 
            /* method to get string representation of derived object [AgDM:??] */
-static inline const char *derived_method_str(const ag_object_t *obj)
+static inline ag_string_t *derived_method_str(const ag_object_t *obj)
 {
     (void) obj;
-    return "derived";
+    return ag_string_new("derived");
 }
 
 
@@ -618,7 +618,8 @@ static void derived_test_str(void)
             " object");
 
     ag_object_smart_t *o = derived_sample();
-    ag_require (!strcmp("derived", ag_object_str(o)), AG_ERNO_TEST, NULL);
+    ag_string_smart_t *s = ag_object_str(o);
+    ag_require (!strcmp("derived", s), AG_ERNO_TEST, NULL);
 
     printf("...OK\n");
 }

--- a/test/object.c
+++ b/test/object.c
@@ -138,12 +138,12 @@ static void base_test_len(void)
                                     /* test case #9 for base object [AgDM:??] */
 static void base_test_cmp(void)
 {
-    printf("ag_object_cmp() returns AG_OBJECT_CMP_EQ for the same base object");
+    printf("ag_object_cmp() returns AG_TRISTATE_GND for the same base object");
 
     ag_object_smart_t *o1 = base_sample();
     ag_object_smart_t *o2 = base_sample();
 
-    ag_require (ag_object_cmp(o1, o2) == AG_OBJECT_CMP_EQ, AG_ERNO_TEST, NULL);
+    ag_require (ag_object_cmp(o1, o2) == AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
     printf("...OK\n");
 }
 
@@ -382,16 +382,16 @@ static inline size_t derived_method_hash(const ag_object_t *obj)
 
 
                             /* method to compare two derived object [AgDM:??] */
-static inline enum ag_object_cmp derived_method_cmp(const ag_object_t *lhs, 
+static inline enum ag_tristate derived_method_cmp(const ag_object_t *lhs, 
         const ag_object_t *rhs)
 {
     size_t lid = ag_object_id(lhs);
     size_t rid = ag_object_id(rhs);
 
     if (lid == rid)
-        return AG_OBJECT_CMP_EQ;
+        return AG_TRISTATE_GND;
 
-    return lid < rid ? AG_OBJECT_CMP_LT : AG_OBJECT_CMP_GT;
+    return lid < rid ? AG_TRISTATE_LO : AG_TRISTATE_HI;
 }
 
 
@@ -525,13 +525,13 @@ static void derived_test_empty(void)
                                  /* test case #9 for derived object [AgDM:??] */
 static void derived_test_cmp(void)
 {
-    printf("ag_object_cmp() returns AG_OBJECT_CMP_EQ for the same derived"
+    printf("ag_object_cmp() returns AG_TRISTATE_GND for the same derived"
             " object");
 
     ag_object_smart_t *o1 = derived_sample();
     ag_object_smart_t *o2 = derived_sample();
 
-    ag_require (ag_object_cmp(o1, o2) == AG_OBJECT_CMP_EQ, AG_ERNO_TEST, NULL);
+    ag_require (ag_object_cmp(o1, o2) == AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
     printf("...OK\n");
 }
 

--- a/test/runner.c
+++ b/test/runner.c
@@ -7,6 +7,7 @@ int main(int argc, char **argv)
     (void) argv;
 
     ag_test_memblock();
+    ag_test_string();
     ag_test_object();
 
     return 0;

--- a/test/string.c
+++ b/test/string.c
@@ -1,0 +1,130 @@
+#include "../src/api.h"
+#include "./test.h"
+
+
+
+
+/*******************************************************************************
+ *                              EMPTY STRING TESTS
+ */
+
+
+                                   /* test case #1 for empty string [AgDM:??] */
+static void empty_test_new(void)
+{
+    printf("ag_string_new_empty() can create an empty string");
+
+    ag_string_smart_t *test = ag_string_new_empty();
+    ag_require (test && !*test, AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+
+                                   /* test case #2 for empty string [AgDM:??] */
+static void empty_test_copy(void)
+{
+    printf("ag_string_copy() can copy an empty string");
+
+    ag_string_smart_t *test = ag_string_new_empty();
+    ag_string_smart_t *copy = ag_string_copy(test);
+    ag_require (copy && !*copy, AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+
+                                   /* test case #3 for empty string [AgDM:??] */
+static void empty_test_len(void)
+{
+    printf("ag_string_len() reports 0 for an empty string");
+
+    ag_string_smart_t *test = ag_string_new_empty();
+    ag_require (ag_string_len(test) == 0, AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+
+                                   /* test case #4 for empty string [AgDM:??] */
+static void empty_test_sz(void)
+{
+    printf("ag_string_sz() reports 0 for an empty string");
+
+    ag_string_smart_t *test = ag_string_new_empty();
+    ag_require (!ag_string_sz(test), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+
+                                   /* test case #5 for empty string [AgDM:??] */
+static void empty_test_cmp(void)
+{
+    printf("ag_string_cmp() detects two equal empty strings...");
+
+    ag_string_smart_t *lhs = ag_string_new_empty();
+    ag_string_smart_t *rhs = ag_string_new_empty();
+    ag_require (!ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+
+                                   /* test case #6 for empty string [AgDM:??] */
+static void empty_test_add(void)
+{
+    printf("ag_string_add() adds two empty strings...");
+
+    ag_string_smart_t *test = ag_string_new_empty();
+    ag_string_add(&test, "");
+    ag_require (!*test, AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+
+
+
+/*******************************************************************************
+ *                              ASCII STRING TESTS
+ */
+
+
+
+
+/*******************************************************************************
+ *                             UNICODE STRING TESTS
+ */
+
+
+
+
+/*******************************************************************************
+ *                                  TEST SUITE
+ */
+
+
+                                         /* runs empty string tests [AgDM:??] */
+static void test_empty(void)
+{
+    empty_test_new();
+    empty_test_copy();
+    empty_test_len();
+    empty_test_sz();
+    empty_test_cmp();
+    empty_test_add();
+}
+
+
+                             /* implementation of string test suite [AgDM:??] */
+extern void ag_test_string(void)
+{
+    printf("===============================================================\n");
+    printf("Starting object model interface test suite...\n\n");
+
+    test_empty();
+    
+    printf("\n");
+}
+

--- a/test/string.c
+++ b/test/string.c
@@ -72,7 +72,7 @@ static void empty_sz(void)
                                    /* test case #6 for empty string [AgDM:??] */
 static void empty_cmp(void)
 {
-    printf("ag_string_cmp() detects two equal empty strings...");
+    printf("ag_string_cmp() detects two equal empty strings");
 
     ag_string_smart_t *lhs = ag_string_new_empty();
     ag_string_smart_t *rhs = ag_string_new_empty();
@@ -85,7 +85,7 @@ static void empty_cmp(void)
                                    /* test case #7 for empty string [AgDM:??] */
 static void empty_add(void)
 {
-    printf("ag_string_add() adds two empty strings...");
+    printf("ag_string_add() has no effect on adding two empty strings");
 
     ag_string_smart_t *s1 = ag_string_new_empty();
     ag_string_smart_t *s2 = ag_string_new_empty();
@@ -98,7 +98,7 @@ static void empty_add(void)
                                    /* test case #8 for empty string [AgDM:??] */
 static void empty_lt(void)
 {
-    printf("ag_string_lt() returns false for two empty strings...");
+    printf("ag_string_lt() returns false for two empty strings");
 
     ag_string_smart_t *s1 = ag_string_new_empty();
     ag_string_smart_t *s2 = ag_string_new_empty();
@@ -110,7 +110,7 @@ static void empty_lt(void)
                                    /* test case #9 for empty string [AgDM:??] */
 static void empty_eq(void)
 {
-    printf("ag_string_eq() returns true for two empty strings...");
+    printf("ag_string_eq() returns true for two empty strings");
 
     ag_string_smart_t *s1 = ag_string_new_empty();
     ag_string_smart_t *s2 = ag_string_new_empty();
@@ -122,11 +122,24 @@ static void empty_eq(void)
                                   /* test case #10 for empty string [AgDM:??] */
 static void empty_gt(void)
 {
-    printf("ag_string_gt() returns false for two empty strings...");
+    printf("ag_string_gt() returns false for two empty strings");
 
     ag_string_smart_t *s1 = ag_string_new_empty();
     ag_string_smart_t *s2 = ag_string_new_empty();
     ag_require (!ag_string_lt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                  /* test case #11 for empty string [AgDM:??] */
+static void empty_add_cstr(void)
+{
+    printf("ag_string_add_cstr() has no effect on adding null string to an"
+            " empty string");
+
+    ag_string_smart_t *s1 = ag_string_new_empty();
+    ag_string_add_cstr(&s1, "");
+    ag_require (!*s1, AG_ERNO_TEST, NULL);
 
     printf("...OK\n");
 }
@@ -144,6 +157,7 @@ static void empty_test(void)
     empty_lt();
     empty_eq();
     empty_gt();
+    empty_add_cstr();
 }
 
 
@@ -196,80 +210,80 @@ static void ascii_copy_2(void)
                                    /* test case #4 for ASCII string [AgDM:??] */
 static void ascii_len(void)
 {
-    printf("ag_string_len() reports the length of an ASCII string...");
+    printf("ag_string_len() reports the length of an ASCII string");
 
     ag_string_smart_t *test = ag_string_new("Hello, world!");
     ag_require (ag_string_len(test) == 13, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                    /* test case #5 for ASCII string [AgDM:??] */
 static void ascii_sz(void)
 {
-    printf("ag_string_sz() reports the size of an ASCII string...");
+    printf("ag_string_sz() reports the size of an ASCII string");
 
     const ag_string_t *sample = "Hello, world!";
     ag_string_smart_t *test = ag_string_new(sample);
     ag_require (ag_string_sz(test) == strlen(sample), AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                    /* test case #6 for ASCII string [AgDM:??] */
 static void ascii_cmp_1(void)
 {
-    printf("ag_string_cmp() detects two equal ASCII strings...");
+    printf("ag_string_cmp() detects two equal ASCII strings");
 
     ag_string_smart_t *lhs = ag_string_new("Hello, world!");
     ag_string_smart_t *rhs = ag_string_new("Hello, world!");
     ag_require (ag_string_cmp(lhs, rhs) == AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                    /* test case #7 for ASCII string [AgDM:??] */
 static void ascii_cmp_2(void)
 {
-    printf("ag_string_cmp() detects two unequal ASCII strings...");
+    printf("ag_string_cmp() detects two unequal ASCII strings");
 
     ag_string_smart_t *lhs = ag_string_new("Hello, world!");
     ag_string_smart_t *rhs = ag_string_new("Goodbye, moon?");
     ag_require (ag_string_cmp(lhs, rhs) != AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                    /* test case #8 for ASCII string [AgDM:??] */
 static void ascii_cmp(void)
 {
     printf("ag_string_cmp() detects a lexicographically smaller ASCII"
-            " string...");
+            " string");
 
     ag_string_smart_t *lhs = ag_string_new("Goodbye, moon?");
     ag_string_smart_t *rhs = ag_string_new("Hello, world!");
     ag_require (ag_string_cmp(lhs, rhs) == AG_TRISTATE_LO, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                    /* test case #9 for ASCII string [AgDM:??] */
 static void ascii_cmp_4(void)
 {
     printf("ag_string_cmp() detects a lexicographically greater ASCII"
-            "string...");
+            "string");
 
     ag_string_smart_t *lhs = ag_string_new("Goodbye, moon?");
     ag_string_smart_t *rhs = ag_string_new("Hello, world!");
     ag_require (ag_string_cmp(rhs, lhs) == AG_TRISTATE_HI, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                   /* test case #10 for ASCII string [AgDM:??] */
 static void ascii_add(void)
 {
-    printf("ag_string_add() adds two ASCII strings...");
+    printf("ag_string_add() adds two ASCII strings");
 
     ag_string_smart_t *s1 = ag_string_new("Hello");
     ag_string_smart_t *s2 = ag_string_new(", ");
@@ -281,7 +295,7 @@ static void ascii_add(void)
     ag_string_add(&s1, s4);
     ag_require (!strcmp(s1, "Hello, world!"), AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                   /* test case #11 for ASCII string [AgDM:??] */
@@ -362,6 +376,21 @@ static void ascii_gt_2(void)
     printf("...OK\n");
 }
 
+                                  /* test case #17 for ASCII string [AgDM:??] */
+static void ascii_add_cstr(void)
+{
+    printf("ag_string_add() adds a C-style ASCII string to a string instance");
+
+    ag_string_smart_t *s1 = ag_string_new("Hello");
+
+    ag_string_add_cstr(&s1, ", ");
+    ag_string_add_cstr(&s1, "world");
+    ag_string_add_cstr(&s1, "!");
+    ag_require (!strcmp(s1, "Hello, world!"), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
                                          /* runs ASCII string tests [AgDM:??] */
 static void ascii_test(void)
 {
@@ -381,6 +410,7 @@ static void ascii_test(void)
     ascii_eq_2();
     ascii_gt_1();
     ascii_gt_2();
+    ascii_add_cstr();
 }
 
 
@@ -391,26 +421,26 @@ static void ascii_test(void)
                                  /* test case #1 for Unicode string [AgDM:??] */
 static void unicode_new(void)
 {
-    printf("ag_string_new() can create a Unicode string...");
+    printf("ag_string_new() can create a Unicode string");
 
     const ag_string_t *expect = "Привет, мир!";
     ag_string_smart_t *test = ag_string_new(expect);
     ag_require (test && !strcmp(test, expect), AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                  /* test case #2 for Unicode string [AgDM:??] */
 static void unicode_copy(void)
 {
-    printf("ag_string_copy() can copy a Unicode string...");
+    printf("ag_string_copy() can copy a Unicode string");
 
     const ag_string_t *expect = "Привет, мир!";
     ag_string_smart_t *test = ag_string_new(expect);
     ag_string_smart_t *copy = ag_string_copy(test);
     ag_require (test && !strcmp(copy, expect), AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                  /* test case #3 for Unicode string [AgDM:??] */
@@ -433,80 +463,80 @@ static void unicode_copy_2(void)
                                  /* test case #4 for Unicode string [AgDM:??] */
 static void unicode_len(void)
 {
-    printf("ag_string_len() reports the length of a Unicode string...");
+    printf("ag_string_len() reports the length of a Unicode string");
 
     ag_string_smart_t *test = ag_string_new("Привет, мир!");
     ag_require (ag_string_len(test) == 12, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                  /* test case #5 for Unicode string [AgDM:??] */
 static void unicode_sz(void)
 {
-    printf("ag_string_sz() reports the size of a Unicode string...");
+    printf("ag_string_sz() reports the size of a Unicode string");
 
     const ag_string_t *sample = "Привет, мир!";
     ag_string_smart_t *test = ag_string_new(sample);
     ag_require (ag_string_sz(test) == strlen(sample), AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                  /* test case #6 for Unicode string [AgDM:??] */
 static void unicode_cmp_1(void)
 {
-    printf("ag_string_cmp() detects two equal Unicode strings...");
+    printf("ag_string_cmp() detects two equal Unicode strings");
 
     ag_string_smart_t *lhs = ag_string_new("Привет, мир!");
     ag_string_smart_t *rhs = ag_string_new("Привет, мир!");
     ag_require (ag_string_cmp(lhs, rhs) == AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                  /* test case #7 for Unicode string [AgDM:??] */
 static void unicode_cmp_2(void)
 {
-    printf("ag_string_cmp() detects two unequal Unicode strings...");
+    printf("ag_string_cmp() detects two unequal Unicode strings");
 
     ag_string_smart_t *lhs = ag_string_new("Привет, мир!");
     ag_string_smart_t *rhs = ag_string_new("До свидания, луна?");
     ag_require (ag_string_cmp(lhs, rhs) != AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                  /* test case #8 for Unicode string [AgDM:??] */
 static void unicode_cmp_3(void)
 {
     printf("ag_string_cmp() detects a lexicographically smaller Unicode"
-            " string...");
+            " string");
 
     ag_string_smart_t *lhs = ag_string_new("До свидания, луна?");
     ag_string_smart_t *rhs = ag_string_new("Привет, мир!");
     ag_require (ag_string_cmp(lhs, rhs) == AG_TRISTATE_LO, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                  /* test case #9 for Unicode string [AgDM:??] */
 static void unicode_cmp_4(void)
 {
     printf("ag_string_cmp() detects a lexicographically greater Unicode"
-            " string...");
+            " string");
 
     ag_string_smart_t *lhs = ag_string_new("До свидания, луна?");
     ag_string_smart_t *rhs = ag_string_new("Привет, мир!");
     ag_require (ag_string_cmp(rhs, lhs) == AG_TRISTATE_HI, AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                 /* test case #10 for Unicode string [AgDM:??] */
 static void unicode_add(void)
 {
-    printf("ag_string_add() adds two Unicode strings...");
+    printf("ag_string_add() adds two Unicode strings");
 
     ag_string_smart_t *expect = ag_string_new("До свидания, луна?");
     ag_string_smart_t *test = ag_string_new("До свидания");
@@ -519,7 +549,7 @@ static void unicode_add(void)
     ag_string_add(&test, s3);
     ag_require (!strcmp(test, expect), AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                 /* test case #11 for Unicode string [AgDM:??] */
@@ -569,7 +599,7 @@ static void unicode_eq_2(void)
     ag_string_smart_t *s2 = ag_string_new("Привет, мир!");
     ag_require (!ag_string_eq(s1, s2), AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
 }
 
                                 /* test case #15 for Unicode string [AgDM:??] */
@@ -598,6 +628,21 @@ static void unicode_gt_2(void)
     printf("...OK\n");
 }
 
+                                /* test case #17 for Unicode string [AgDM:??] */
+static void unicode_add_cstr(void)
+{
+    printf("ag_string_add() adds C-style Unicode string to a string instance");
+
+    ag_string_smart_t *expect = ag_string_new("До свидания, луна?");
+    ag_string_smart_t *s = ag_string_new("До свидания");
+    ag_string_add_cstr(&s, ", ");
+    ag_string_add_cstr(&s, "луна");
+    ag_string_add_cstr(&s, "?");
+    ag_require (!strcmp(s, expect), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
                                        /* runs Unicode string tests [AgDM:??] */
 static void unicode_test(void)
 {
@@ -617,6 +662,7 @@ static void unicode_test(void)
     unicode_eq_2();
     unicode_gt_1();
     unicode_gt_2();
+    unicode_add_cstr();
 }
 
 

--- a/test/string.c
+++ b/test/string.c
@@ -8,7 +8,7 @@
  */
 
                                    /* test case #1 for empty string [AgDM:??] */
-static void empty_test_new(void)
+static void empty_new(void)
 {
     printf("ag_string_new_empty() can create an empty string");
 
@@ -19,7 +19,7 @@ static void empty_test_new(void)
 }
 
                                    /* test case #2 for empty string [AgDM:??] */
-static void empty_test_copy(void)
+static void empty_copy(void)
 {
     printf("ag_string_copy() can copy an empty string");
 
@@ -31,7 +31,7 @@ static void empty_test_copy(void)
 }
 
                                    /* test case #3 for empty string [AgDM:??] */
-static void empty_test_len(void)
+static void empty_len(void)
 {
     printf("ag_string_len() reports 0 for an empty string");
 
@@ -42,7 +42,7 @@ static void empty_test_len(void)
 }
 
                                    /* test case #4 for empty string [AgDM:??] */
-static void empty_test_sz(void)
+static void empty_sz(void)
 {
     printf("ag_string_sz() reports 0 for an empty string");
 
@@ -53,7 +53,7 @@ static void empty_test_sz(void)
 }
 
                                    /* test case #5 for empty string [AgDM:??] */
-static void empty_test_cmp(void)
+static void empty_cmp(void)
 {
     printf("ag_string_cmp() detects two equal empty strings...");
 
@@ -64,8 +64,9 @@ static void empty_test_cmp(void)
     printf("...OK\n");
 }
 
+
                                    /* test case #6 for empty string [AgDM:??] */
-static void empty_test_add(void)
+static void empty_add(void)
 {
     printf("ag_string_add() adds two empty strings...");
 
@@ -76,15 +77,54 @@ static void empty_test_add(void)
     printf("...OK\n");
 }
 
+                                   /* test case #7 for empty string [AgDM:??] */
+static void empty_lt(void)
+{
+    printf("ag_string_lt() returns false for two empty strings...");
+
+    ag_string_smart_t *s1 = ag_string_new_empty();
+    ag_string_smart_t *s2 = ag_string_new_empty();
+    ag_require (!ag_string_lt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                   /* test case #8 for empty string [AgDM:??] */
+static void empty_eq(void)
+{
+    printf("ag_string_eq() returns true for two empty strings...");
+
+    ag_string_smart_t *s1 = ag_string_new_empty();
+    ag_string_smart_t *s2 = ag_string_new_empty();
+    ag_require (ag_string_eq(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                   /* test case #9 for empty string [AgDM:??] */
+static void empty_gt(void)
+{
+    printf("ag_string_gt() returns false for two empty strings...");
+
+    ag_string_smart_t *s1 = ag_string_new_empty();
+    ag_string_smart_t *s2 = ag_string_new_empty();
+    ag_require (!ag_string_lt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
                                          /* runs empty string tests [AgDM:??] */
 static void empty_test(void)
 {
-    empty_test_new();
-    empty_test_copy();
-    empty_test_len();
-    empty_test_sz();
-    empty_test_cmp();
-    empty_test_add();
+    empty_new();
+    empty_copy();
+    empty_len();
+    empty_sz();
+    empty_cmp();
+    empty_add();
+    empty_lt();
+    empty_eq();
+    empty_gt();
 }
 
 
@@ -204,6 +244,84 @@ static void ascii_add(void)
     printf("OK\n");
 }
 
+                                  /* test case #10 for ASCII string [AgDM:??] */
+static void ascii_lt_1(void)
+{
+    printf("ag_string_lt() returns true if an ASCII string is lexicographically"
+            " less than another");
+
+    ag_string_smart_t *s1 = ag_string_new("Goodbye, moon?");
+    ag_string_smart_t *s2 = ag_string_new("Hello, world!");
+    ag_require (ag_string_lt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                  /* test case #11 for ASCII string [AgDM:??] */
+static void ascii_lt_2(void)
+{
+    printf("ag_string_lt() returns false if an ASCII string is not"
+            " lexicographically less than another");
+
+    ag_string_smart_t *s1 = ag_string_new("Hello, world!");
+    ag_string_smart_t *s2 = ag_string_new("Goodbye, moon?");
+    ag_require (!ag_string_lt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                  /* test case #12 for ASCII string [AgDM:??] */
+static void ascii_eq_1(void)
+{
+    printf("ag_string_eq() returns true if an ASCII string is lexicographically"
+            " equal to another");
+
+    ag_string_smart_t *s1 = ag_string_new("Hello, world!");
+    ag_string_smart_t *s2 = ag_string_new("Hello, world!");
+    ag_require (ag_string_eq(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                  /* test case #13 for ASCII string [AgDM:??] */
+static void ascii_eq_2(void)
+{
+    printf("ag_string_eq() returns true if an ASCII string is lexicographically"
+            " not equal to another");
+
+    ag_string_smart_t *s1 = ag_string_new("Hello, world!");
+    ag_string_smart_t *s2 = ag_string_new("Goodbye, moon?");
+    ag_require (!ag_string_eq(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                  /* test case #14 for ASCII string [AgDM:??] */
+static void ascii_gt_1(void)
+{
+    printf("ag_string_gt() returns true if an ASCII string is lexicographically"
+            " greater than another");
+
+    ag_string_smart_t *s1 = ag_string_new("Hello, world!");
+    ag_string_smart_t *s2 = ag_string_new("Goodbye, moon?");
+    ag_require (ag_string_gt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                  /* test case #15 for ASCII string [AgDM:??] */
+static void ascii_gt_2(void)
+{
+    printf("ag_string_gt() returns false if an ASCII string is not"
+            " lexicographically greater than another");
+
+    ag_string_smart_t *s1 = ag_string_new("Goodbye, moon?");
+    ag_string_smart_t *s2 = ag_string_new("Hello, world!");
+    ag_require (!ag_string_gt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
                                          /* runs ASCII string tests [AgDM:??] */
 static void ascii_test(void)
 {
@@ -216,6 +334,12 @@ static void ascii_test(void)
     ascii_cmp();
     ascii_cmp_4();
     ascii_add();
+    ascii_lt_1();
+    ascii_lt_2();
+    ascii_eq_1();
+    ascii_eq_2();
+    ascii_gt_1();
+    ascii_gt_2();
 }
 
 
@@ -336,6 +460,82 @@ static void unicode_add(void)
     printf("OK\n");
 }
 
+                                /* test case #11 for Unicode string [AgDM:??] */
+static void unicode_lt_1(void)
+{
+    printf("ag_string_lt() returns true if a Unicode string is"
+            " lexicographically less than another");
+
+    ag_string_smart_t *s1 = ag_string_new("До свидания, луна?");
+    ag_string_smart_t *s2 = ag_string_new("Привет, мир!");
+    ag_require (ag_string_lt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                /* test case #12 for Unicode string [AgDM:??] */
+static void unicode_lt_2(void)
+{
+    printf("ag_string_lt() returns false if a Unicode string is not"
+            " lexicographically less than another");
+
+    ag_string_smart_t *s1 = ag_string_new("Привет, мир!");
+    ag_string_smart_t *s2 = ag_string_new("До свидания, луна?");
+    ag_require (!ag_string_lt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                /* test case #13 for Unicode string [AgDM:??] */
+static void unicode_eq_1(void)
+{
+    printf("ag_string_eq() returns true for two equal Unicode strings");
+
+    ag_string_smart_t *s1 = ag_string_new("Привет, мир!");
+    ag_string_smart_t *s2 = ag_string_new("Привет, мир!");
+    ag_require (ag_string_eq(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                /* test case #14 for Unicode string [AgDM:??] */
+static void unicode_eq_2(void)
+{
+    printf("ag_string_eq() returns false for two unequal Unicode strings");
+
+    ag_string_smart_t *s1 = ag_string_new("До свидания, луна?");
+    ag_string_smart_t *s2 = ag_string_new("Привет, мир!");
+    ag_require (!ag_string_eq(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                /* test case #15 for Unicode string [AgDM:??] */
+static void unicode_gt_1(void)
+{
+    printf("ag_string_gt() returns true if a Unicode string is"
+            " lexicographically less than another");
+
+    ag_string_smart_t *s1 = ag_string_new("Привет, мир!");
+    ag_string_smart_t *s2 = ag_string_new("До свидания, луна?");
+    ag_require (ag_string_gt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                /* test case #16 for Unicode string [AgDM:??] */
+static void unicode_gt_2(void)
+{
+    printf("ag_string_gt() returns false if a Unicode string is not"
+            " lexicographically less than another");
+
+    ag_string_smart_t *s1 = ag_string_new("До свидания, луна?");
+    ag_string_smart_t *s2 = ag_string_new("Привет, мир!");
+    ag_require (!ag_string_gt(s1, s2), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
                                        /* runs Unicode string tests [AgDM:??] */
 static void unicode_test(void)
 {
@@ -348,6 +548,12 @@ static void unicode_test(void)
     unicode_cmp_3();
     unicode_cmp_4();
     unicode_add();
+    unicode_lt_1();
+    unicode_lt_2();
+    unicode_eq_1();
+    unicode_eq_2();
+    unicode_gt_1();
+    unicode_gt_2();
 }
 
 

--- a/test/string.c
+++ b/test/string.c
@@ -70,9 +70,10 @@ static void empty_add(void)
 {
     printf("ag_string_add() adds two empty strings...");
 
-    ag_string_smart_t *test = ag_string_new_empty();
-    ag_string_add(&test, "");
-    ag_require (!*test, AG_ERNO_TEST, NULL);
+    ag_string_smart_t *s1 = ag_string_new_empty();
+    ag_string_smart_t *s2 = ag_string_new_empty();
+    ag_string_add(&s1, s2);
+    ag_require (!*s1, AG_ERNO_TEST, NULL);
 
     printf("...OK\n");
 }
@@ -235,11 +236,15 @@ static void ascii_add(void)
 {
     printf("ag_string_add() adds two ASCII strings...");
 
-    ag_string_smart_t *test = ag_string_new("Hello");
-    ag_string_add(&test, ", ");
-    ag_string_add(&test, "world");
-    ag_string_add(&test, "!");
-    ag_require (!strcmp(test, "Hello, world!"), AG_ERNO_TEST, NULL);
+    ag_string_smart_t *s1 = ag_string_new("Hello");
+    ag_string_smart_t *s2 = ag_string_new(", ");
+    ag_string_smart_t *s3 = ag_string_new("world");
+    ag_string_smart_t *s4 = ag_string_new("!");
+
+    ag_string_add(&s1, s2);
+    ag_string_add(&s1, s3);
+    ag_string_add(&s1, s4);
+    ag_require (!strcmp(s1, "Hello, world!"), AG_ERNO_TEST, NULL);
 
     printf("OK\n");
 }
@@ -450,11 +455,15 @@ static void unicode_add(void)
 {
     printf("ag_string_add() adds two Unicode strings...");
 
-    const ag_string_t *expect = "До свидания, луна?";
+    ag_string_smart_t *expect = ag_string_new("До свидания, луна?");
     ag_string_smart_t *test = ag_string_new("До свидания");
-    ag_string_add(&test, ", ");
-    ag_string_add(&test, "луна");
-    ag_string_add(&test, "?");
+    ag_string_smart_t *s1 = ag_string_new(", ");
+    ag_string_smart_t *s2 = ag_string_new("луна");
+    ag_string_smart_t *s3 = ag_string_new("?");
+
+    ag_string_add(&test, s1);
+    ag_string_add(&test, s2);
+    ag_string_add(&test, s3);
     ag_require (!strcmp(test, expect), AG_ERNO_TEST, NULL);
 
     printf("OK\n");

--- a/test/string.c
+++ b/test/string.c
@@ -31,6 +31,23 @@ static void empty_copy(void)
 }
 
                                    /* test case #3 for empty string [AgDM:??] */
+static void empty_copy_2(void)
+{
+    printf("ag_string_copy() creates a mutually exclusive copy of an empty"
+           " string");
+
+    ag_string_smart_t *s = ag_string_new_empty();
+    ag_string_smart_t *cp = ag_string_copy(s);
+
+    ag_string_smart_t *add = ag_string_new("Hello!");
+    ag_string_add(&s, add);
+    ag_require (!strcmp(s, "Hello!"), AG_ERNO_TEST, NULL);
+    ag_require (!*cp, AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                   /* test case #4 for empty string [AgDM:??] */
 static void empty_len(void)
 {
     printf("ag_string_len() reports 0 for an empty string");
@@ -41,7 +58,7 @@ static void empty_len(void)
     printf("...OK\n");
 }
 
-                                   /* test case #4 for empty string [AgDM:??] */
+                                   /* test case #5 for empty string [AgDM:??] */
 static void empty_sz(void)
 {
     printf("ag_string_sz() reports 0 for an empty string");
@@ -52,7 +69,7 @@ static void empty_sz(void)
     printf("...OK\n");
 }
 
-                                   /* test case #5 for empty string [AgDM:??] */
+                                   /* test case #6 for empty string [AgDM:??] */
 static void empty_cmp(void)
 {
     printf("ag_string_cmp() detects two equal empty strings...");
@@ -65,7 +82,7 @@ static void empty_cmp(void)
 }
 
 
-                                   /* test case #6 for empty string [AgDM:??] */
+                                   /* test case #7 for empty string [AgDM:??] */
 static void empty_add(void)
 {
     printf("ag_string_add() adds two empty strings...");
@@ -78,7 +95,7 @@ static void empty_add(void)
     printf("...OK\n");
 }
 
-                                   /* test case #7 for empty string [AgDM:??] */
+                                   /* test case #8 for empty string [AgDM:??] */
 static void empty_lt(void)
 {
     printf("ag_string_lt() returns false for two empty strings...");
@@ -90,7 +107,7 @@ static void empty_lt(void)
     printf("...OK\n");
 }
 
-                                   /* test case #8 for empty string [AgDM:??] */
+                                   /* test case #9 for empty string [AgDM:??] */
 static void empty_eq(void)
 {
     printf("ag_string_eq() returns true for two empty strings...");
@@ -102,7 +119,7 @@ static void empty_eq(void)
     printf("...OK\n");
 }
 
-                                   /* test case #9 for empty string [AgDM:??] */
+                                  /* test case #10 for empty string [AgDM:??] */
 static void empty_gt(void)
 {
     printf("ag_string_gt() returns false for two empty strings...");
@@ -119,6 +136,7 @@ static void empty_test(void)
 {
     empty_new();
     empty_copy();
+    empty_copy_2();
     empty_len();
     empty_sz();
     empty_cmp();
@@ -159,6 +177,23 @@ static void ascii_copy(void)
 }
 
                                    /* test case #3 for ASCII string [AgDM:??] */
+static void ascii_copy_2(void)
+{
+    printf("ag_string_copy() creates a mutually exclusive copy of an ASCII"
+           " string");
+
+    ag_string_smart_t *s = ag_string_new("Hello");
+    ag_string_smart_t *cp = ag_string_copy(s);
+
+    ag_string_smart_t *add = ag_string_new(", world!");
+    ag_string_add(&s, add);
+    ag_require (!strcmp(s, "Hello, world!"), AG_ERNO_TEST, NULL);
+    ag_require (!strcmp(cp, "Hello"), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                   /* test case #4 for ASCII string [AgDM:??] */
 static void ascii_len(void)
 {
     printf("ag_string_len() reports the length of an ASCII string...");
@@ -169,7 +204,7 @@ static void ascii_len(void)
     printf("OK\n");
 }
 
-                                   /* test case #4 for ASCII string [AgDM:??] */
+                                   /* test case #5 for ASCII string [AgDM:??] */
 static void ascii_sz(void)
 {
     printf("ag_string_sz() reports the size of an ASCII string...");
@@ -181,7 +216,7 @@ static void ascii_sz(void)
     printf("OK\n");
 }
 
-                                   /* test case #5 for ASCII string [AgDM:??] */
+                                   /* test case #6 for ASCII string [AgDM:??] */
 static void ascii_cmp_1(void)
 {
     printf("ag_string_cmp() detects two equal ASCII strings...");
@@ -193,7 +228,7 @@ static void ascii_cmp_1(void)
     printf("OK\n");
 }
 
-                                   /* test case #6 for ASCII string [AgDM:??] */
+                                   /* test case #7 for ASCII string [AgDM:??] */
 static void ascii_cmp_2(void)
 {
     printf("ag_string_cmp() detects two unequal ASCII strings...");
@@ -205,7 +240,7 @@ static void ascii_cmp_2(void)
     printf("OK\n");
 }
 
-                                   /* test case #7 for ASCII string [AgDM:??] */
+                                   /* test case #8 for ASCII string [AgDM:??] */
 static void ascii_cmp(void)
 {
     printf("ag_string_cmp() detects a lexicographically smaller ASCII"
@@ -218,7 +253,7 @@ static void ascii_cmp(void)
     printf("OK\n");
 }
 
-                                   /* test case #8 for ASCII string [AgDM:??] */
+                                   /* test case #9 for ASCII string [AgDM:??] */
 static void ascii_cmp_4(void)
 {
     printf("ag_string_cmp() detects a lexicographically greater ASCII"
@@ -231,7 +266,7 @@ static void ascii_cmp_4(void)
     printf("OK\n");
 }
 
-                                   /* test case #9 for ASCII string [AgDM:??] */
+                                  /* test case #10 for ASCII string [AgDM:??] */
 static void ascii_add(void)
 {
     printf("ag_string_add() adds two ASCII strings...");
@@ -249,7 +284,7 @@ static void ascii_add(void)
     printf("OK\n");
 }
 
-                                  /* test case #10 for ASCII string [AgDM:??] */
+                                  /* test case #11 for ASCII string [AgDM:??] */
 static void ascii_lt_1(void)
 {
     printf("ag_string_lt() returns true if an ASCII string is lexicographically"
@@ -262,7 +297,7 @@ static void ascii_lt_1(void)
     printf("...OK\n");
 }
 
-                                  /* test case #11 for ASCII string [AgDM:??] */
+                                  /* test case #12 for ASCII string [AgDM:??] */
 static void ascii_lt_2(void)
 {
     printf("ag_string_lt() returns false if an ASCII string is not"
@@ -275,7 +310,7 @@ static void ascii_lt_2(void)
     printf("...OK\n");
 }
 
-                                  /* test case #12 for ASCII string [AgDM:??] */
+                                  /* test case #13 for ASCII string [AgDM:??] */
 static void ascii_eq_1(void)
 {
     printf("ag_string_eq() returns true if an ASCII string is lexicographically"
@@ -288,7 +323,7 @@ static void ascii_eq_1(void)
     printf("...OK\n");
 }
 
-                                  /* test case #13 for ASCII string [AgDM:??] */
+                                  /* test case #14 for ASCII string [AgDM:??] */
 static void ascii_eq_2(void)
 {
     printf("ag_string_eq() returns true if an ASCII string is lexicographically"
@@ -301,7 +336,7 @@ static void ascii_eq_2(void)
     printf("...OK\n");
 }
 
-                                  /* test case #14 for ASCII string [AgDM:??] */
+                                  /* test case #15 for ASCII string [AgDM:??] */
 static void ascii_gt_1(void)
 {
     printf("ag_string_gt() returns true if an ASCII string is lexicographically"
@@ -314,7 +349,7 @@ static void ascii_gt_1(void)
     printf("...OK\n");
 }
 
-                                  /* test case #15 for ASCII string [AgDM:??] */
+                                  /* test case #16 for ASCII string [AgDM:??] */
 static void ascii_gt_2(void)
 {
     printf("ag_string_gt() returns false if an ASCII string is not"
@@ -332,6 +367,7 @@ static void ascii_test(void)
 {
     ascii_new();
     ascii_copy();
+    ascii_copy_2();
     ascii_len();
     ascii_sz();
     ascii_cmp_1();
@@ -378,6 +414,23 @@ static void unicode_copy(void)
 }
 
                                  /* test case #3 for Unicode string [AgDM:??] */
+static void unicode_copy_2(void)
+{
+    printf("ag_string_copy() creates a mutually exclusive copy of a Unicode"
+           " string");
+
+    ag_string_smart_t *s = ag_string_new("Привет");
+    ag_string_smart_t *cp = ag_string_copy(s);
+
+    ag_string_smart_t *add = ag_string_new(", мир!");
+    ag_string_add(&s, add);
+    ag_require (!strcmp(s, "Привет, мир!"), AG_ERNO_TEST, NULL);
+    ag_require (!strcmp(cp, "Привет"), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+                                 /* test case #4 for Unicode string [AgDM:??] */
 static void unicode_len(void)
 {
     printf("ag_string_len() reports the length of a Unicode string...");
@@ -388,7 +441,7 @@ static void unicode_len(void)
     printf("OK\n");
 }
 
-                                 /* test case #4 for Unicode string [AgDM:??] */
+                                 /* test case #5 for Unicode string [AgDM:??] */
 static void unicode_sz(void)
 {
     printf("ag_string_sz() reports the size of a Unicode string...");
@@ -400,7 +453,7 @@ static void unicode_sz(void)
     printf("OK\n");
 }
 
-                                 /* test case #5 for Unicode string [AgDM:??] */
+                                 /* test case #6 for Unicode string [AgDM:??] */
 static void unicode_cmp_1(void)
 {
     printf("ag_string_cmp() detects two equal Unicode strings...");
@@ -412,7 +465,7 @@ static void unicode_cmp_1(void)
     printf("OK\n");
 }
 
-                                 /* test case #6 for Unicode string [AgDM:??] */
+                                 /* test case #7 for Unicode string [AgDM:??] */
 static void unicode_cmp_2(void)
 {
     printf("ag_string_cmp() detects two unequal Unicode strings...");
@@ -424,7 +477,7 @@ static void unicode_cmp_2(void)
     printf("OK\n");
 }
 
-                                 /* test case #7 for Unicode string [AgDM:??] */
+                                 /* test case #8 for Unicode string [AgDM:??] */
 static void unicode_cmp_3(void)
 {
     printf("ag_string_cmp() detects a lexicographically smaller Unicode"
@@ -437,7 +490,7 @@ static void unicode_cmp_3(void)
     printf("OK\n");
 }
 
-                                 /* test case #8 for Unicode string [AgDM:??] */
+                                 /* test case #9 for Unicode string [AgDM:??] */
 static void unicode_cmp_4(void)
 {
     printf("ag_string_cmp() detects a lexicographically greater Unicode"
@@ -550,6 +603,7 @@ static void unicode_test(void)
 {
     unicode_new();
     unicode_copy();
+    unicode_copy_2();
     unicode_len();
     unicode_sz();
     unicode_cmp_1();

--- a/test/string.c
+++ b/test/string.c
@@ -59,7 +59,7 @@ static void empty_test_cmp(void)
 
     ag_string_smart_t *lhs = ag_string_new_empty();
     ag_string_smart_t *rhs = ag_string_new_empty();
-    ag_require (!ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+    ag_require (ag_string_cmp(lhs, rhs) == AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
 
     printf("...OK\n");
 }
@@ -147,7 +147,7 @@ static void ascii_cmp_1(void)
 
     ag_string_smart_t *lhs = ag_string_new("Hello, world!");
     ag_string_smart_t *rhs = ag_string_new("Hello, world!");
-    ag_require (!ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+    ag_require (ag_string_cmp(lhs, rhs) == AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
 
     printf("OK\n");
 }
@@ -159,7 +159,7 @@ static void ascii_cmp_2(void)
 
     ag_string_smart_t *lhs = ag_string_new("Hello, world!");
     ag_string_smart_t *rhs = ag_string_new("Goodbye, moon?");
-    ag_require (ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+    ag_require (ag_string_cmp(lhs, rhs) != AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
 
     printf("OK\n");
 }
@@ -172,7 +172,7 @@ static void ascii_cmp(void)
 
     ag_string_smart_t *lhs = ag_string_new("Goodbye, moon?");
     ag_string_smart_t *rhs = ag_string_new("Hello, world!");
-    ag_require (ag_string_cmp(lhs, rhs) < 0, AG_ERNO_TEST, NULL);
+    ag_require (ag_string_cmp(lhs, rhs) == AG_TRISTATE_LO, AG_ERNO_TEST, NULL);
 
     printf("OK\n");
 }
@@ -185,7 +185,7 @@ static void ascii_cmp_4(void)
 
     ag_string_smart_t *lhs = ag_string_new("Goodbye, moon?");
     ag_string_smart_t *rhs = ag_string_new("Hello, world!");
-    ag_require (ag_string_cmp(rhs, lhs) > 0, AG_ERNO_TEST, NULL);
+    ag_require (ag_string_cmp(rhs, lhs) == AG_TRISTATE_HI, AG_ERNO_TEST, NULL);
 
     printf("OK\n");
 }
@@ -278,7 +278,7 @@ static void unicode_cmp_1(void)
 
     ag_string_smart_t *lhs = ag_string_new("Привет, мир!");
     ag_string_smart_t *rhs = ag_string_new("Привет, мир!");
-    ag_require (!ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+    ag_require (ag_string_cmp(lhs, rhs) == AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
 
     printf("OK\n");
 }
@@ -290,7 +290,7 @@ static void unicode_cmp_2(void)
 
     ag_string_smart_t *lhs = ag_string_new("Привет, мир!");
     ag_string_smart_t *rhs = ag_string_new("До свидания, луна?");
-    ag_require (ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+    ag_require (ag_string_cmp(lhs, rhs) != AG_TRISTATE_GND, AG_ERNO_TEST, NULL);
 
     printf("OK\n");
 }
@@ -303,7 +303,7 @@ static void unicode_cmp_3(void)
 
     ag_string_smart_t *lhs = ag_string_new("До свидания, луна?");
     ag_string_smart_t *rhs = ag_string_new("Привет, мир!");
-    ag_require (ag_string_cmp(lhs, rhs) < 0, AG_ERNO_TEST, NULL);
+    ag_require (ag_string_cmp(lhs, rhs) == AG_TRISTATE_LO, AG_ERNO_TEST, NULL);
 
     printf("OK\n");
 }
@@ -316,7 +316,7 @@ static void unicode_cmp_4(void)
 
     ag_string_smart_t *lhs = ag_string_new("До свидания, луна?");
     ag_string_smart_t *rhs = ag_string_new("Привет, мир!");
-    ag_require (ag_string_cmp(rhs, lhs) > 0, AG_ERNO_TEST, NULL);
+    ag_require (ag_string_cmp(rhs, lhs) == AG_TRISTATE_HI, AG_ERNO_TEST, NULL);
 
     printf("OK\n");
 }

--- a/test/string.c
+++ b/test/string.c
@@ -3,12 +3,9 @@
 #include "./test.h"
 
 
-
-
 /*******************************************************************************
  *                              EMPTY STRING TESTS
  */
-
 
                                    /* test case #1 for empty string [AgDM:??] */
 static void empty_test_new(void)
@@ -20,7 +17,6 @@ static void empty_test_new(void)
 
     printf("...OK\n");
 }
-
 
                                    /* test case #2 for empty string [AgDM:??] */
 static void empty_test_copy(void)
@@ -34,7 +30,6 @@ static void empty_test_copy(void)
     printf("...OK\n");
 }
 
-
                                    /* test case #3 for empty string [AgDM:??] */
 static void empty_test_len(void)
 {
@@ -46,7 +41,6 @@ static void empty_test_len(void)
     printf("...OK\n");
 }
 
-
                                    /* test case #4 for empty string [AgDM:??] */
 static void empty_test_sz(void)
 {
@@ -57,7 +51,6 @@ static void empty_test_sz(void)
 
     printf("...OK\n");
 }
-
 
                                    /* test case #5 for empty string [AgDM:??] */
 static void empty_test_cmp(void)
@@ -71,7 +64,6 @@ static void empty_test_cmp(void)
     printf("...OK\n");
 }
 
-
                                    /* test case #6 for empty string [AgDM:??] */
 static void empty_test_add(void)
 {
@@ -83,7 +75,6 @@ static void empty_test_add(void)
 
     printf("...OK\n");
 }
-
 
                                          /* runs empty string tests [AgDM:??] */
 static void empty_test(void)
@@ -97,12 +88,9 @@ static void empty_test(void)
 }
 
 
-
-
 /*******************************************************************************
  *                              ASCII STRING TESTS
  */
-
 
                                    /* test case #1 for ASCII string [AgDM:??] */
 static void ascii_new(void)
@@ -115,7 +103,6 @@ static void ascii_new(void)
 
     printf("OK\n");
 }
-
 
                                    /* test case #2 for ASCII string [AgDM:??] */
 static void ascii_copy(void)
@@ -130,7 +117,6 @@ static void ascii_copy(void)
     printf("OK\n");
 }
 
-
                                    /* test case #3 for ASCII string [AgDM:??] */
 static void ascii_len(void)
 {
@@ -141,7 +127,6 @@ static void ascii_len(void)
 
     printf("OK\n");
 }
-
 
                                    /* test case #4 for ASCII string [AgDM:??] */
 static void ascii_sz(void)
@@ -155,7 +140,6 @@ static void ascii_sz(void)
     printf("OK\n");
 }
 
-
                                    /* test case #5 for ASCII string [AgDM:??] */
 static void ascii_cmp_1(void)
 {
@@ -167,7 +151,6 @@ static void ascii_cmp_1(void)
 
     printf("OK\n");
 }
-
 
                                    /* test case #6 for ASCII string [AgDM:??] */
 static void ascii_cmp_2(void)
@@ -181,9 +164,8 @@ static void ascii_cmp_2(void)
     printf("OK\n");
 }
 
-
                                    /* test case #7 for ASCII string [AgDM:??] */
-static void ascii_cmp_3(void)
+static void ascii_cmp(void)
 {
     printf("ag_string_cmp() detects a lexicographically smaller ASCII"
             " string...");
@@ -194,7 +176,6 @@ static void ascii_cmp_3(void)
 
     printf("OK\n");
 }
-
 
                                    /* test case #8 for ASCII string [AgDM:??] */
 static void ascii_cmp_4(void)
@@ -208,7 +189,6 @@ static void ascii_cmp_4(void)
 
     printf("OK\n");
 }
-
 
                                    /* test case #9 for ASCII string [AgDM:??] */
 static void ascii_add(void)
@@ -224,7 +204,6 @@ static void ascii_add(void)
     printf("OK\n");
 }
 
-
                                          /* runs ASCII string tests [AgDM:??] */
 static void ascii_test(void)
 {
@@ -234,26 +213,147 @@ static void ascii_test(void)
     ascii_sz();
     ascii_cmp_1();
     ascii_cmp_2();
-    ascii_cmp_3();
+    ascii_cmp();
     ascii_cmp_4();
     ascii_add();
 }
-
-
 
 
 /*******************************************************************************
  *                             UNICODE STRING TESTS
  */
 
+                                 /* test case #1 for Unicode string [AgDM:??] */
+static void unicode_new(void)
+{
+    printf("ag_string_new() can create a Unicode string...");
 
+    const ag_string_t *expect = "Привет, мир!";
+    ag_string_smart_t *test = ag_string_new(expect);
+    ag_require (test && !strcmp(test, expect), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                 /* test case #2 for Unicode string [AgDM:??] */
+static void unicode_copy(void)
+{
+    printf("ag_string_copy() can copy a Unicode string...");
+
+    const ag_string_t *expect = "Привет, мир!";
+    ag_string_smart_t *test = ag_string_new(expect);
+    ag_string_smart_t *copy = ag_string_copy(test);
+    ag_require (test && !strcmp(copy, expect), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                 /* test case #3 for Unicode string [AgDM:??] */
+static void unicode_len(void)
+{
+    printf("ag_string_len() reports the length of a Unicode string...");
+
+    ag_string_smart_t *test = ag_string_new("Привет, мир!");
+    ag_require (ag_string_len(test) == 12, AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                 /* test case #4 for Unicode string [AgDM:??] */
+static void unicode_sz(void)
+{
+    printf("ag_string_sz() reports the size of a Unicode string...");
+
+    const ag_string_t *sample = "Привет, мир!";
+    ag_string_smart_t *test = ag_string_new(sample);
+    ag_require (ag_string_sz(test) == strlen(sample), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                 /* test case #5 for Unicode string [AgDM:??] */
+static void unicode_cmp_1(void)
+{
+    printf("ag_string_cmp() detects two equal Unicode strings...");
+
+    ag_string_smart_t *lhs = ag_string_new("Привет, мир!");
+    ag_string_smart_t *rhs = ag_string_new("Привет, мир!");
+    ag_require (!ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                 /* test case #6 for Unicode string [AgDM:??] */
+static void unicode_cmp_2(void)
+{
+    printf("ag_string_cmp() detects two unequal Unicode strings...");
+
+    ag_string_smart_t *lhs = ag_string_new("Привет, мир!");
+    ag_string_smart_t *rhs = ag_string_new("До свидания, луна?");
+    ag_require (ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                 /* test case #7 for Unicode string [AgDM:??] */
+static void unicode_cmp_3(void)
+{
+    printf("ag_string_cmp() detects a lexicographically smaller Unicode"
+            " string...");
+
+    ag_string_smart_t *lhs = ag_string_new("До свидания, луна?");
+    ag_string_smart_t *rhs = ag_string_new("Привет, мир!");
+    ag_require (ag_string_cmp(lhs, rhs) < 0, AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                 /* test case #8 for Unicode string [AgDM:??] */
+static void unicode_cmp_4(void)
+{
+    printf("ag_string_cmp() detects a lexicographically greater Unicode"
+            " string...");
+
+    ag_string_smart_t *lhs = ag_string_new("До свидания, луна?");
+    ag_string_smart_t *rhs = ag_string_new("Привет, мир!");
+    ag_require (ag_string_cmp(rhs, lhs) > 0, AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                /* test case #10 for Unicode string [AgDM:??] */
+static void unicode_add(void)
+{
+    printf("ag_string_add() adds two Unicode strings...");
+
+    const ag_string_t *expect = "До свидания, луна?";
+    ag_string_smart_t *test = ag_string_new("До свидания");
+    ag_string_add(&test, ", ");
+    ag_string_add(&test, "луна");
+    ag_string_add(&test, "?");
+    ag_require (!strcmp(test, expect), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+                                       /* runs Unicode string tests [AgDM:??] */
+static void unicode_test(void)
+{
+    unicode_new();
+    unicode_copy();
+    unicode_len();
+    unicode_sz();
+    unicode_cmp_1();
+    unicode_cmp_2();
+    unicode_cmp_3();
+    unicode_cmp_4();
+    unicode_add();
+}
 
 
 /*******************************************************************************
  *                                  TEST SUITE
  */
-
-
 
                              /* implementation of string test suite [AgDM:??] */
 extern void ag_test_string(void)
@@ -263,6 +363,7 @@ extern void ag_test_string(void)
 
     empty_test();
     ascii_test();
+    unicode_test();
     
     printf("\n");
 }

--- a/test/string.c
+++ b/test/string.c
@@ -388,7 +388,18 @@ static void ascii_add_cstr(void)
     ag_string_add_cstr(&s1, "!");
     ag_require (!strcmp(s1, "Hello, world!"), AG_ERNO_TEST, NULL);
 
-    printf("OK\n");
+    printf("...OK\n");
+}
+
+                                  /* test case #18 for ASCII string [AgDM:??] */
+static void ascii_new_fmt(void)
+{
+    printf("ag_string_new_fmt() creates a formatted ASCII string");
+
+    ag_string_smart_t *s = ag_string_new_fmt("Hello, #%d %s", 1, "world!");
+    ag_require (!strcmp(s, "Hello, #1 world!"), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
 }
 
                                          /* runs ASCII string tests [AgDM:??] */
@@ -411,6 +422,7 @@ static void ascii_test(void)
     ascii_gt_1();
     ascii_gt_2();
     ascii_add_cstr();
+    ascii_new_fmt();
 }
 
 
@@ -643,6 +655,17 @@ static void unicode_add_cstr(void)
     printf("...OK\n");
 }
 
+                                /* test case #18 for Unicode string [AgDM:??] */
+static void unicode_new_fmt(void)
+{
+    printf("ag_string_new_fmt() creates a formatted Unicode string");
+
+    ag_string_smart_t *s = ag_string_new_fmt("Привет, #%d %s", 1, "мир!");
+    ag_require (!strcmp(s, "Привет, #1 мир!"), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
                                        /* runs Unicode string tests [AgDM:??] */
 static void unicode_test(void)
 {
@@ -663,6 +686,7 @@ static void unicode_test(void)
     unicode_gt_1();
     unicode_gt_2();
     unicode_add_cstr();
+    unicode_new_fmt();
 }
 
 

--- a/test/string.c
+++ b/test/string.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "../src/api.h"
 #include "./test.h"
 
@@ -84,11 +85,159 @@ static void empty_test_add(void)
 }
 
 
+                                         /* runs empty string tests [AgDM:??] */
+static void empty_test(void)
+{
+    empty_test_new();
+    empty_test_copy();
+    empty_test_len();
+    empty_test_sz();
+    empty_test_cmp();
+    empty_test_add();
+}
+
+
 
 
 /*******************************************************************************
  *                              ASCII STRING TESTS
  */
+
+
+                                   /* test case #1 for ASCII string [AgDM:??] */
+static void ascii_new(void)
+{
+    printf("ag_string_new() can create an ASCII string...");
+
+    const ag_string_t *expect = "Hello, world!";
+    ag_string_smart_t *test = ag_string_new(expect);
+    ag_require (test && !strcmp(test, expect), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+
+                                   /* test case #2 for ASCII string [AgDM:??] */
+static void ascii_copy(void)
+{
+    printf("ag_string_copy() can copy an ASCII string...");
+
+    const ag_string_t *expect = "Hello, world!";
+    ag_string_smart_t *test = ag_string_new(expect);
+    ag_string_smart_t *copy = ag_string_copy(test);
+    ag_require (test && !strcmp(copy, expect), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+
+                                   /* test case #3 for ASCII string [AgDM:??] */
+static void ascii_len(void)
+{
+    printf("ag_string_len() reports the length of an ASCII string...");
+
+    ag_string_smart_t *test = ag_string_new("Hello, world!");
+    ag_require (ag_string_len(test) == 13, AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+
+                                   /* test case #4 for ASCII string [AgDM:??] */
+static void ascii_sz(void)
+{
+    printf("ag_string_sz() reports the size of an ASCII string...");
+
+    const ag_string_t *sample = "Hello, world!";
+    ag_string_smart_t *test = ag_string_new(sample);
+    ag_require (ag_string_sz(test) == strlen(sample), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+
+                                   /* test case #5 for ASCII string [AgDM:??] */
+static void ascii_cmp_1(void)
+{
+    printf("ag_string_cmp() detects two equal ASCII strings...");
+
+    ag_string_smart_t *lhs = ag_string_new("Hello, world!");
+    ag_string_smart_t *rhs = ag_string_new("Hello, world!");
+    ag_require (!ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+
+                                   /* test case #6 for ASCII string [AgDM:??] */
+static void ascii_cmp_2(void)
+{
+    printf("ag_string_cmp() detects two unequal ASCII strings...");
+
+    ag_string_smart_t *lhs = ag_string_new("Hello, world!");
+    ag_string_smart_t *rhs = ag_string_new("Goodbye, moon?");
+    ag_require (ag_string_cmp(lhs, rhs), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+
+                                   /* test case #7 for ASCII string [AgDM:??] */
+static void ascii_cmp_3(void)
+{
+    printf("ag_string_cmp() detects a lexicographically smaller ASCII"
+            " string...");
+
+    ag_string_smart_t *lhs = ag_string_new("Goodbye, moon?");
+    ag_string_smart_t *rhs = ag_string_new("Hello, world!");
+    ag_require (ag_string_cmp(lhs, rhs) < 0, AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+
+                                   /* test case #8 for ASCII string [AgDM:??] */
+static void ascii_cmp_4(void)
+{
+    printf("ag_string_cmp() detects a lexicographically greater ASCII"
+            "string...");
+
+    ag_string_smart_t *lhs = ag_string_new("Goodbye, moon?");
+    ag_string_smart_t *rhs = ag_string_new("Hello, world!");
+    ag_require (ag_string_cmp(rhs, lhs) > 0, AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+
+                                   /* test case #9 for ASCII string [AgDM:??] */
+static void ascii_add(void)
+{
+    printf("ag_string_add() adds two ASCII strings...");
+
+    ag_string_smart_t *test = ag_string_new("Hello");
+    ag_string_add(&test, ", ");
+    ag_string_add(&test, "world");
+    ag_string_add(&test, "!");
+    ag_require (!strcmp(test, "Hello, world!"), AG_ERNO_TEST, NULL);
+
+    printf("OK\n");
+}
+
+
+                                         /* runs ASCII string tests [AgDM:??] */
+static void ascii_test(void)
+{
+    ascii_new();
+    ascii_copy();
+    ascii_len();
+    ascii_sz();
+    ascii_cmp_1();
+    ascii_cmp_2();
+    ascii_cmp_3();
+    ascii_cmp_4();
+    ascii_add();
+}
 
 
 
@@ -105,17 +254,6 @@ static void empty_test_add(void)
  */
 
 
-                                         /* runs empty string tests [AgDM:??] */
-static void test_empty(void)
-{
-    empty_test_new();
-    empty_test_copy();
-    empty_test_len();
-    empty_test_sz();
-    empty_test_cmp();
-    empty_test_add();
-}
-
 
                              /* implementation of string test suite [AgDM:??] */
 extern void ag_test_string(void)
@@ -123,7 +261,8 @@ extern void ag_test_string(void)
     printf("===============================================================\n");
     printf("Starting object model interface test suite...\n\n");
 
-    test_empty();
+    empty_test();
+    ascii_test();
     
     printf("\n");
 }

--- a/test/test.h
+++ b/test/test.h
@@ -4,6 +4,8 @@
 
 extern void ag_test_memblock(void);
 
+extern void ag_test_string(void);
+
 extern void ag_test_object(void);
 
 #endif /* !defined ARGENT_TESTS */


### PR DESCRIPTION
The `ag_string_t` type has been implemented as a reference counted character buffer with extra padding in the front containing metadata. The advantage of this approach is that `ag_string_t` can be passed to C functions expecting `char  *` values without any need for conversion. At the same time, having the reference count and size metadata padded in front of the string buffer skips out on needless copying and string length computations, thereby improving performance.

Associated with the `ag_string_t` type is the `ag_string_smart_t` type, which automatically releases the memory allocated to it once it goes out of scope. However, the `ag_string_smart_t` type is available only for GCC-compatible compilers.

The `ag_string_t` interface has been created with the following functions:
  * `ag_string_new()`
  * `ag_string_new_empty()`
  * `ag_string_new_fmt()`
  * `ag_string_copy()`
  * `ag_string_dispose()`
  * `ag_string_len()`
  * `ag_string_sz()`
  * `ag_string_cmp()`
  * `ag_string_lt()`
  * `ag_string_eq()`
  * `ag_string_gt()`
  * `ag_string_add()`
  * `ag_string_add_cstr()`

This pull request closes #6.