### PR TITLE
Issue/3/logging

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -120,16 +120,16 @@ enum ag_tristate {
  */
 
                                        /* logs an emergency message [AgDM:??] */
-extern void ag_log_emergency(const char *fmt, ...);
+extern void ag_log_emerg(const char *fmt, ...);
 
                                            /* logs an alert message [AgDM:??] */
 extern void ag_log_alert(const char *fmt, ...);
 
                                          /* logs a critical message [AgDM:??] */
-extern void ag_log_critical(const char *fmt, ...);
+extern void ag_log_crit(const char *fmt, ...);
 
                                            /* logs an error message [AgDM:??] */
-extern void ag_log_error(const char *fmt, ...);
+extern void ag_log_err(const char *fmt, ...);
 
                                           /* logs a warning message [AgDM:??] */
 extern void ag_log_warning(const char *fmt, ...);

--- a/src/api.h
+++ b/src/api.h
@@ -213,6 +213,8 @@ extern void ag_exception_handler_set(ag_exception_handler *eh);
         if (ag_unlikely (!(p))) {                              \
             printf("[!] assertion failed: %s [%s(), %s:%d]\n", \
                     #p, __func__, __FILE__, __LINE__);         \
+            ag_log_err("assertion failed: %s [%s(), %s:%d]\n", \
+                    #p, __func__, __FILE__, __LINE__);         \
             abort();                                           \
         }                                                      \
     } while (0)

--- a/src/api.h
+++ b/src/api.h
@@ -119,14 +119,28 @@ enum ag_tristate {
  *                                   LOGGING
  */
 
-
+                                       /* logs an emergency message [AgDM:??] */
 extern void ag_log_emergency(const char *fmt, ...);
+
+                                           /* logs an alert message [AgDM:??] */
 extern void ag_log_alert(const char *fmt, ...);
+
+                                         /* logs a critical message [AgDM:??] */
 extern void ag_log_critical(const char *fmt, ...);
+
+                                           /* logs an error message [AgDM:??] */
 extern void ag_log_error(const char *fmt, ...);
+
+                                          /* logs a warning message [AgDM:??] */
 extern void ag_log_warning(const char *fmt, ...);
+
+                                           /* logs a notice message [AgDM:??] */
 extern void ag_log_notice(const char *fmt, ...);
+
+                                      /* logs an information message [AgDM:??] */
 extern void ag_log_info(const char *fmt, ...);
+
+                                            /* logs a debug message [AgDM:??] */
 extern void ag_log_debug(const char *fmt, ...);
 
 

--- a/src/api.h
+++ b/src/api.h
@@ -115,6 +115,19 @@ enum ag_tristate {
 };
 
 
+/*******************************************************************************
+ *                                   LOGGING
+ */
+
+
+extern void ag_log_emergency(const char *fmt, ...);
+extern void ag_log_alert(const char *fmt, ...);
+extern void ag_log_critical(const char *fmt, ...);
+extern void ag_log_error(const char *fmt, ...);
+extern void ag_log_warning(const char *fmt, ...);
+extern void ag_log_notice(const char *fmt, ...);
+extern void ag_log_info(const char *fmt, ...);
+extern void ag_log_debug(const char *fmt, ...);
 
 
 /*******************************************************************************

--- a/src/exception.c
+++ b/src/exception.c
@@ -114,7 +114,10 @@ extern void ag_exception_handler_set(ag_exception_handler *eh)
 static void eh_default(const struct ag_exception *ex, void *opt)
 {
     (void) opt;
+
     printf("[!] unhandled exception: 0x%x [%s(), %s:%lu]\n%s\n", ex->erno, 
+            ex->func, ex->file, ex->line, ag_exception_message(ex->erno));
+    ag_log_err("unhandled exception: 0x%x [%s(), %s:%lu]\n%s\n", ex->erno, 
             ex->func, ex->file, ex->line, ag_exception_message(ex->erno));
 
     exit(EXIT_FAILURE);

--- a/src/log.c
+++ b/src/log.c
@@ -4,10 +4,10 @@
 
 
 /*******************************************************************************
- *                              LOGGING EXTERNALS
+ *                              LOGGING INTERNALS
  */
 
-
+                                         /* writes a syslog message [AgDM:??] */
 static inline void log_write(int pr, const char *fmt, va_list ap)
 {
     openlog(NULL, LOG_CONS | LOG_PID | LOG_NDELAY, LOG_USER);
@@ -20,7 +20,7 @@ static inline void log_write(int pr, const char *fmt, va_list ap)
  *                              LOGGING EXTERNALS
  */
 
-
+                                /* implementation of ag_log_emerg() [AgDM:??] */
 extern void ag_log_emergency(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
@@ -31,7 +31,7 @@ extern void ag_log_emergency(const char *fmt, ...)
     va_end(ap);
 }
 
-
+                                /* implementation of ag_log_alert() [AgDM:??] */
 extern void ag_log_alert(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
@@ -42,7 +42,7 @@ extern void ag_log_alert(const char *fmt, ...)
     va_end(ap);
 }
 
-
+                                 /* implementation of ag_log_crit() [AgDM:??] */
 extern void ag_log_critical(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
@@ -53,7 +53,7 @@ extern void ag_log_critical(const char *fmt, ...)
     va_end(ap);
 }
 
-
+                                  /* implementation of ag_log_err() [AgDM:??] */
 extern void ag_log_error(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
@@ -64,7 +64,7 @@ extern void ag_log_error(const char *fmt, ...)
     va_end(ap);
 }
 
-
+                              /* implementation of ag_log_warning() [AgDM:??] */
 extern void ag_log_warning(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
@@ -75,7 +75,7 @@ extern void ag_log_warning(const char *fmt, ...)
     va_end(ap);
 }
 
-
+                               /* implementation of ag_log_notice() [AgDM:??] */
 extern void ag_log_notice(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
@@ -86,7 +86,7 @@ extern void ag_log_notice(const char *fmt, ...)
     va_end(ap);
 }
 
-
+                                 /* implementation of ag_log_info() [AgDM:??] */
 extern void ag_log_info(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
@@ -97,7 +97,7 @@ extern void ag_log_info(const char *fmt, ...)
     va_end(ap);
 }
 
-
+                                /* implementation of ag_log_debug() [AgDM:??] */
 extern void ag_log_debug(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);

--- a/src/log.c
+++ b/src/log.c
@@ -21,7 +21,7 @@ static inline void log_write(int pr, const char *fmt, va_list ap)
  */
 
                                 /* implementation of ag_log_emerg() [AgDM:??] */
-extern void ag_log_emergency(const char *fmt, ...)
+extern void ag_log_emerg(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
     va_list ap;
@@ -43,7 +43,7 @@ extern void ag_log_alert(const char *fmt, ...)
 }
 
                                  /* implementation of ag_log_crit() [AgDM:??] */
-extern void ag_log_critical(const char *fmt, ...)
+extern void ag_log_crit(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
     va_list ap;
@@ -54,7 +54,7 @@ extern void ag_log_critical(const char *fmt, ...)
 }
 
                                   /* implementation of ag_log_err() [AgDM:??] */
-extern void ag_log_error(const char *fmt, ...)
+extern void ag_log_err(const char *fmt, ...)
 {
     ag_assert (fmt && *fmt);
     va_list ap;

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,110 @@
+#include <syslog.h>
+#include <stdarg.h>
+#include "./api.h"
+
+
+/*******************************************************************************
+ *                              LOGGING EXTERNALS
+ */
+
+
+static inline void log_write(int pr, const char *fmt, va_list ap)
+{
+    openlog(NULL, LOG_CONS | LOG_PID | LOG_NDELAY, LOG_USER);
+    vsyslog(pr, fmt, ap);
+    closelog();
+}
+
+
+/*******************************************************************************
+ *                              LOGGING EXTERNALS
+ */
+
+
+extern void ag_log_emergency(const char *fmt, ...)
+{
+    ag_assert (fmt && *fmt);
+    va_list ap;
+    va_start(ap, fmt);
+
+    log_write(LOG_EMERG, fmt, ap);
+    va_end(ap);
+}
+
+
+extern void ag_log_alert(const char *fmt, ...)
+{
+    ag_assert (fmt && *fmt);
+    va_list ap;
+    va_start(ap, fmt);
+
+    log_write(LOG_ALERT, fmt, ap);
+    va_end(ap);
+}
+
+
+extern void ag_log_critical(const char *fmt, ...)
+{
+    ag_assert (fmt && *fmt);
+    va_list ap;
+    va_start(ap, fmt);
+
+    log_write(LOG_CRIT, fmt, ap);
+    va_end(ap);
+}
+
+
+extern void ag_log_error(const char *fmt, ...)
+{
+    ag_assert (fmt && *fmt);
+    va_list ap;
+    va_start(ap, fmt);
+
+    log_write(LOG_ERR, fmt, ap);
+    va_end(ap);
+}
+
+
+extern void ag_log_warning(const char *fmt, ...)
+{
+    ag_assert (fmt && *fmt);
+    va_list ap;
+    va_start(ap, fmt);
+
+    log_write(LOG_WARNING, fmt, ap);
+    va_end(ap);
+}
+
+
+extern void ag_log_notice(const char *fmt, ...)
+{
+    ag_assert (fmt && *fmt);
+    va_list ap;
+    va_start(ap, fmt);
+
+    log_write(LOG_NOTICE, fmt, ap);
+    va_end(ap);
+}
+
+
+extern void ag_log_info(const char *fmt, ...)
+{
+    ag_assert (fmt && *fmt);
+    va_list ap;
+    va_start(ap, fmt);
+
+    log_write(LOG_INFO, fmt, ap);
+    va_end(ap);
+}
+
+
+extern void ag_log_debug(const char *fmt, ...)
+{
+    ag_assert (fmt && *fmt);
+    va_list ap;
+    va_start(ap, fmt);
+
+    log_write(LOG_DEBUG, fmt, ap);
+    va_end(ap);
+}
+

--- a/test/log.c
+++ b/test/log.c
@@ -6,6 +6,7 @@
  *                                  TEST CASES
  */
 
+                                    /* test case for ag_log_emerg() [AgDM:??] */
 static void emergency_test(void)
 {
     printf("ag_log_emergency() logs an emergency message");
@@ -18,6 +19,7 @@ static void emergency_test(void)
     printf("...OK\n");
 }
 
+                                    /* test case for ag_log_alert() [AgDM:??] */
 static void alert_test(void)
 {
     printf("ag_log_alert() logs an alert message");
@@ -30,6 +32,7 @@ static void alert_test(void)
     printf("...OK\n");
 }
 
+                                     /* test case for ag_log_crit() [AgDM:??] */
 static void critical_test(void)
 {
     printf("ag_log_critical() logs a critical message");
@@ -42,6 +45,7 @@ static void critical_test(void)
     printf("...OK\n");
 }
 
+                                      /* test case for ag_log_err() [AgDM:??] */
 static void error_test(void)
 {
     printf("ag_log_error() logs an error message");
@@ -54,6 +58,7 @@ static void error_test(void)
     printf("...OK\n");
 }
 
+                                  /* test case for ag_log_warning() [AgDM:??] */
 static void warning_test(void)
 {
     printf("ag_log_warning() logs a warning message");
@@ -66,6 +71,7 @@ static void warning_test(void)
     printf("...OK\n");
 }
 
+                                   /* test case for ag_log_notice() [AgDM:??] */
 static void notice_test(void)
 {
     printf("ag_log_notice() logs a notice message");
@@ -78,6 +84,7 @@ static void notice_test(void)
     printf("...OK\n");
 }
 
+                                     /* test case for ag_log_info() [AgDM:??] */
 static void info_test(void)
 {
     printf("ag_log_info() logs an information message");
@@ -90,6 +97,7 @@ static void info_test(void)
     printf("...OK\n");
 }
 
+                                    /* test case for ag_log_debug() [AgDM:??] */
 static void debug_test(void)
 {
     printf("ag_log_debug() logs a debug message");
@@ -108,7 +116,7 @@ static void debug_test(void)
  *                                  TEST SUITE
  */
 
-                             /* implementation of string test suite [AgDM:??] */
+                            /* implementation of logging test suite [AgDM:??] */
 extern void ag_test_log(void)
 {
     printf("===============================================================\n");

--- a/test/log.c
+++ b/test/log.c
@@ -7,10 +7,10 @@
  */
 
                                     /* test case for ag_log_emerg() [AgDM:??] */
-static void emergency_test(void)
+static void emerg_test(void)
 {
-    printf("ag_log_emergency() logs an emergency message");
-    ag_log_emergency("Testing ag_log_emergency()...");
+    printf("ag_log_emerg() logs an emergency message");
+    ag_log_emerg("Testing ag_log_emerg()...");
     
     char *cmd = "journaltcl -t ag-tests -p \"emerg\" -S \"5 sec ago\""
             " | grep \"No entries\"";
@@ -33,10 +33,10 @@ static void alert_test(void)
 }
 
                                      /* test case for ag_log_crit() [AgDM:??] */
-static void critical_test(void)
+static void crit_test(void)
 {
-    printf("ag_log_critical() logs a critical message");
-    ag_log_critical("Testing ag_log_critical()...");
+    printf("ag_log_crit() logs a critical message");
+    ag_log_crit("Testing ag_log_crit()...");
     
     char *cmd = "journaltcl -t ag-tests -p \"crit\" -S \"5 sec ago\""
             " | grep \"No entries\"";
@@ -46,10 +46,10 @@ static void critical_test(void)
 }
 
                                       /* test case for ag_log_err() [AgDM:??] */
-static void error_test(void)
+static void err_test(void)
 {
-    printf("ag_log_error() logs an error message");
-    ag_log_error("Testing ag_log_error()...");
+    printf("ag_log_err() logs an error message");
+    ag_log_err("Testing ag_log_err()...");
     
     char *cmd = "journaltcl -t ag-tests -p \"err\" -S \"5 sec ago\""
             " | grep \"No entries\"";
@@ -122,10 +122,10 @@ extern void ag_test_log(void)
     printf("===============================================================\n");
     printf("Starting logging interface test suite...\n\n");
 
-    emergency_test();
+    emerg_test();
     alert_test();
-    critical_test();
-    error_test();
+    crit_test();
+    err_test();
     warning_test();
     notice_test();
     info_test();

--- a/test/log.c
+++ b/test/log.c
@@ -1,0 +1,128 @@
+#include "../src/api.h"
+#include "./test.h"
+
+
+/*******************************************************************************
+ *                                  TEST CASES
+ */
+
+static void emergency_test(void)
+{
+    printf("ag_log_emergency() logs an emergency message");
+    ag_log_emergency("Testing ag_log_emergency()...");
+    
+    char *cmd = "journaltcl -t ag-tests -p \"emerg\" -S \"5 sec ago\""
+            " | grep \"No entries\"";
+    ag_require (system(cmd), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+static void alert_test(void)
+{
+    printf("ag_log_alert() logs an alert message");
+    ag_log_alert("Testing ag_log_alert()...");
+    
+    char *cmd = "journaltcl -t ag-tests -p \"alert\" -S \"5 sec ago\""
+            " | grep \"No entries\"";
+    ag_require (system(cmd), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+static void critical_test(void)
+{
+    printf("ag_log_critical() logs a critical message");
+    ag_log_critical("Testing ag_log_critical()...");
+    
+    char *cmd = "journaltcl -t ag-tests -p \"crit\" -S \"5 sec ago\""
+            " | grep \"No entries\"";
+    ag_require (system(cmd), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+static void error_test(void)
+{
+    printf("ag_log_error() logs an error message");
+    ag_log_error("Testing ag_log_error()...");
+    
+    char *cmd = "journaltcl -t ag-tests -p \"err\" -S \"5 sec ago\""
+            " | grep \"No entries\"";
+    ag_require (system(cmd), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+static void warning_test(void)
+{
+    printf("ag_log_warning() logs a warning message");
+    ag_log_warning("Testing ag_log_warning()...");
+    
+    char *cmd = "journaltcl -t ag-tests -p \"warning\" -S \"5 sec ago\""
+            " | grep \"No entries\"";
+    ag_require (system(cmd), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+static void notice_test(void)
+{
+    printf("ag_log_notice() logs a notice message");
+    ag_log_notice("Testing ag_log_notice()...");
+
+    char *cmd = "journaltcl -t ag-tests -p \"notice\" -S \"5 sec ago\""
+            " | grep \"No entries\"";
+    ag_require (system(cmd), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+static void info_test(void)
+{
+    printf("ag_log_info() logs an information message");
+    ag_log_info("Testing ag_log_info()...");
+    
+    char *cmd = "journaltcl -t ag-tests -p \"info\" -S \"5 sec ago\""
+            " | grep \"No entries\"";
+    ag_require (system(cmd), AG_ERNO_TEST, NULL);
+
+    printf("...OK\n");
+}
+
+static void debug_test(void)
+{
+    printf("ag_log_debug() logs a debug message");
+    ag_log_debug("Testing ag_log_debug()...");
+
+    char *cmd = "journaltcl -t ag-tests -p \"debug\" -S \"5 sec ago\""
+            " | grep \"No entries\"";
+    ag_require (system(cmd), AG_ERNO_TEST, NULL);
+
+
+    printf("...OK\n");
+}
+
+
+/*******************************************************************************
+ *                                  TEST SUITE
+ */
+
+                             /* implementation of string test suite [AgDM:??] */
+extern void ag_test_log(void)
+{
+    printf("===============================================================\n");
+    printf("Starting logging interface test suite...\n\n");
+
+    emergency_test();
+    alert_test();
+    critical_test();
+    error_test();
+    warning_test();
+    notice_test();
+    info_test();
+    debug_test();
+    
+    printf("\n");
+}
+

--- a/test/runner.c
+++ b/test/runner.c
@@ -9,6 +9,7 @@ int main(int argc, char **argv)
     ag_test_memblock();
     ag_test_string();
     ag_test_object();
+    ag_test_log();
 
     return 0;
 }

--- a/test/test.h
+++ b/test/test.h
@@ -8,5 +8,7 @@ extern void ag_test_string(void);
 
 extern void ag_test_object(void);
 
+extern void ag_test_log(void);
+
 #endif /* !defined ARGENT_TESTS */
 


### PR DESCRIPTION
The logging interface has been implemented with the following functions:
  * `ag_log_emerg()`
  * `ag_log_alert()`
  * `ag_log_crit()`
  * `ag_log_err()`
  * `ag_log_warning()`
  * `ag_log_notice()`
  * `ag_log_info()`
  * `ag_log_debug()`

The logging interface is compatible with `syslog`, and the functions have been named to reflect the standard `syslog` priority naming convention. Since `systemd` is becoming increasingly prevalent, the test cases have been written assuming that the `systemd-journald.service` is running.

This pull request closes #3.