### PR TITLE
Rewrite string interface with new memory block interface

### DIFF
--- a/include/argent.h
+++ b/include/argent.h
@@ -29,6 +29,7 @@
 #include "./erno.h"
 #include "./exception.h"
 #include "./mblock.h"
+#include "./str.h"
 #include "./test.h"
 #include "./manager.h"
 

--- a/include/exception.h
+++ b/include/exception.h
@@ -31,6 +31,7 @@
 #include "./argent.h"
 
 #include <stddef.h>
+#include <stdlib.h>
 
 
 /*

--- a/include/exception.h
+++ b/include/exception.h
@@ -20,6 +20,7 @@
  * You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
  */
 
+
 #ifndef __ARGENT_EXCEPTION_H__
 #define __ARGENT_EXCEPTION_H__
 

--- a/include/mblock.h
+++ b/include/mblock.h
@@ -23,13 +23,15 @@ struct ag_mblock_exception {
 extern void ag_mblock_exception_handler(const struct ag_exception *, void *);
 
 typedef void ag_mblock;
-#define ag_mblock_auto __attribute__((cleanup(ag_mblock_dispose))) ag_mblock
+#define ag_mblock_auto __attribute__((cleanup(ag_mblock_release))) ag_mblock
 
 extern ag_mblock *ag_mblock_new(size_t);
 extern ag_mblock *ag_mblock_new_align(size_t, size_t);
 extern ag_mblock *ag_mblock_copy(const ag_mblock *);
 extern ag_mblock *ag_mblock_copy_align(const ag_mblock *, size_t);
 extern void ag_mblock_dispose(ag_mblock **);
+extern void ag_mblock_retain(ag_mblock *);
+extern void ag_mblock_release(ag_mblock **);
 
 // warning: don't use with structs containing non-scalar members
 // if not equal, comparison based on first differing byte
@@ -55,8 +57,6 @@ extern size_t ag_mblock_sz_total(const ag_mblock *);
 extern size_t ag_mblock_refc(const ag_mblock *);
 extern bool ag_mblock_aligned(const ag_mblock *, size_t);
 
-extern ag_mblock *ag_mblock_retain(ag_mblock *);
-extern void ag_mblock_release(ag_mblock *);
 extern void ag_mblock_resize(ag_mblock **, size_t);
 extern void ag_mblock_resize_align(ag_mblock **, size_t, size_t);
 extern char *ag_mblock_str(const ag_mblock *);

--- a/include/mblock.h
+++ b/include/mblock.h
@@ -23,7 +23,6 @@ struct ag_mblock_exception {
 extern void ag_mblock_exception_handler(const struct ag_exception *, void *);
 
 typedef void ag_mblock;
-#define ag_mblock_auto __attribute__((cleanup(ag_mblock_release))) ag_mblock
 
 extern ag_mblock *ag_mblock_new(size_t);
 extern ag_mblock *ag_mblock_new_align(size_t, size_t);

--- a/include/mblock.h
+++ b/include/mblock.h
@@ -56,6 +56,8 @@ extern size_t ag_mblock_sz_total(const ag_mblock *);
 extern size_t ag_mblock_refc(const ag_mblock *);
 extern bool ag_mblock_aligned(const ag_mblock *, size_t);
 
+extern void ag_mblock_retain(ag_mblock *);
+extern void ag_mblock_release(ag_mblock *);
 extern void ag_mblock_resize(ag_mblock **, size_t);
 extern void ag_mblock_resize_align(ag_mblock **, size_t, size_t);
 extern char *ag_mblock_str(const ag_mblock *);

--- a/include/mblock.h
+++ b/include/mblock.h
@@ -23,14 +23,14 @@ struct ag_mblock_exception {
 extern void ag_mblock_exception_handler(const struct ag_exception *, void *);
 
 typedef void ag_mblock;
-#define ag_mblock_auto __attribute__((cleanup(ag_mblock_free))) ag_mblock
+#define ag_mblock_auto __attribute__((cleanup(ag_mblock_dispose))) ag_mblock
 
 extern ag_mblock *ag_mblock_new(size_t);
 extern ag_mblock *ag_mblock_new_align(size_t, size_t);
 extern ag_mblock *ag_mblock_copy(const ag_mblock *);
 extern ag_mblock *ag_mblock_copy_deep(const ag_mblock *);
 extern ag_mblock *ag_mblock_copy_deep_align(const ag_mblock *, size_t);
-extern void ag_mblock_free(ag_mblock **);
+extern void ag_mblock_dispose(ag_mblock **);
 
 // warning: don't use with structs containing non-scalar members
 // if not equal, comparison based on first differing byte

--- a/include/mblock.h
+++ b/include/mblock.h
@@ -28,8 +28,7 @@ typedef void ag_mblock;
 extern ag_mblock *ag_mblock_new(size_t);
 extern ag_mblock *ag_mblock_new_align(size_t, size_t);
 extern ag_mblock *ag_mblock_copy(const ag_mblock *);
-extern ag_mblock *ag_mblock_copy_deep(const ag_mblock *);
-extern ag_mblock *ag_mblock_copy_deep_align(const ag_mblock *, size_t);
+extern ag_mblock *ag_mblock_copy_align(const ag_mblock *, size_t);
 extern void ag_mblock_dispose(ag_mblock **);
 
 // warning: don't use with structs containing non-scalar members
@@ -56,7 +55,7 @@ extern size_t ag_mblock_sz_total(const ag_mblock *);
 extern size_t ag_mblock_refc(const ag_mblock *);
 extern bool ag_mblock_aligned(const ag_mblock *, size_t);
 
-extern void ag_mblock_retain(ag_mblock *);
+extern ag_mblock *ag_mblock_retain(ag_mblock *);
 extern void ag_mblock_release(ag_mblock *);
 extern void ag_mblock_resize(ag_mblock **, size_t);
 extern void ag_mblock_resize_align(ag_mblock **, size_t, size_t);

--- a/include/primitives.h
+++ b/include/primitives.h
@@ -58,6 +58,14 @@
 #endif
 
 
+#if (defined __GNUC__ || defined __clang__)
+#       define AG_AUTO(t) __attribute__((cleanup(t##_release))) t
+#else
+#       define AG_AUTO(t) t
+#       warning "[!] AG_AUTO() not supported on current compiler"
+#endif
+
+
 enum ag_cmp {
         AG_CMP_LT = -1,
         AG_CMP_EQ,

--- a/include/str.h
+++ b/include/str.h
@@ -42,16 +42,16 @@ typedef char ag_str;
 #endif
 
 
+
 extern ag_str *ag_str_new(const char *);
+extern ag_str *ag_str_new_fmt(const char *, ...);
+extern ag_str *ag_str_copy(const ag_str *);
+extern void ag_str_release(ag_str **);
 
 inline ag_str *ag_str_new_empty(void)
 {
     return ag_str_new("");
 }
-
-extern ag_str *ag_str_new_fmt(const char *fmt, ...);
-extern ag_str *ag_str_copy(const ag_str *);
-extern void ag_str_release(ag_str **);
 
 
 extern enum ag_cmp ag_str_cmp(const ag_str *,  const char *);

--- a/include/str.h
+++ b/include/str.h
@@ -42,7 +42,7 @@ typedef char ag_str;
 #endif
 
 
-extern ag_str *ag_str_new(const char *cstr);
+extern ag_str *ag_str_new(const char *);
 
 inline ag_str *ag_str_new_empty(void)
 {
@@ -50,8 +50,8 @@ inline ag_str *ag_str_new_empty(void)
 }
 
 extern ag_str *ag_str_new_fmt(const char *fmt, ...);
-extern ag_str *ag_str_copy(const ag_str *ctx);
-extern void ag_str_dispose(ag_str **ctx);
+extern ag_str *ag_str_copy(const ag_str *);
+extern void ag_str_release(ag_str **);
 
 
 extern enum ag_cmp ag_str_cmp(const char *,  const char *);
@@ -72,11 +72,16 @@ inline bool ag_str_gt(const char *ctx, const char *cmp)
 }
 
 
-extern bool ag_str_empty(const ag_str *);
-extern bool ag_str_has(const ag_str *, const char *);
 extern size_t ag_str_len(const ag_str *);
 extern size_t ag_str_sz(const ag_str *);
 extern size_t ag_str_refc(const ag_str *);
+extern bool ag_str_has(const ag_str *, const char *);
+
+inline bool ag_str_empty(const ag_str *ctx)
+{
+        return ag_str_sz(ctx) == 1;
+}
+
 
 
 extern ag_str *ag_str_lower(const char *);

--- a/include/str.h
+++ b/include/str.h
@@ -1,0 +1,94 @@
+/*-
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Argent - infrastructure for building web services
+ * Copyright (C) 2020 Abhishek Chakravarti
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTIBILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
+ */
+
+
+#ifndef __ARGENT_STR_H__
+#define __ARGENT_STR_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#include "./argent.h"
+
+
+typedef char ag_str;
+
+#if (defined __GNUC__ || defined __clang__)
+#       define ag_str_auto __attribute__((cleanup(ag_str_release))) ag_str
+#else
+#       define ag_str_auto ag_str
+#       warning "[!] ag_str_auto leaks memory on current compiler"
+#endif
+
+
+extern ag_str *ag_str_new(const char *cstr);
+
+inline ag_str *ag_str_new_empty(void)
+{
+    return ag_str_new("");
+}
+
+extern ag_str *ag_str_new_fmt(const char *fmt, ...);
+extern ag_str *ag_str_copy(const ag_str *ctx);
+extern void ag_str_dispose(ag_str **ctx);
+
+
+extern enum ag_cmp ag_str_cmp(const char *,  const char *);
+
+inline bool ag_str_lt(const char *ctx, const char *cmp)
+{
+    return ag_str_cmp(ctx, cmp) == AG_CMP_LT;
+}
+
+inline bool ag_str_eq(const char *ctx, const char *cmp)
+{
+    return ag_str_cmp(ctx, cmp) == AG_CMP_EQ;
+}
+
+inline bool ag_str_gt(const char *ctx, const char *cmp)
+{
+    return ag_str_cmp(ctx, cmp) == AG_CMP_GT;
+}
+
+
+extern bool ag_str_empty(const ag_str *);
+extern bool ag_str_has(const ag_str *, const char *);
+extern size_t ag_str_len(const ag_str *);
+extern size_t ag_str_sz(const ag_str *);
+extern size_t ag_str_refc(const ag_str *);
+
+
+extern ag_str *ag_str_lower(const char *);
+extern ag_str *ag_str_upper(const char *);
+extern ag_str *ag_str_proper(const char *);
+extern ag_str *ag_str_split(const char *, const char *);
+extern ag_str *ag_str_split_right(const char *, const char *);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !__ARGENT_STR_H__ */
+

--- a/include/str.h
+++ b/include/str.h
@@ -34,14 +34,6 @@ extern "C" {
 
 typedef char ag_str;
 
-#if (defined __GNUC__ || defined __clang__)
-#       define ag_str_auto __attribute__((cleanup(ag_str_release))) ag_str
-#else
-#       define ag_str_auto ag_str
-#       warning "[!] ag_str_auto leaks memory on current compiler"
-#endif
-
-
 
 extern ag_str *ag_str_new(const char *);
 extern ag_str *ag_str_new_fmt(const char *, ...);

--- a/include/str.h
+++ b/include/str.h
@@ -54,19 +54,19 @@ extern ag_str *ag_str_copy(const ag_str *);
 extern void ag_str_release(ag_str **);
 
 
-extern enum ag_cmp ag_str_cmp(const char *,  const char *);
+extern enum ag_cmp ag_str_cmp(const ag_str *,  const char *);
 
-inline bool ag_str_lt(const char *ctx, const char *cmp)
+inline bool ag_str_lt(const ag_str *ctx, const char *cmp)
 {
     return ag_str_cmp(ctx, cmp) == AG_CMP_LT;
 }
 
-inline bool ag_str_eq(const char *ctx, const char *cmp)
+inline bool ag_str_eq(const ag_str *ctx, const char *cmp)
 {
     return ag_str_cmp(ctx, cmp) == AG_CMP_EQ;
 }
 
-inline bool ag_str_gt(const char *ctx, const char *cmp)
+inline bool ag_str_gt(const ag_str *ctx, const char *cmp)
 {
     return ag_str_cmp(ctx, cmp) == AG_CMP_GT;
 }
@@ -84,11 +84,11 @@ inline bool ag_str_empty(const ag_str *ctx)
 
 
 
-extern ag_str *ag_str_lower(const char *);
-extern ag_str *ag_str_upper(const char *);
-extern ag_str *ag_str_proper(const char *);
-extern ag_str *ag_str_split(const char *, const char *);
-extern ag_str *ag_str_split_right(const char *, const char *);
+extern ag_str *ag_str_lower(const ag_str *);
+extern ag_str *ag_str_upper(const ag_str *);
+extern ag_str *ag_str_proper(const ag_str *);
+extern ag_str *ag_str_split(const ag_str *, const char *);
+extern ag_str *ag_str_split_right(const ag_str *, const char *);
 
 
 #ifdef __cplusplus

--- a/include/test.h
+++ b/include/test.h
@@ -116,7 +116,7 @@ extern void ag_test_suite_push(ag_test_suite *, ag_test *, const char *);
 extern void ag_test_suite_push_array(ag_test_suite *, ag_test *[],
                 const char *[], size_t);
 extern void ag_test_suite_exec(ag_test_suite *);
-extern void ag_test_suite_log(ag_test_suite *, FILE *);
+extern void ag_test_suite_log(const ag_test_suite *, FILE *);
 
 /*-
  * Interface: Test Harness

--- a/include/test.h
+++ b/include/test.h
@@ -127,7 +127,7 @@ typedef struct ag_test_harness ag_test_harness;
 
 extern ag_test_harness *ag_test_harness_new(void);
 extern ag_test_harness *ag_test_harness_copy(const ag_test_harness *);
-extern void ag_test_harness_free(ag_test_harness **);
+extern void ag_test_harness_release(ag_test_harness **);
 
 extern int ag_test_harness_len(const ag_test_harness *);
 extern size_t ag_test_harness_poll(const ag_test_harness *,

--- a/include/test.h
+++ b/include/test.h
@@ -107,7 +107,7 @@ typedef struct ag_test_suite ag_test_suite;
 
 extern ag_test_suite *ag_test_suite_new(const char *);
 extern ag_test_suite *ag_test_suite_copy(const ag_test_suite *);
-extern void ag_test_suite_free(ag_test_suite **);
+extern void ag_test_suite_release(ag_test_suite **);
 
 extern size_t ag_test_suite_len(const ag_test_suite *);
 extern size_t ag_test_suite_poll(const ag_test_suite *, enum ag_test_status);

--- a/src/mblock.c
+++ b/src/mblock.c
@@ -160,7 +160,7 @@ extern ag_mblock *ag_mblock_copy_deep_align(const ag_mblock *ctx, size_t align)
 }
 
 
-extern void ag_mblock_free(ag_mblock **ctx)
+extern void ag_mblock_dispose(ag_mblock **ctx)
 {
         ag_mblock *hnd;
 
@@ -248,7 +248,7 @@ extern void ag_mblock_resize(ag_mblock **ctx, size_t sz)
         ag_mblock *cp = ag_mblock_new(sz);
         memcpy(cp, hnd, sz < oldsz ? sz : oldsz);
         
-        ag_mblock_free(ctx);
+        ag_mblock_dispose(ctx);
         *ctx = cp;
 }
 
@@ -265,7 +265,7 @@ extern void ag_mblock_resize_align(ag_mblock **ctx, size_t sz, size_t align)
         ag_mblock *cp = ag_mblock_new_align(sz, align);
         memcpy(cp, hnd, sz < oldsz ? sz : oldsz);
         
-        ag_mblock_free(ctx);
+        ag_mblock_dispose(ctx);
         *ctx = cp;
 }
 

--- a/src/mblock.c
+++ b/src/mblock.c
@@ -165,10 +165,10 @@ extern void ag_mblock_release(ag_mblock **ctx)
         size_t *hnd;
 
         if (AG_LIKELY (ctx && (hnd = (size_t *)*ctx))) {
-                if (!(--hnd[-2])) {
+                if (!(--hnd[-2]))
                         free(&hnd[-2]);
-                        *ctx = NULL;
-                }
+                        
+                *ctx = NULL;
         }
 }
 

--- a/src/mblock.c
+++ b/src/mblock.c
@@ -154,14 +154,22 @@ extern void ag_mblock_dispose(ag_mblock **ctx)
         ag_mblock *hnd;
 
         if (AG_LIKELY (ctx && (hnd = *ctx))) {
-                ag_mblock_release(hnd);
+                free(meta_head(hnd));
+                *ctx = NULL;
+        }
 
-                if (!meta_refc(hnd)) {
-                        free(meta_head(hnd));
+}
+
+extern void ag_mblock_release(ag_mblock **ctx)
+{
+        size_t *hnd;
+
+        if (AG_LIKELY (ctx && (hnd = (size_t *)*ctx))) {
+                if (!(--hnd[-2])) {
+                        free(&hnd[-2]);
                         *ctx = NULL;
                 }
         }
-
 }
 
 extern enum ag_cmp ag_mblock_cmp(const ag_mblock *ctx, const ag_mblock *cmp)
@@ -210,21 +218,14 @@ extern bool ag_mblock_aligned(const ag_mblock *ctx, size_t align)
 }
 
 
-extern ag_mblock *ag_mblock_retain(ag_mblock *ctx)
+extern void ag_mblock_retain(ag_mblock *ctx)
 {
         AG_ASSERT (is_pointer_valid(ctx));
         
         ((size_t *) ctx)[-2]++;
-        return ctx;
 }
 
 
-extern void ag_mblock_release(ag_mblock *ctx)
-{
-        AG_ASSERT (is_pointer_valid(ctx));
-        
-        ((size_t *) ctx)[-2]--;
-}
 
 
 extern void ag_mblock_resize(ag_mblock **ctx, size_t sz)

--- a/src/mblock.c
+++ b/src/mblock.c
@@ -225,6 +225,22 @@ extern bool ag_mblock_aligned(const ag_mblock *ctx, size_t align)
 }
 
 
+extern void ag_mblock_retain(ag_mblock *ctx)
+{
+        AG_ASSERT (ctx);
+        
+        ((size_t *) ctx)[-2]++;
+}
+
+
+extern void ag_mblock_release(ag_mblock *ctx)
+{
+        AG_ASSERT (ctx);
+        
+        ((size_t *) ctx)[-2]--;
+}
+
+
 extern void ag_mblock_resize(ag_mblock **ctx, size_t sz)
 {
         AG_ASSERT (ctx && *ctx);

--- a/src/mblock.c
+++ b/src/mblock.c
@@ -128,17 +128,6 @@ extern ag_mblock *ag_mblock_copy(const ag_mblock *ctx)
 {
         AG_ASSERT (is_pointer_valid(ctx));
 
-        size_t *hnd = (ag_mblock *)ctx;
-        ag_mblock_retain(hnd);
-
-        return hnd;
-}
-
-
-extern ag_mblock *ag_mblock_copy_deep(const ag_mblock *ctx)
-{
-        AG_ASSERT (ctx);
-
         size_t sz = meta_sz(ctx);
         ag_mblock *cp = ag_mblock_new(sz);
         memcpy(cp, ctx, sz);
@@ -147,7 +136,7 @@ extern ag_mblock *ag_mblock_copy_deep(const ag_mblock *ctx)
 }
 
 
-extern ag_mblock *ag_mblock_copy_deep_align(const ag_mblock *ctx, size_t align)
+extern ag_mblock *ag_mblock_copy_align(const ag_mblock *ctx, size_t align)
 {
         AG_ASSERT (is_pointer_valid(ctx));
         AG_ASSERT (is_alignment_valid(align));
@@ -221,11 +210,12 @@ extern bool ag_mblock_aligned(const ag_mblock *ctx, size_t align)
 }
 
 
-extern void ag_mblock_retain(ag_mblock *ctx)
+extern ag_mblock *ag_mblock_retain(ag_mblock *ctx)
 {
         AG_ASSERT (is_pointer_valid(ctx));
         
         ((size_t *) ctx)[-2]++;
+        return ctx;
 }
 
 

--- a/src/mblock.c
+++ b/src/mblock.c
@@ -7,6 +7,14 @@
 #include <string.h>
 
 
+#ifndef NDEBUG
+        static inline bool is_pointer_valid(const ag_mblock *);
+        static inline bool is_handle_valid(ag_mblock **);
+        static inline bool is_size_valid(size_t );
+        static inline bool is_alignment_valid(size_t);
+#endif
+
+
 /*
  * str_new_fmt(): create new dynamic formatted string.
  *
@@ -49,18 +57,6 @@ static inline size_t meta_refc(const ag_mblock *ctx)
 }
 
 
-static inline void meta_refc_retain(ag_mblock *ctx)
-{
-        ((size_t *)ctx)[-2]++;
-}
-
-
-static inline void meta_refc_release(ag_mblock *ctx)
-{
-        ((size_t *)ctx)[-2]--;
-}
-
-
 extern void ag_mblock_exception_handler(const struct ag_exception *ex,
                 void *opt)
 {
@@ -88,7 +84,7 @@ extern void ag_mblock_exception_handler(const struct ag_exception *ex,
 
 extern ag_mblock *ag_mblock_new(size_t sz)
 {
-        AG_ASSERT (sz);
+        AG_ASSERT (is_size_valid(sz));
 
         struct ag_mblock_exception x = {
                 .sz = sz,
@@ -108,8 +104,8 @@ extern ag_mblock *ag_mblock_new(size_t sz)
 
 extern ag_mblock *ag_mblock_new_align(size_t sz, size_t align)
 {
-        AG_ASSERT (sz);
-        AG_ASSERT (align && !(align % 2));
+        AG_ASSERT (is_size_valid(sz));
+        AG_ASSERT (is_alignment_valid(align));
         
         struct ag_mblock_exception x = {
                 .sz = sz,
@@ -124,16 +120,16 @@ extern ag_mblock *ag_mblock_new_align(size_t sz, size_t align)
         ctx[0] = 1;
         ctx[1] = sz;
 
-        return (ag_mblock *) &(ctx[2]);
+        return (ag_mblock *)&(ctx[2]);
 }
 
 
 extern ag_mblock *ag_mblock_copy(const ag_mblock *ctx)
 {
-        AG_ASSERT (ctx);
+        AG_ASSERT (is_pointer_valid(ctx));
 
         size_t *hnd = (ag_mblock *)ctx;
-        meta_refc_retain(hnd);
+        ag_mblock_retain(hnd);
 
         return hnd;
 }
@@ -153,8 +149,8 @@ extern ag_mblock *ag_mblock_copy_deep(const ag_mblock *ctx)
 
 extern ag_mblock *ag_mblock_copy_deep_align(const ag_mblock *ctx, size_t align)
 {
-        AG_ASSERT (ctx);
-        AG_ASSERT (align && !(align % 2));
+        AG_ASSERT (is_pointer_valid(ctx));
+        AG_ASSERT (is_alignment_valid(align));
 
         size_t sz = meta_sz(ctx);
         ag_mblock *cp = ag_mblock_new_align(sz, align);
@@ -169,7 +165,7 @@ extern void ag_mblock_free(ag_mblock **ctx)
         ag_mblock *hnd;
 
         if (AG_LIKELY (ctx && (hnd = *ctx))) {
-                meta_refc_release(hnd);
+                ag_mblock_release(hnd);
 
                 if (!meta_refc(hnd)) {
                         free(meta_head(hnd));
@@ -193,14 +189,14 @@ extern inline bool ag_mblock_gt(const ag_mblock *, const ag_mblock *);
 
 extern size_t ag_mblock_sz(const ag_mblock *ctx)
 {
-        AG_ASSERT (ctx);
+        AG_ASSERT (is_pointer_valid(ctx));
 
         return meta_sz(ctx);
 }
 
 extern size_t ag_mblock_sz_total(const ag_mblock *ctx)
 {
-        AG_ASSERT (ctx);
+        AG_ASSERT (is_pointer_valid(ctx));
 
         return malloc_usable_size(meta_head(ctx));
 }
@@ -210,7 +206,7 @@ extern size_t ag_mblock_sz_total(const ag_mblock *ctx)
 
 extern size_t ag_mblock_refc(const ag_mblock *ctx)
 {
-        AG_ASSERT (ctx);
+        AG_ASSERT (is_pointer_valid(ctx));
 
         return meta_refc(ctx);
 }
@@ -218,8 +214,8 @@ extern size_t ag_mblock_refc(const ag_mblock *ctx)
 
 extern bool ag_mblock_aligned(const ag_mblock *ctx, size_t align)
 {
-        AG_ASSERT (ctx);
-        AG_ASSERT (align && !(align % 2));
+        AG_ASSERT (is_pointer_valid(ctx));
+        AG_ASSERT (is_alignment_valid(align));
 
         return !((uintptr_t)meta_head(ctx) & (align - 1));
 }
@@ -227,7 +223,7 @@ extern bool ag_mblock_aligned(const ag_mblock *ctx, size_t align)
 
 extern void ag_mblock_retain(ag_mblock *ctx)
 {
-        AG_ASSERT (ctx);
+        AG_ASSERT (is_pointer_valid(ctx));
         
         ((size_t *) ctx)[-2]++;
 }
@@ -235,7 +231,7 @@ extern void ag_mblock_retain(ag_mblock *ctx)
 
 extern void ag_mblock_release(ag_mblock *ctx)
 {
-        AG_ASSERT (ctx);
+        AG_ASSERT (is_pointer_valid(ctx));
         
         ((size_t *) ctx)[-2]--;
 }
@@ -243,8 +239,8 @@ extern void ag_mblock_release(ag_mblock *ctx)
 
 extern void ag_mblock_resize(ag_mblock **ctx, size_t sz)
 {
-        AG_ASSERT (ctx && *ctx);
-        AG_ASSERT (sz);
+        AG_ASSERT (is_handle_valid(ctx));
+        AG_ASSERT (is_size_valid(sz));
 
         ag_mblock *hnd = *ctx;
         size_t oldsz = meta_sz(hnd);
@@ -259,9 +255,9 @@ extern void ag_mblock_resize(ag_mblock **ctx, size_t sz)
 
 extern void ag_mblock_resize_align(ag_mblock **ctx, size_t sz, size_t align)
 {
-        AG_ASSERT (ctx && *ctx);
-        AG_ASSERT (sz);
-        AG_ASSERT (align && !(align % 2));
+        AG_ASSERT (is_handle_valid(ctx));
+        AG_ASSERT (is_size_valid(sz));
+        AG_ASSERT (is_alignment_valid(align));
 
         ag_mblock *hnd = *ctx;
         size_t oldsz = meta_sz(hnd);
@@ -276,11 +272,43 @@ extern void ag_mblock_resize_align(ag_mblock **ctx, size_t sz, size_t align)
 
 extern char *ag_mblock_str(const ag_mblock *ctx)
 {
-        AG_ASSERT (ctx);
+        AG_ASSERT (is_pointer_valid(ctx));
 
         return str_new_fmt("address = %p, data sz = %lu, total data = %lu,"
                         " refc = %lu", (void *)meta_head(ctx), meta_sz(ctx),
                         ag_mblock_sz_total(ctx), meta_refc(ctx));
 
 }
+
+#ifndef NDEBUG
+static inline bool is_pointer_valid(const ag_mblock *ctx)
+{
+        return ctx;
+}
+#endif
+
+
+#ifndef NDEBUG
+static inline bool is_handle_valid(ag_mblock **ctx)
+{
+        return ctx && *ctx;
+}
+#endif
+
+
+#ifndef NDEBUG
+static inline bool is_size_valid(size_t sz)
+{
+        return sz;
+}
+#endif
+
+
+#ifndef NDEBUG
+static inline bool is_alignment_valid(size_t align)
+{
+        return align && !(align % 2);
+
+}
+#endif
 

--- a/src/str.c
+++ b/src/str.c
@@ -1,0 +1,215 @@
+#include "../include/argent.h"
+
+#include <ctype.h>
+#include <string.h>
+#include <stdarg.h>
+
+
+#ifndef NDEBUG
+static inline bool is_string_valid(const char *);
+static inline bool is_string_not_empty(const char *);
+#endif
+
+
+extern inline ag_str *ag_str_new_empty(void);
+extern inline bool ag_str_lt(const char *, const char *);
+extern inline bool ag_str_eq(const char *, const char *);
+extern inline bool ag_str_gt(const char *, const char *);
+extern inline bool ag_str_empty(const ag_str *);
+
+
+extern ag_str *ag_str_new(const char *src)
+{
+        AG_ASSERT (is_string_valid(src));
+
+        size_t sz = strlen(src);
+        char *s = ag_mblock_new(sz + 1);
+
+        strncpy(s, src, sz);
+        s[sz] = '\0';
+        return s;
+}
+
+
+
+extern ag_str *ag_str_new_fmt(const char *fmt, ...)
+{
+        AG_ASSERT (is_string_not_empty(fmt));
+
+        va_list args;
+        va_start(args, fmt);
+        char *bfr = ag_mblock_new(vsnprintf(NULL, 0, fmt, args));
+        va_end(args);
+
+        va_start(args, fmt);
+        (void)vsprintf(bfr, fmt, args);
+        va_end(args);
+
+        char *s = ag_str_new(bfr);
+        ag_mblock_release((ag_mblock **)&bfr);
+        return s;
+}
+
+
+extern ag_str *ag_str_copy(const ag_str *ctx)
+{
+        AG_ASSERT (is_string_valid(ctx));
+
+        ag_str *cp = (ag_str *)ctx;
+        ag_mblock_retain(cp);
+        return cp;
+}
+
+
+extern void ag_str_release(ag_str **ctx)
+{
+        ag_mblock_release((ag_mblock **)ctx);
+}
+
+
+extern enum ag_cmp ag_str_cmp(const char *ctx,  const char *cmp)
+{
+        AG_ASSERT (is_string_valid(ctx));
+        AG_ASSERT (is_string_valid(cmp));
+
+        return strcmp(ctx, cmp);
+}
+
+
+extern bool ag_str_has(const ag_str *ctx, const char *tgt)
+{
+        AG_ASSERT (is_string_valid(ctx));
+        AG_ASSERT (is_string_not_empty(tgt));
+
+        return strstr(ctx, tgt);
+}
+
+
+extern size_t ag_str_len(const ag_str *ctx)
+{
+        AG_ASSERT (is_string_valid(ctx));
+
+        register size_t i = 0, len = 0;
+
+        while (ctx[i]) {
+                if ((ctx[i] & 0xC0) != 0x80)
+                        len++;
+                
+                i++;
+        }
+
+        return len;
+}
+
+
+extern size_t ag_str_sz(const ag_str *ctx)
+{
+        AG_ASSERT (is_string_valid(ctx));
+
+        return ag_mblock_sz(ctx);
+}
+
+
+
+extern size_t ag_str_refc(const ag_str *ctx)
+{
+        AG_ASSERT (is_string_valid(ctx));
+
+        return ag_mblock_refc(ctx);
+}
+
+
+extern ag_str *ag_str_lower(const char *ctx)
+{
+        AG_ASSERT (is_string_valid(ctx));
+
+        ag_str *s = ag_str_new(ctx);
+        register char *c = s;
+
+        while (*c) {
+                *c = tolower(*c);
+                c++;
+        }
+
+        return s;
+}
+
+
+
+extern ag_str *ag_str_upper(const char *ctx)
+{
+        AG_ASSERT (is_string_valid(ctx));
+        
+        ag_str *s = ag_str_new(ctx);
+        register char *c = s;
+
+        while (*c) {
+                *c = toupper(*c);
+                c++;
+        }
+
+        return s;
+}
+
+
+extern ag_str *ag_str_proper(const char *ctx)
+{
+        AG_ASSERT (is_string_valid(ctx));
+        
+        ag_str *s = ag_str_new(ctx);
+        register size_t sz = ag_mblock_sz(s);
+
+        for (register size_t i = 0; i < sz; i++) {
+                s[i] = (!i || s[i - 1] == ' ' || s[i - 1] == '.')
+                        ? toupper(s[i]) : tolower(s[i]);
+        }
+
+        return s;
+}
+
+
+extern ag_str *ag_str_split(const char *ctx, const char *pvt)
+{
+        AG_ASSERT (is_string_valid(ctx));
+        AG_ASSERT (is_string_not_empty(pvt));
+
+        if (AG_UNLIKELY (!(*ctx && strstr(ctx, pvt))))
+                return ag_str_new_empty();
+
+        char *save;
+        ag_str_auto *s = ag_str_new(ctx);
+        return ag_str_new(strtok_r(s, pvt, &save));
+}
+
+
+extern ag_str *ag_str_split_right(const char *ctx, const char *pvt)
+{
+        AG_ASSERT (is_string_valid(ctx));
+        AG_ASSERT (is_string_not_empty(pvt));
+
+        if (AG_UNLIKELY (!(*ctx && strstr(ctx, pvt))))
+                return ag_str_new_empty();
+
+        char *save;
+        ag_str_auto *s = ag_str_new(ctx);
+        (void)strtok_r(s, pvt, &save);
+        return ag_str_new(save);
+}
+
+        
+
+#ifndef NDEBUG
+static inline bool is_string_valid(const char *ctx)
+{
+        return ctx;
+}
+#endif
+        
+
+#ifndef NDEBUG
+static inline bool is_string_not_empty(const char *ctx)
+{
+        return ctx && *ctx;
+}
+#endif
+

--- a/src/str.c
+++ b/src/str.c
@@ -1,3 +1,26 @@
+/*-
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Argent - infrastructure for building web services
+ * Copyright (C) 2020 Abhishek Chakravarti
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTIBILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
+ */
+
+
 #include "../include/argent.h"
 
 #include <ctype.h>
@@ -5,12 +28,19 @@
 #include <stdarg.h>
 
 
+/*
+ * The following macros are helpers for the assertion checks. We use these
+ * macros to improve readability when debugging. is_string_valid() checks
+ * whether a given string is not a null pointer, and is_string_not_empty()
+ * checks whether a string is not null and not empty.
+ */
 #ifndef NDEBUG
 #       define is_string_valid(s) (s)
 #       define is_string_not_empty(s) (s && *s)
 #endif
 
 
+/* Declare the public inline functions of the string interface. */
 extern inline ag_str *ag_str_new_empty(void);
 extern inline bool ag_str_lt(const char *, const char *);
 extern inline bool ag_str_eq(const char *, const char *);
@@ -18,6 +48,10 @@ extern inline bool ag_str_gt(const char *, const char *);
 extern inline bool ag_str_empty(const ag_str *);
 
 
+/* 
+ * ag_str_new() creates a new instance of a dynamic string from a statically
+ * allocated string.
+ */
 extern ag_str *ag_str_new(const char *src)
 {
         AG_ASSERT (is_string_valid(src));
@@ -31,7 +65,10 @@ extern ag_str *ag_str_new(const char *src)
 }
 
 
-
+/*
+ * ag_str_new_fmt() creates a new instance of a dynamic string from a statically
+ * allocated format string with variable arguments a la printf().
+ */
 extern ag_str *ag_str_new_fmt(const char *fmt, ...)
 {
         AG_ASSERT (is_string_not_empty(fmt));
@@ -51,6 +88,7 @@ extern ag_str *ag_str_new_fmt(const char *fmt, ...)
 }
 
 
+/* ag_str_copy() creates a shallow copy of a dynamic string. */
 extern ag_str *ag_str_copy(const ag_str *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -61,12 +99,14 @@ extern ag_str *ag_str_copy(const ag_str *ctx)
 }
 
 
+/* ag_str_release() releases a dynamic string. */
 extern void ag_str_release(ag_str **ctx)
 {
         ag_mblock_release((ag_mblock **)ctx);
 }
 
 
+/* ag_str_cmp() compares two strings lexicographically. */
 extern enum ag_cmp ag_str_cmp(const char *ctx,  const char *cmp)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -76,6 +116,7 @@ extern enum ag_cmp ag_str_cmp(const char *ctx,  const char *cmp)
 }
 
 
+/* ag_str_has() checks whether a string contains a particular substring. */
 extern bool ag_str_has(const ag_str *ctx, const char *tgt)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -85,6 +126,10 @@ extern bool ag_str_has(const ag_str *ctx, const char *tgt)
 }
 
 
+/* 
+ * ag_str_len() determines the lexicographcical length of a string, taking into
+ * consideration that the string may contain non-ASCII UTF-8 characters.
+ */
 extern size_t ag_str_len(const ag_str *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -102,6 +147,11 @@ extern size_t ag_str_len(const ag_str *ctx)
 }
 
 
+/*
+ * ag_str_sz() gets the size in bytes of a dynamic string. Since dynamic strings
+ * are allocated through memory blocks, we can retrieve their size by querying
+ * ag_mblock_sz().
+ */
 extern size_t ag_str_sz(const ag_str *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -110,7 +160,10 @@ extern size_t ag_str_sz(const ag_str *ctx)
 }
 
 
-
+/*
+ * ag_str_refc() gets the reference count of a dynamic string. Again, as in the
+ * case of ag_str_sz(), we use the memory block interface to do so.
+ */
 extern size_t ag_str_refc(const ag_str *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -119,6 +172,10 @@ extern size_t ag_str_refc(const ag_str *ctx)
 }
 
 
+/*
+ * ag_str_lower() transforms a string to lowercase. Since we have chosen to keep
+ * strings as immutable, we return a new string instance after processing.
+ */
 extern ag_str *ag_str_lower(const char *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -135,7 +192,11 @@ extern ag_str *ag_str_lower(const char *ctx)
 }
 
 
-
+/*
+ * ag_str_upper() transforms a string to uppercase. As in the case of
+ * ag_str_lower(), we choose to return a new instance instead of modifying the
+ * original string.
+ */
 extern ag_str *ag_str_upper(const char *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -152,6 +213,16 @@ extern ag_str *ag_str_upper(const char *ctx)
 }
 
 
+/* 
+ * ag_str_proper() transforms a string to proper case. In proper case, we
+ * capitalise a character if:
+ *   - it is the first character,
+ *   - it is preceded by a space, or
+ *   - it is preceded by a period.
+ *
+ * As in the case of ag_str_lower() and ag_str_upper(), we choose to return a
+ * new string instance after processing.
+ */
 extern ag_str *ag_str_proper(const char *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -168,6 +239,11 @@ extern ag_str *ag_str_proper(const char *ctx)
 }
 
 
+/*
+ * ag_str_split() splits a string around a pivot, returning the left side of the
+ * pivot. In case the pivot isn't found, then an empty string is returned. We
+ * use the reentrant version of strtok() in order to be thread-safe.
+ */
 extern ag_str *ag_str_split(const char *ctx, const char *pvt)
 {
         AG_ASSERT (is_string_valid(ctx));
@@ -182,6 +258,11 @@ extern ag_str *ag_str_split(const char *ctx, const char *pvt)
 }
 
 
+/*
+ * ag_str_split_right() splits a string around a pivot and returns the substring
+ * on the right side of the pivot. As in the case of ag_str_split(), in case the
+ * pivot doesn't exist then an empty string is returned.
+ */
 extern ag_str *ag_str_split_right(const char *ctx, const char *pvt)
 {
         AG_ASSERT (is_string_valid(ctx));

--- a/src/str.c
+++ b/src/str.c
@@ -301,7 +301,7 @@ extern ag_str *ag_str_split(const ag_str *ctx, const char *pvt)
                 return ag_str_new_empty();
 
         char *save;
-        ag_str_auto *s = ag_str_new(ctx);
+        AG_AUTO(ag_str) *s = ag_str_new(ctx);
         return ag_str_new(strtok_r(s, pvt, &save));
 }
 
@@ -323,7 +323,7 @@ extern ag_str *ag_str_split_right(const ag_str *ctx, const char *pvt)
                 return ag_str_new_empty();
 
         char *save;
-        ag_str_auto *s = ag_str_new(ctx);
+        AG_AUTO(ag_str) *s = ag_str_new(ctx);
         (void)strtok_r(s, pvt, &save);
         return ag_str_new(save);
 }

--- a/src/str.c
+++ b/src/str.c
@@ -211,7 +211,11 @@ extern size_t ag_str_refc(const ag_str *ctx)
 
 /*
  * ag_str_lower() transforms a string to lowercase. Since we have chosen to keep
- * strings as immutable, we return a new string instance after processing. 
+ * strings as immutable, we return a new string instance after processing. Since
+ * we rely on tolower(), this function isn't guaranteed to work correctly with
+ * Unicode strings.
+ *
+ * TODO: make ag_str_lower() Unicode-safe.
  */
 extern ag_str *ag_str_lower(const ag_str *ctx)
 {
@@ -230,7 +234,10 @@ extern ag_str *ag_str_lower(const ag_str *ctx)
 /*
  * ag_str_upper() transforms a string to uppercase. As in the case of
  * ag_str_lower(), we choose to return a new instance instead of modifying the
- * original string.
+ * original string. Again, as in the case of ag_str_lower(), this function isn't
+ * guaranteed to be Unicode-safe.
+ *
+ * TODO: make ag_str_upper() Unicode-safe.
  */
 extern ag_str *ag_str_upper(const ag_str *ctx)
 {
@@ -254,7 +261,10 @@ extern ag_str *ag_str_upper(const ag_str *ctx)
  *   - it is preceded by a period.
  *
  * As in the case of ag_str_lower() and ag_str_upper(), we choose to return a
- * new string instance after processing.
+ * new string instance after processing. And like both these functions, this one
+ * isn't Unicode-safe.
+ *
+ * TODO: make ag_str_proper() Unicode-safe.
  */
 extern ag_str *ag_str_proper(const ag_str *ctx)
 {
@@ -275,7 +285,9 @@ extern ag_str *ag_str_proper(const ag_str *ctx)
 /*
  * ag_str_split() splits a string around a pivot, returning the left side of the
  * pivot. In case the pivot isn't found, then an empty string is returned. We
- * use the reentrant version of strtok() in order to be thread-safe.
+ * use the reentrant version of strtok() in order to be thread-safe. The caveat
+ * is that since strtok_r() doesn't seem to handle Unicode characters well.
+ * TODO: make ag_str_split() Unicode-safe.
  */
 extern ag_str *ag_str_split(const ag_str *ctx, const char *pvt)
 {
@@ -294,7 +306,10 @@ extern ag_str *ag_str_split(const ag_str *ctx, const char *pvt)
 /*
  * ag_str_split_right() splits a string around a pivot and returns the substring
  * on the right side of the pivot. As in the case of ag_str_split(), in case the
- * pivot doesn't exist then an empty string is returned.
+ * pivot doesn't exist then an empty string is returned. Again, since we're
+ * relying on strtok_r(), this function isn't Unicode-safe. 
+ *
+ * TODO: make ag_str_split_right() Unicode-safe.
  */
 extern ag_str *ag_str_split_right(const ag_str *ctx, const char *pvt)
 {

--- a/src/str.c
+++ b/src/str.c
@@ -42,9 +42,9 @@
 
 /* Declare the public inline functions of the string interface. */
 extern inline ag_str *ag_str_new_empty(void);
-extern inline bool ag_str_lt(const char *, const char *);
-extern inline bool ag_str_eq(const char *, const char *);
-extern inline bool ag_str_gt(const char *, const char *);
+extern inline bool ag_str_lt(const ag_str *, const char *);
+extern inline bool ag_str_eq(const ag_str *, const char *);
+extern inline bool ag_str_gt(const ag_str *, const char *);
 extern inline bool ag_str_empty(const ag_str *);
 
 
@@ -107,7 +107,7 @@ extern void ag_str_release(ag_str **ctx)
 
 
 /* ag_str_cmp() compares two strings lexicographically. */
-extern enum ag_cmp ag_str_cmp(const char *ctx,  const char *cmp)
+extern enum ag_cmp ag_str_cmp(const ag_str *ctx,  const char *cmp)
 {
         AG_ASSERT (is_string_valid(ctx));
         AG_ASSERT (is_string_valid(cmp));
@@ -174,19 +174,17 @@ extern size_t ag_str_refc(const ag_str *ctx)
 
 /*
  * ag_str_lower() transforms a string to lowercase. Since we have chosen to keep
- * strings as immutable, we return a new string instance after processing.
+ * strings as immutable, we return a new string instance after processing. 
  */
-extern ag_str *ag_str_lower(const char *ctx)
+extern ag_str *ag_str_lower(const ag_str *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
 
-        ag_str *s = ag_str_new(ctx);
-        register char *c = s;
+        ag_str *s = ag_mblock_copy(ctx);
+        register size_t sz = ag_mblock_sz(ctx);
 
-        while (*c) {
-                *c = tolower(*c);
-                c++;
-        }
+        for (register size_t i = 0; i < sz; i++)
+                s[i] = tolower(s[i]);
 
         return s;
 }
@@ -197,17 +195,15 @@ extern ag_str *ag_str_lower(const char *ctx)
  * ag_str_lower(), we choose to return a new instance instead of modifying the
  * original string.
  */
-extern ag_str *ag_str_upper(const char *ctx)
+extern ag_str *ag_str_upper(const ag_str *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
         
-        ag_str *s = ag_str_new(ctx);
-        register char *c = s;
+        ag_str *s = ag_mblock_copy(ctx);
+        register size_t sz = ag_mblock_sz(ctx);
 
-        while (*c) {
-                *c = toupper(*c);
-                c++;
-        }
+        for (register size_t i = 0; i < sz; i++)
+                s[i] = toupper(s[i]);
 
         return s;
 }
@@ -223,11 +219,11 @@ extern ag_str *ag_str_upper(const char *ctx)
  * As in the case of ag_str_lower() and ag_str_upper(), we choose to return a
  * new string instance after processing.
  */
-extern ag_str *ag_str_proper(const char *ctx)
+extern ag_str *ag_str_proper(const ag_str *ctx)
 {
         AG_ASSERT (is_string_valid(ctx));
         
-        ag_str *s = ag_str_new(ctx);
+        ag_str *s = ag_mblock_copy(ctx);
         register size_t sz = ag_mblock_sz(s);
 
         for (register size_t i = 0; i < sz; i++) {
@@ -244,7 +240,7 @@ extern ag_str *ag_str_proper(const char *ctx)
  * pivot. In case the pivot isn't found, then an empty string is returned. We
  * use the reentrant version of strtok() in order to be thread-safe.
  */
-extern ag_str *ag_str_split(const char *ctx, const char *pvt)
+extern ag_str *ag_str_split(const ag_str *ctx, const char *pvt)
 {
         AG_ASSERT (is_string_valid(ctx));
         AG_ASSERT (is_string_not_empty(pvt));
@@ -263,7 +259,7 @@ extern ag_str *ag_str_split(const char *ctx, const char *pvt)
  * on the right side of the pivot. As in the case of ag_str_split(), in case the
  * pivot doesn't exist then an empty string is returned.
  */
-extern ag_str *ag_str_split_right(const char *ctx, const char *pvt)
+extern ag_str *ag_str_split_right(const ag_str *ctx, const char *pvt)
 {
         AG_ASSERT (is_string_valid(ctx));
         AG_ASSERT (is_string_not_empty(pvt));

--- a/src/str.c
+++ b/src/str.c
@@ -157,7 +157,10 @@ extern enum ag_cmp ag_str_cmp(const ag_str *ctx,  const char *cmp)
 extern bool ag_str_has(const ag_str *ctx, const char *tgt)
 {
         AG_ASSERT (is_string_valid(ctx));
-        AG_ASSERT (is_string_not_empty(tgt));
+        AG_ASSERT (is_string_valid(tgt));
+
+        if (AG_UNLIKELY (!*tgt && *ctx))
+                return false;
 
         return strstr(ctx, tgt);
 }

--- a/src/str.c
+++ b/src/str.c
@@ -6,8 +6,8 @@
 
 
 #ifndef NDEBUG
-static inline bool is_string_valid(const char *);
-static inline bool is_string_not_empty(const char *);
+#       define is_string_valid(s) (s)
+#       define is_string_not_empty(s) (s && *s)
 #endif
 
 
@@ -195,21 +195,4 @@ extern ag_str *ag_str_split_right(const char *ctx, const char *pvt)
         (void)strtok_r(s, pvt, &save);
         return ag_str_new(save);
 }
-
-        
-
-#ifndef NDEBUG
-static inline bool is_string_valid(const char *ctx)
-{
-        return ctx;
-}
-#endif
-        
-
-#ifndef NDEBUG
-static inline bool is_string_not_empty(const char *ctx)
-{
-        return ctx && *ctx;
-}
-#endif
 

--- a/src/str.c
+++ b/src/str.c
@@ -101,10 +101,20 @@ extern ag_str *ag_str_copy(const ag_str *ctx)
 }
 
 
-/* ag_str_release() releases a dynamic string. */
+/* 
+ * ag_str_release() releases a dynamic string. We don't cast ctx to (void **)
+ * when calling ag_mblock_release() in order to avoid potential portability
+ * issues in case the size of pointers differ. See the C-FAQ List question 4.9
+ * at http://c-faq.com/ptrs/genericpp.html.
+ */
 extern void ag_str_release(ag_str **ctx)
 {
-        ag_mblock_release((ag_mblock **)ctx);
+        if (AG_LIKELY (ctx && *ctx)) {
+                ag_str *hnd = *ctx;
+                void *ptr = hnd;
+                ag_mblock_release(&ptr);
+                *ctx = ptr;
+        }
 }
 
 

--- a/src/str.c
+++ b/src/str.c
@@ -67,7 +67,9 @@ extern ag_str *ag_str_new(const char *src)
 
 /*
  * ag_str_new_fmt() creates a new instance of a dynamic string from a statically
- * allocated format string with variable arguments a la printf().
+ * allocated format string with variable arguments a la printf(). By passing
+ * NULL and 0 as the first two arguments to vsnprintf() we determine the size of
+ * the formatted string (excluding the terminating null character).
  */
 extern ag_str *ag_str_new_fmt(const char *fmt, ...)
 {
@@ -75,7 +77,7 @@ extern ag_str *ag_str_new_fmt(const char *fmt, ...)
 
         va_list args;
         va_start(args, fmt);
-        char *bfr = ag_mblock_new(vsnprintf(NULL, 0, fmt, args));
+        char *bfr = ag_mblock_new(vsnprintf(NULL, 0, fmt, args) + 1);
         va_end(args);
 
         va_start(args, fmt);

--- a/src/str.c
+++ b/src/str.c
@@ -118,13 +118,38 @@ extern void ag_str_release(ag_str **ctx)
 }
 
 
-/* ag_str_cmp() compares two strings lexicographically. */
+/* 
+ * ag_str_cmp() compares two strings lexicographically. We have adapted the code
+ * from the uf8cmp() function in Sheredom's UTF-8 header only library (see
+ * https://github.com/sheredom/utf8.h/blob/master/utf8.h). We could have simply
+ * used strcmp(), but there may be edge cases in Unicode strings which strcmp()
+ * doesn't handle.
+ */
 extern enum ag_cmp ag_str_cmp(const ag_str *ctx,  const char *cmp)
 {
         AG_ASSERT (is_string_valid(ctx));
         AG_ASSERT (is_string_valid(cmp));
 
-        return strcmp(ctx, cmp);
+        if (!*ctx && *cmp)
+                return AG_CMP_LT;
+
+        if (*ctx && !*cmp)
+                return AG_CMP_GT;
+
+        register const unsigned char *s1 = (const unsigned char *)ctx;
+        register const unsigned char *s2 = (const unsigned char *)cmp;
+
+        while (*s1 || *s2) {
+                if (*s1 < *s2)
+                        return AG_CMP_LT;
+                else if (*s1 > *s2)
+                        return AG_CMP_GT;
+
+                s1++;
+                s2++;
+        }
+
+        return AG_CMP_EQ;
 }
 
 

--- a/src/test-harness.c
+++ b/src/test-harness.c
@@ -298,7 +298,8 @@ extern void ag_test_harness_log(const ag_test_harness *ctx, FILE *log)
         }
 
         size_t pass = ag_test_harness_poll(ctx, AG_TEST_STATUS_OK);
-        size_t skip = ag_test_harness_poll(ctx, AG_TEST_STATUS_SKIP);
+        size_t skip = ag_test_harness_poll(ctx, AG_TEST_STATUS_SKIP)
+                        + ag_test_harness_poll(ctx, AG_TEST_STATUS_WAIT);
         size_t fail = ag_test_harness_poll(ctx, AG_TEST_STATUS_FAIL);
 
         char *s = str_new_fmt("%d test suite(s), %d test(s), %d passed,"

--- a/src/test-harness.c
+++ b/src/test-harness.c
@@ -101,41 +101,6 @@ static inline struct node *node_free(struct node *ctx)
 
 
 /*
- * str_new_fmt(): create new dynamic formatted string.
- *
- * @fmt: formatted static source string.
- * @...: format arguments.
- *
- * Return: new dynamic formatted string.
- */
-static char *str_new_fmt(const char *fmt, ...)
-{
-        va_list args;
-
-        va_start(args, fmt);
-        char *bfr = ag_mblock_new(vsnprintf(NULL, 0, fmt, args) + 1);
-        va_end(args);
-
-        va_start(args, fmt);
-        (void) vsprintf(bfr, fmt, args);
-        va_end(args);
-
-        return bfr;
-}
-
-
-/*
- * str_free(): release dynamic string.
- *
- * @ctx: contextual string.
- */
-static inline void str_free(char *ctx)
-{
-        ag_mblock_release((ag_mblock **)&ctx);
-}
-
-
-/*
  * struct ag_test_harness: internal structure of `ag_test_harness`.
  *
  * @head: head of test suite list.
@@ -291,7 +256,8 @@ extern void ag_test_harness_log(const ag_test_harness *ctx, FILE *log)
         AG_ASSERT (ctx);
         AG_ASSERT (log);
 
-        struct node *n = ctx->head;
+        register struct node *n = ctx->head;
+
         while (AG_LIKELY (n)) {
                 ag_test_suite_log(n->ts, log);
                 n = n->nxt;
@@ -302,10 +268,10 @@ extern void ag_test_harness_log(const ag_test_harness *ctx, FILE *log)
                         + ag_test_harness_poll(ctx, AG_TEST_STATUS_WAIT);
         size_t fail = ag_test_harness_poll(ctx, AG_TEST_STATUS_FAIL);
 
-        char *s = str_new_fmt("%d test suite(s), %d test(s), %d passed,"
-                       " %d skipped, %d failed.", ag_test_harness_len(ctx),
-                       pass + skip + fail, pass, skip, fail);
+        ag_str_auto *s = ag_str_new_fmt("%d test suite(s), %d test(s),"
+                        " %d passed, %d skipped, %d failed.",
+                        ag_test_harness_len(ctx), pass + skip + fail, 
+                        pass, skip, fail);
         fprintf(log, "\n%s\n", s);
-        str_free(s);
 }
 

--- a/src/test-harness.c
+++ b/src/test-harness.c
@@ -93,7 +93,7 @@ static inline struct node *node_free(struct node *ctx)
 {
         struct node *nxt = ctx->nxt;
 
-        ag_test_suite_free(&ctx->ts);
+        ag_test_suite_release(&ctx->ts);
         ag_mblock_release((ag_mblock **)&ctx);
 
         return nxt;

--- a/src/test-harness.c
+++ b/src/test-harness.c
@@ -170,15 +170,10 @@ extern ag_test_harness *ag_test_harness_copy(const ag_test_harness *ctx)
 {
         AG_ASSERT (ctx);
 
-        ag_test_harness *cp = ag_test_harness_new();
+        ag_test_harness *hnd = (ag_test_harness *)ctx;
+        ag_mblock_retain(hnd);
 
-        struct node *n = ctx->head;
-        while (AG_LIKELY (n)) {
-                ag_test_harness_push(cp, n->ts);
-                n = n->nxt;
-        }
-
-        return cp;
+        return hnd;
 }
 
 

--- a/src/test-harness.c
+++ b/src/test-harness.c
@@ -268,7 +268,7 @@ extern void ag_test_harness_log(const ag_test_harness *ctx, FILE *log)
                         + ag_test_harness_poll(ctx, AG_TEST_STATUS_WAIT);
         size_t fail = ag_test_harness_poll(ctx, AG_TEST_STATUS_FAIL);
 
-        ag_str_auto *s = ag_str_new_fmt("%d test suite(s), %d test(s),"
+        AG_AUTO(ag_str) *s = ag_str_new_fmt("%d test suite(s), %d test(s),"
                         " %d passed, %d skipped, %d failed.",
                         ag_test_harness_len(ctx), pass + skip + fail, 
                         pass, skip, fail);

--- a/src/test-harness.c
+++ b/src/test-harness.c
@@ -187,14 +187,15 @@ extern ag_test_harness *ag_test_harness_copy(const ag_test_harness *ctx)
  *
  * @ctx: contextual test suite.
  */
-extern void ag_test_harness_free(ag_test_harness **ctx)
+extern void ag_test_harness_release(ag_test_harness **ctx)
 {
         ag_test_harness *hnd;
 
         if (AG_LIKELY (ctx && (hnd = *ctx))) {
-                struct node *n = hnd->head;
-                while (AG_LIKELY (n)) {
-                        n = node_free(n);
+                if (ag_mblock_refc(hnd) == 1) {
+                        struct node *n = hnd->head;
+                        while (n)
+                                n = node_free(n);
                 }
 
                 ag_mblock_release((ag_mblock **)ctx);

--- a/src/test-harness.c
+++ b/src/test-harness.c
@@ -94,7 +94,7 @@ static inline struct node *node_free(struct node *ctx)
         struct node *nxt = ctx->nxt;
 
         ag_test_suite_free(&ctx->ts);
-        ag_mblock_free((ag_mblock **)&ctx);
+        ag_mblock_dispose((ag_mblock **)&ctx);
 
         return nxt;
 }
@@ -131,7 +131,7 @@ static char *str_new_fmt(const char *fmt, ...)
  */
 static inline void str_free(char *ctx)
 {
-        ag_mblock_free((ag_mblock **)&ctx);
+        ag_mblock_dispose((ag_mblock **)&ctx);
 }
 
 
@@ -197,7 +197,7 @@ extern void ag_test_harness_free(ag_test_harness **ctx)
                         n = node_free(n);
                 }
 
-                ag_mblock_free((ag_mblock **)ctx);
+                ag_mblock_dispose((ag_mblock **)ctx);
         }
 }
 

--- a/src/test-harness.c
+++ b/src/test-harness.c
@@ -94,7 +94,7 @@ static inline struct node *node_free(struct node *ctx)
         struct node *nxt = ctx->nxt;
 
         ag_test_suite_free(&ctx->ts);
-        ag_mblock_dispose((ag_mblock **)&ctx);
+        ag_mblock_release((ag_mblock **)&ctx);
 
         return nxt;
 }
@@ -131,7 +131,7 @@ static char *str_new_fmt(const char *fmt, ...)
  */
 static inline void str_free(char *ctx)
 {
-        ag_mblock_dispose((ag_mblock **)&ctx);
+        ag_mblock_release((ag_mblock **)&ctx);
 }
 
 
@@ -197,7 +197,7 @@ extern void ag_test_harness_free(ag_test_harness **ctx)
                         n = node_free(n);
                 }
 
-                ag_mblock_dispose((ag_mblock **)ctx);
+                ag_mblock_release((ag_mblock **)ctx);
         }
 }
 

--- a/src/test-suite.c
+++ b/src/test-suite.c
@@ -168,16 +168,18 @@ extern ag_test_suite *ag_test_suite_copy(const ag_test_suite *ctx)
 }
 
 
-extern void ag_test_suite_free(ag_test_suite **ctx)
+extern void ag_test_suite_release(ag_test_suite **ctx)
 {
         ag_test_suite *hnd;
 
         if (AG_LIKELY (ctx && (hnd = *ctx))) {
-                str_free(hnd->desc);
+                if (ag_mblock_refc(hnd) == 1) {
+                        str_free(hnd->desc);
 
-                struct node *n = hnd->head;
-                while (AG_LIKELY (n)) 
-                        n = node_free(n);
+                        struct node *n = hnd->head;
+                        while (n)
+                                n = node_free(n);
+                }
 
                 ag_mblock_release((ag_mblock **)ctx);
         }

--- a/src/test-suite.c
+++ b/src/test-suite.c
@@ -36,7 +36,7 @@ static char *str_new_fmt(const char *fmt, ...)
  */
 static inline void str_free(char *ctx)
 {
-        ag_mblock_free((ag_mblock **)&ctx);
+        ag_mblock_dispose((ag_mblock **)&ctx);
 }
 
 
@@ -65,7 +65,7 @@ static inline struct node *node_free(struct node *ctx)
         struct node *next = ctx->next;
 
         str_free(ctx->desc);
-        ag_mblock_free((ag_mblock **)&ctx);
+        ag_mblock_dispose((ag_mblock **)&ctx);
 
         return next;
 }
@@ -179,7 +179,7 @@ extern void ag_test_suite_free(ag_test_suite **ctx)
                 while (AG_LIKELY (n)) 
                         n = node_free(n);
 
-                ag_mblock_free((ag_mblock **)ctx);
+                ag_mblock_dispose((ag_mblock **)ctx);
         }
 }
 

--- a/src/test-suite.c
+++ b/src/test-suite.c
@@ -36,7 +36,7 @@ static char *str_new_fmt(const char *fmt, ...)
  */
 static inline void str_free(char *ctx)
 {
-        ag_mblock_dispose((ag_mblock **)&ctx);
+        ag_mblock_release((ag_mblock **)&ctx);
 }
 
 
@@ -65,7 +65,7 @@ static inline struct node *node_free(struct node *ctx)
         struct node *next = ctx->next;
 
         str_free(ctx->desc);
-        ag_mblock_dispose((ag_mblock **)&ctx);
+        ag_mblock_release((ag_mblock **)&ctx);
 
         return next;
 }
@@ -179,7 +179,7 @@ extern void ag_test_suite_free(ag_test_suite **ctx)
                 while (AG_LIKELY (n)) 
                         n = node_free(n);
 
-                ag_mblock_dispose((ag_mblock **)ctx);
+                ag_mblock_release((ag_mblock **)ctx);
         }
 }
 

--- a/src/test-suite.c
+++ b/src/test-suite.c
@@ -262,7 +262,7 @@ extern void ag_test_suite_exec(ag_test_suite *ctx)
 }
 
 
-extern void ag_test_suite_log(ag_test_suite *ctx, FILE *log)
+extern void ag_test_suite_log(const ag_test_suite *ctx, FILE *log)
 {
         AG_ASSERT (ctx);
         AG_ASSERT (log);

--- a/src/test-suite.c
+++ b/src/test-suite.c
@@ -89,7 +89,8 @@ static inline void log_footer(const ag_test_suite *ctx, FILE *log)
         fprintf(log, "\n\n%lu test(s), %lu passed, %lu skipped, %lu failed.\n",
                         ag_test_suite_len(ctx),
                         ag_test_suite_poll(ctx, AG_TEST_STATUS_OK),
-                        ag_test_suite_poll(ctx, AG_TEST_STATUS_SKIP),
+                        ag_test_suite_poll(ctx, AG_TEST_STATUS_SKIP)
+                        + ag_test_suite_poll(ctx, AG_TEST_STATUS_WAIT),
                         ag_test_suite_poll(ctx, AG_TEST_STATUS_FAIL));
 }
 
@@ -170,8 +171,8 @@ extern size_t ag_test_suite_poll(const ag_test_suite *ctx,
         AG_ASSERT (ctx);
 
         register size_t tot = 0;
-        
-        struct node *n = ctx->head;
+        register struct node *n = ctx->head;
+
         while (AG_LIKELY (n)) {
                 if ((n->status) == status)
                         tot++;

--- a/src/test-suite.c
+++ b/src/test-suite.c
@@ -40,27 +40,27 @@ static void node_log(const struct node *ctx, FILE *log)
 {
         switch (ctx->status) {
                 case AG_TEST_STATUS_OK:
-                        fprintf(log, "[OK]   %s", ctx->desc);
+                        fprintf(log, "[OK]   %s\n", ctx->desc);
                         break;
 
                 case AG_TEST_STATUS_WAIT:
-                        fprintf(log, "[WAIT] %s", ctx->desc);
+                        fprintf(log, "[WAIT] %s\n", ctx->desc);
                         break;
 
                 case AG_TEST_STATUS_SKIP:
-                        fprintf(log, "[SKIP] %s", ctx->desc);
+                        fprintf(log, "[SKIP] %s\n", ctx->desc);
                         break;
 
                 case AG_TEST_STATUS_SIGABRT:
-                        fprintf(log, "[FAIL] %s (SIGABRT)", ctx->desc);
+                        fprintf(log, "[FAIL] %s (SIGABRT)\n", ctx->desc);
                         break;
 
                 case AG_TEST_STATUS_SIGSEGV:
-                        fprintf(log, "[FAIL] %s (SIGSEGV)", ctx->desc);
+                        fprintf(log, "[FAIL] %s (SIGSEGV)\n", ctx->desc);
                         break;
 
                 default:
-                        fprintf(log, "[FAIL] %s", ctx->desc);
+                        fprintf(log, "[FAIL] %s\n", ctx->desc);
         }
 }
 
@@ -98,7 +98,7 @@ static void log_body(const ag_test_suite *ctx, FILE *log)
 
         struct node *n = ctx->head;
         while (AG_LIKELY (n)) {
-                fprintf(log, "\n%.2lu. ", ++i);
+                fprintf(log, "%.2lu. ", ++i);
                 node_log(n, log);
                 n = n->next;
         }
@@ -220,8 +220,10 @@ extern void ag_test_suite_exec(ag_test_suite *ctx)
         struct node *n = ctx->head;
         while (AG_LIKELY (n)) {
                 n->status = n->test();
+
                 if (AG_UNLIKELY (n->status != AG_TEST_STATUS_OK))
                         node_log(n, stdout);
+
                 n = n->next;
         }
 }

--- a/src/test-suite.c
+++ b/src/test-suite.c
@@ -79,6 +79,8 @@ static void log_header(const ag_test_suite *ctx, FILE *log)
 
         for (register size_t i = 0; i < strlen(ctx->desc) + 12; i++)
                 fputs("=", log);
+
+        fputs("\n", log);
 }
 
 

--- a/src/test-suite.c
+++ b/src/test-suite.c
@@ -156,15 +156,10 @@ extern ag_test_suite *ag_test_suite_copy(const ag_test_suite *ctx)
 {
         AG_ASSERT (ctx);
 
-        ag_test_suite *cp = ag_test_suite_new(ctx->desc);
+        ag_test_suite *hnd = (ag_test_suite *)ctx;
+        ag_mblock_retain(hnd);
 
-        struct node *n = ctx->head;
-        while (AG_LIKELY (n)) {
-                ag_test_suite_push(cp, n->test, n->desc);
-                n = n->next;
-        }
-
-        return cp;
+        return hnd;
 }
 
 

--- a/test/mblock.c
+++ b/test/mblock.c
@@ -31,9 +31,9 @@ AG_TEST_INIT(new_02, "ag_mblock_new() allocates memory on the heap for"
 
         AG_TEST_ASSERT (t && t->i && t->j);
         
-        ag_mblock_dispose((ag_mblock **)&t->i);
-        ag_mblock_dispose((ag_mblock **)&t->j);
-        ag_mblock_dispose((ag_mblock **)&t);
+        ag_mblock_release((ag_mblock **)&t->i);
+        ag_mblock_release((ag_mblock **)&t->j);
+        ag_mblock_release((ag_mblock **)&t);
 
 }
 AG_TEST_EXIT();
@@ -84,9 +84,9 @@ AG_TEST_INIT(new_align_02, "ag_mblock_new_align() allocates memory on the heap"
 
         AG_TEST_ASSERT (t && t->i && t->j);
         
-        ag_mblock_dispose((ag_mblock **)&t->i);
-        ag_mblock_dispose((ag_mblock **)&t->j);
-        ag_mblock_dispose((ag_mblock **)&t);
+        ag_mblock_release((ag_mblock **)&t->i);
+        ag_mblock_release((ag_mblock **)&t->j);
+        ag_mblock_release((ag_mblock **)&t);
 }
 AG_TEST_EXIT();
 
@@ -136,8 +136,8 @@ AG_TEST_INIT(copy_01, "ag_mblock_copy() makes a deep copy of an int in the"
         int *j = ag_mblock_copy(i);
         AG_TEST_ASSERT (*j == 555);
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -154,10 +154,10 @@ AG_TEST_INIT(copy_02, "ag_mblock_copy() makes a deep copy of a test structure"
         struct test *cp = ag_mblock_copy(t);
         AG_TEST_ASSERT (*cp->i == *t->i && *cp->j == *t->j);
 
-        ag_mblock_dispose((ag_mblock **)&t->i);
-        ag_mblock_dispose((ag_mblock **)&t->j);
-        ag_mblock_dispose((ag_mblock **)&t);
-        ag_mblock_dispose((ag_mblock **)&cp);
+        ag_mblock_release((ag_mblock **)&t->i);
+        ag_mblock_release((ag_mblock **)&t->j);
+        ag_mblock_release((ag_mblock **)&t);
+        ag_mblock_release((ag_mblock **)&cp);
 }
 AG_TEST_EXIT();
 
@@ -220,8 +220,8 @@ AG_TEST_INIT(copy_align_01, "ag_mblock_copy_align() makes a deep copy of an int"
         int *j = ag_mblock_copy_align(i, 8);
         AG_TEST_ASSERT (*j == 555);
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -239,10 +239,10 @@ AG_TEST_INIT(copy_align_02, "ag_mblock_copy_align() makes a deep copy of a test"
         struct test *cp = ag_mblock_copy_align(t, 8);
         AG_TEST_ASSERT (*cp->i == *t->i && *cp->j == *t->j);
 
-        ag_mblock_dispose((ag_mblock **)&t->i);
-        ag_mblock_dispose((ag_mblock **)&t->j);
-        ag_mblock_dispose((ag_mblock **)&t);
-        ag_mblock_dispose((ag_mblock **)&cp);
+        ag_mblock_release((ag_mblock **)&t->i);
+        ag_mblock_release((ag_mblock **)&t->j);
+        ag_mblock_release((ag_mblock **)&t);
+        ag_mblock_release((ag_mblock **)&cp);
 }
 AG_TEST_EXIT();
 
@@ -261,7 +261,8 @@ AG_TEST_INIT(copy_align_04, "ag_mblock_copy_align() sets the reference count of"
                 " the copy to 1")
 {
         ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_retain(src);
+        ag_mblock_retain(src);
+        ag_mblock_auto *cp = src;
         ag_mblock_auto *cp2 = ag_mblock_copy_align(cp, 8);
         
         AG_TEST_ASSERT (ag_mblock_refc(cp2) == 1);
@@ -272,7 +273,8 @@ AG_TEST_INIT(copy_align_05, "ag_mblock_copy_align() does not change the"
                 " reference count of the source")
 {
         ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_retain(src);
+        ag_mblock_retain(src);
+        ag_mblock_auto *cp = src;
         ag_mblock_auto *cp2 = ag_mblock_copy_align(cp, 8);
         
         AG_TEST_ASSERT (ag_mblock_refc(src) == 2 && ag_mblock_refc(cp) == 2);
@@ -313,62 +315,64 @@ AG_TEST_INIT(copy_align_08, "ag_mblock_copy_align() honours its alignment"
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(dispose_01, "ag_mblock_dispose() performs a no-op if passed NULL")
+AG_TEST_INIT(release_01, "ag_mblock_release() performs a no-op if passed NULL")
 {
-        ag_mblock_dispose(NULL);
+        ag_mblock_release(NULL);
         AG_TEST_ASSERT (true);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(dispose_02, "ag_mblock_dispose() performs a no-op if passed a"
+AG_TEST_INIT(release_02, "ag_mblock_release() performs a no-op if passed a"
                 " handle to a null pointer")
 {
         ag_mblock *m = NULL;
-        ag_mblock_dispose((ag_mblock **) &m);
+        ag_mblock_release((ag_mblock **) &m);
         AG_TEST_ASSERT (true);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(dispose_03, "ag_mblock_dispose() release an int on the heap")
+AG_TEST_INIT(release_03, "ag_mblock_release() release an int on the heap")
 {
         int *i = ag_mblock_new(sizeof *i);
-        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&i);
         AG_TEST_ASSERT (!i);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(dispose_04, "ag_mblock_dispose() releases a test struct on the"
+AG_TEST_INIT(release_04, "ag_mblock_release() releases a test struct on the"
                 " heap")
 {
         struct test *t = ag_mblock_new(sizeof *t);
-        ag_mblock_dispose((ag_mblock **)&t);
+        ag_mblock_release((ag_mblock **)&t);
         AG_TEST_ASSERT (!t);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(dispose_05, "ag_mblock_dispose() reduces the reference count by 1"
+AG_TEST_INIT(release_05, "ag_mblock_release() reduces the reference count by 1"
                 "for lazy copies")
 {
         int *i = ag_mblock_new(sizeof *i);
-        ag_mblock_auto *j = ag_mblock_retain(i);
-        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_retain(i);
+        ag_mblock_auto *j = i;
+        ag_mblock_release((ag_mblock **)&i);
 
         AG_TEST_ASSERT (ag_mblock_refc(j) == 1);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(dispose_06, "ag_mblock_dispose() on a deep copy does not alter the"
+AG_TEST_INIT(release_06, "ag_mblock_release() on a deep copy does not alter the"
                 " reference count of the source")
 {
         ag_mblock_auto *i = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *j = ag_mblock_retain(i);
+        ag_mblock_retain(i);
+        ag_mblock_auto *j = i;
         ag_mblock *k = ag_mblock_copy(j);
-        ag_mblock_dispose(&k);
+        ag_mblock_release(&k);
         
         AG_TEST_ASSERT (ag_mblock_refc(i) == 2);
 }
@@ -386,8 +390,8 @@ AG_TEST_INIT(cmp_01, "ag_mblock_cmp() returns AG_CMP_EQ for two int memory"
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_EQ);
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -397,12 +401,13 @@ AG_TEST_INIT(cmp_02, "ag_mblock_cmp() returns AG_CMP_EQ when comparing a"
 {
         int *i = ag_mblock_new(sizeof *i);
         *i = 555;
-        int *j = ag_mblock_retain(i);
+        ag_mblock_retain(i);
+        int *j = i;
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_EQ);
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -416,8 +421,8 @@ AG_TEST_INIT(cmp_03, "ag_mblock_cmp() returns AG_CMP_EQ when comparing a deep"
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_EQ);
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -434,8 +439,8 @@ AG_TEST_INIT(cmp_04, "ag_mblock_cmp() returns AG_CMP_EQ for two memory blocks"
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_EQ);
 
-        ag_mblock_dispose((ag_mblock **)&a);
-        ag_mblock_dispose((ag_mblock **)&b);
+        ag_mblock_release((ag_mblock **)&a);
+        ag_mblock_release((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -446,12 +451,14 @@ AG_TEST_INIT(cmp_05, "ag_mblock_cmp() returns AG_CMP_EQ when comparing a"
         struct test2 *a = ag_mblock_new(sizeof *a);
         a->i = 555;
         a->j = -666;
-        struct test2 *b = ag_mblock_retain(a);
+
+        ag_mblock_retain(a);
+        struct test2 *b = a;
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_EQ);
 
-        ag_mblock_dispose((ag_mblock **)&a);
-        ag_mblock_dispose((ag_mblock **)&b);
+        ag_mblock_release((ag_mblock **)&a);
+        ag_mblock_release((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -466,8 +473,8 @@ AG_TEST_INIT(cmp_06, "ag_mblock_cmp() returns AG_CMP_EQ when comparing a deep"
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_EQ);
 
-        ag_mblock_dispose((ag_mblock **)&a);
-        ag_mblock_dispose((ag_mblock **)&b);
+        ag_mblock_release((ag_mblock **)&a);
+        ag_mblock_release((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -483,8 +490,8 @@ AG_TEST_INIT(cmp_07, "ag_mblock_cmp() returns AG_CMP_LT when comparing an int"
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_LT);
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -499,8 +506,8 @@ AG_TEST_INIT(cmp_08, "ag_mblock_cmp() returns AG_CMP_GT when comparing an int"
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_GT);
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -519,8 +526,8 @@ AG_TEST_INIT(cmp_09, "ag_mblock_cmp() returns AG_CMP_LT when comparing a memory"
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_LT);
 
-        ag_mblock_dispose((ag_mblock **)&a);
-        ag_mblock_dispose((ag_mblock **)&b);
+        ag_mblock_release((ag_mblock **)&a);
+        ag_mblock_release((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -539,8 +546,8 @@ AG_TEST_INIT(cmp_10, "ag_mblock_cmp() returns AG_CMP_GT when comparing a memory"
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_GT);
 
-        ag_mblock_dispose((ag_mblock **)&a);
-        ag_mblock_dispose((ag_mblock **)&b);
+        ag_mblock_release((ag_mblock **)&a);
+        ag_mblock_release((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -555,8 +562,8 @@ AG_TEST_INIT(lt_01, "ag_mblock_lt() returns true for an int memory block with"
 
         AG_TEST_ASSERT (ag_mblock_lt(i, j));
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -571,8 +578,8 @@ AG_TEST_INIT(lt_02, "ag_mblock_lt() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_lt(i, j));
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -587,8 +594,8 @@ AG_TEST_INIT(lt_03, "ag_mblock_lt() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_lt(i, j));
         
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -603,8 +610,8 @@ AG_TEST_INIT(gt_01, "ag_mblock_gt() returns true for an int memory block with"
 
         AG_TEST_ASSERT (ag_mblock_gt(i, j));
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -619,8 +626,8 @@ AG_TEST_INIT(gt_02, "ag_mblock_gt() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_gt(i, j));
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -635,8 +642,8 @@ AG_TEST_INIT(gt_03, "ag_mblock_gt() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_gt(i, j));
         
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -651,8 +658,8 @@ AG_TEST_INIT(eq_01, "ag_mblock_eq() returns true for two int memory blocks with"
 
         AG_TEST_ASSERT (ag_mblock_eq(i, j));
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -667,8 +674,8 @@ AG_TEST_INIT(eq_02, "ag_mblock_eq() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_eq(i, j));
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -683,8 +690,8 @@ AG_TEST_INIT(eq_03, "ag_mblock_eq() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_eq(i, j));
         
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&j);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -695,7 +702,7 @@ AG_TEST_INIT(resize_01, "ag_mblock_resize() resizes an existing memory block")
 
         AG_TEST_ASSERT (ag_mblock_sz(bfr) == 15);
 
-        ag_mblock_dispose((ag_mblock **)&bfr);
+        ag_mblock_release((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -710,7 +717,7 @@ AG_TEST_INIT(resize_02, "ag_mblock_resize() preserves data when resizing to a"
 
         AG_TEST_ASSERT (!strcmp(bfr, "Hello"));
 
-        ag_mblock_dispose((ag_mblock **)&bfr);
+        ag_mblock_release((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -723,7 +730,7 @@ AG_TEST_INIT(resize_align_01, "ag_mblock_resize_align() resizes an existing"
 
         AG_TEST_ASSERT (ag_mblock_sz(bfr) == 15);
 
-        ag_mblock_dispose((ag_mblock **)&bfr);
+        ag_mblock_release((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -738,7 +745,7 @@ AG_TEST_INIT(resize_align_02, "ag_mblock_resize_align() preserves data when"
 
         AG_TEST_ASSERT (!strcmp(bfr, "Hello"));
 
-        ag_mblock_dispose((ag_mblock **)&bfr);
+        ag_mblock_release((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -753,7 +760,7 @@ AG_TEST_INIT(resize_align_03, "ag_mblock_resize_align() aligns to the requested"
 
         AG_TEST_ASSERT (ag_mblock_aligned(bfr, 32));
 
-        ag_mblock_dispose((ag_mblock **)&bfr);
+        ag_mblock_release((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -766,8 +773,8 @@ AG_TEST_INIT(str_01, "ag_mblock_str() generates the string representation of a"
 
         AG_TEST_ASSERT (s && *s);
 
-        ag_mblock_dispose((ag_mblock **)&i);
-        ag_mblock_dispose((ag_mblock **)&s);
+        ag_mblock_release((ag_mblock **)&i);
+        ag_mblock_release((ag_mblock **)&s);
 }
 AG_TEST_EXIT();
 
@@ -779,16 +786,14 @@ extern ag_test_suite *ag_test_suite_mblock(void)
         ag_test *test[] = {
                 &new_01, &new_02, &new_03, &new_04, &new_05, &new_align_01,
                 &new_align_02, &new_align_03, &new_align_04, &new_align_05,
-                &new_align_06, 
-                &copy_01, &copy_02, &copy_03,
-                &copy_04, &copy_05, &copy_06, &copy_07,
-                &copy_align_01, &copy_align_02, &copy_align_03,
-                &copy_align_04, &copy_align_05, &copy_align_06,
-                &copy_align_07, &copy_align_08, &dispose_01, 
-                &dispose_02, &dispose_03, &dispose_04, dispose_05, &dispose_06,
-                &cmp_01, &cmp_02, &cmp_03, &cmp_04, cmp_05, &cmp_06, &cmp_07,
-                &cmp_08, &cmp_09, &cmp_10, &lt_01, &lt_02, &lt_03, &gt_01,
-                &gt_02, &gt_03, &eq_01, &eq_02, &eq_03, &resize_01, &resize_02,
+                &new_align_06, &copy_01, &copy_02, &copy_03, &copy_04, &copy_05,
+                &copy_06, &copy_07, &copy_align_01, &copy_align_02,
+                &copy_align_03, &copy_align_04, &copy_align_05, &copy_align_06,
+                &copy_align_07, &copy_align_08, &release_01, &release_02,
+                &release_03, &release_04, release_05, &release_06, &cmp_01,
+                &cmp_02, &cmp_03, &cmp_04, cmp_05, &cmp_06, &cmp_07, &cmp_08,
+                &cmp_09, &cmp_10, &lt_01, &lt_02, &lt_03, &gt_01, &gt_02,
+                &gt_03, &eq_01, &eq_02, &eq_03, &resize_01, &resize_02,
                 &resize_align_01, &resize_align_02, &resize_align_03, &str_01,
         };
 
@@ -796,20 +801,18 @@ extern ag_test_suite *ag_test_suite_mblock(void)
                 new_01_desc, new_02_desc, new_03_desc, new_04_desc, new_05_desc,
                 new_align_01_desc, new_align_02_desc, new_align_03_desc,
                 new_align_04_desc, new_align_05_desc, new_align_06_desc,
-                copy_01_desc,
-                copy_02_desc, copy_03_desc, copy_04_desc,
-                copy_05_desc, copy_06_desc, copy_07_desc,
-                copy_align_01_desc, copy_align_02_desc,
-                copy_align_03_desc, copy_align_04_desc,
-                copy_align_05_desc, copy_align_06_desc,
-                copy_align_07_desc, copy_align_08_desc,
-                dispose_01_desc, dispose_02_desc, dispose_03_desc,
-                dispose_04_desc, dispose_05_desc, dispose_06_desc, cmp_01_desc,
-                cmp_02_desc, cmp_03_desc, cmp_04_desc, cmp_05_desc, cmp_06_desc,
-                cmp_07_desc, cmp_08_desc, cmp_09_desc, cmp_10_desc, lt_01_desc,
-                lt_02_desc, lt_03_desc, gt_01_desc, gt_02_desc, gt_03_desc,
-                eq_01_desc, eq_02_desc, eq_03_desc, resize_01_desc,
-                resize_02_desc, resize_align_01_desc, resize_align_02_desc,
+                copy_01_desc, copy_02_desc, copy_03_desc, copy_04_desc,
+                copy_05_desc, copy_06_desc, copy_07_desc, copy_align_01_desc,
+                copy_align_02_desc, copy_align_03_desc, copy_align_04_desc,
+                copy_align_05_desc, copy_align_06_desc, copy_align_07_desc,
+                copy_align_08_desc, release_01_desc, release_02_desc,
+                release_03_desc, release_04_desc, release_05_desc,
+                release_06_desc, cmp_01_desc, cmp_02_desc, cmp_03_desc,
+                cmp_04_desc, cmp_05_desc, cmp_06_desc, cmp_07_desc, cmp_08_desc,
+                cmp_09_desc, cmp_10_desc, lt_01_desc, lt_02_desc, lt_03_desc,
+                gt_01_desc, gt_02_desc, gt_03_desc, eq_01_desc, eq_02_desc,
+                eq_03_desc, resize_01_desc, resize_02_desc,
+                resize_align_01_desc, resize_align_02_desc,
                 resize_align_03_desc, str_01_desc,
         };
 

--- a/test/mblock.c
+++ b/test/mblock.c
@@ -31,9 +31,9 @@ AG_TEST_INIT(new_02, "ag_mblock_new() allocates memory on the heap for"
 
         AG_TEST_ASSERT (t && t->i && t->j);
         
-        ag_mblock_free((ag_mblock **)&t->i);
-        ag_mblock_free((ag_mblock **)&t->j);
-        ag_mblock_free((ag_mblock **)&t);
+        ag_mblock_dispose((ag_mblock **)&t->i);
+        ag_mblock_dispose((ag_mblock **)&t->j);
+        ag_mblock_dispose((ag_mblock **)&t);
 
 }
 AG_TEST_EXIT();
@@ -84,9 +84,9 @@ AG_TEST_INIT(new_align_02, "ag_mblock_new_align() allocates memory on the heap"
 
         AG_TEST_ASSERT (t && t->i && t->j);
         
-        ag_mblock_free((ag_mblock **)&t->i);
-        ag_mblock_free((ag_mblock **)&t->j);
-        ag_mblock_free((ag_mblock **)&t);
+        ag_mblock_dispose((ag_mblock **)&t->i);
+        ag_mblock_dispose((ag_mblock **)&t->j);
+        ag_mblock_dispose((ag_mblock **)&t);
 }
 AG_TEST_EXIT();
 
@@ -135,8 +135,8 @@ AG_TEST_INIT(copy_01, "ag_mblock_copy() makes a copy of an int in the heap")
         int *j = ag_mblock_copy(i);
         AG_TEST_ASSERT (*j == 555);
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -153,10 +153,10 @@ AG_TEST_INIT(copy_02, "ag_mblock_copy() makes a copy of a test structure")
         struct test *cp = ag_mblock_copy(t);
         AG_TEST_ASSERT (*cp->i == *t->i && *cp->j == *t->j);
 
-        ag_mblock_free((ag_mblock **)&t->i);
-        ag_mblock_free((ag_mblock **)&t->j);
-        ag_mblock_free((ag_mblock **)&t);
-        ag_mblock_free((ag_mblock **)&cp);
+        ag_mblock_dispose((ag_mblock **)&t->i);
+        ag_mblock_dispose((ag_mblock **)&t->j);
+        ag_mblock_dispose((ag_mblock **)&t);
+        ag_mblock_dispose((ag_mblock **)&cp);
 }
 AG_TEST_EXIT();
 
@@ -221,8 +221,8 @@ AG_TEST_INIT(copy_deep_01, "ag_mblock_copy_deep() makes a copy of an int in the"
         int *j = ag_mblock_copy_deep(i);
         AG_TEST_ASSERT (*j == 555);
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -239,10 +239,10 @@ AG_TEST_INIT(copy_deep_02, "ag_mblock_copy_deep() makes a copy of a test"
         struct test *cp = ag_mblock_copy_deep(t);
         AG_TEST_ASSERT (*cp->i == *t->i && *cp->j == *t->j);
 
-        ag_mblock_free((ag_mblock **)&t->i);
-        ag_mblock_free((ag_mblock **)&t->j);
-        ag_mblock_free((ag_mblock **)&t);
-        ag_mblock_free((ag_mblock **)&cp);
+        ag_mblock_dispose((ag_mblock **)&t->i);
+        ag_mblock_dispose((ag_mblock **)&t->j);
+        ag_mblock_dispose((ag_mblock **)&t);
+        ag_mblock_dispose((ag_mblock **)&cp);
 }
 AG_TEST_EXIT();
 
@@ -310,8 +310,8 @@ AG_TEST_INIT(copy_deep_align_01, "ag_mblock_copy_deep_align() makes a copy of"
         int *j = ag_mblock_copy_deep_align(i, 8);
         AG_TEST_ASSERT (*j == 555);
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -328,10 +328,10 @@ AG_TEST_INIT(copy_deep_align_02, "ag_mblock_copy_deep_align() makes a copy of"
         struct test *cp = ag_mblock_copy_deep_align(t, 8);
         AG_TEST_ASSERT (*cp->i == *t->i && *cp->j == *t->j);
 
-        ag_mblock_free((ag_mblock **)&t->i);
-        ag_mblock_free((ag_mblock **)&t->j);
-        ag_mblock_free((ag_mblock **)&t);
-        ag_mblock_free((ag_mblock **)&cp);
+        ag_mblock_dispose((ag_mblock **)&t->i);
+        ag_mblock_dispose((ag_mblock **)&t->j);
+        ag_mblock_dispose((ag_mblock **)&t);
+        ag_mblock_dispose((ag_mblock **)&cp);
 }
 AG_TEST_EXIT();
 
@@ -402,61 +402,62 @@ AG_TEST_INIT(copy_deep_align_08, "ag_mblock_copy_deep_align() honours alignment"
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(free_01, "ag_mblock_free() performs a no-op if passed NULL")
+AG_TEST_INIT(dispose_01, "ag_mblock_dispose() performs a no-op if passed NULL")
 {
-        ag_mblock_free(NULL);
+        ag_mblock_dispose(NULL);
         AG_TEST_ASSERT (true);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(free_02, "ag_mblock_free() performs a no-op if passed a handle to"
-                " a null pointer")
+AG_TEST_INIT(dispose_02, "ag_mblock_dispose() performs a no-op if passed a"
+                " handle to a null pointer")
 {
         ag_mblock *m = NULL;
-        ag_mblock_free((ag_mblock **) &m);
+        ag_mblock_dispose((ag_mblock **) &m);
         AG_TEST_ASSERT (true);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(free_03, "ag_mblock_free() release an int on the heap")
+AG_TEST_INIT(dispose_03, "ag_mblock_dispose() release an int on the heap")
 {
         int *i = ag_mblock_new(sizeof *i);
-        ag_mblock_free((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&i);
         AG_TEST_ASSERT (!i);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(free_04, "ag_mblock_free() releases a test struct on the heap")
+AG_TEST_INIT(dispose_04, "ag_mblock_dispose() releases a test struct on the"
+                " heap")
 {
         struct test *t = ag_mblock_new(sizeof *t);
-        ag_mblock_free((ag_mblock **)&t);
+        ag_mblock_dispose((ag_mblock **)&t);
         AG_TEST_ASSERT (!t);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(free_05, "ag_mblock_free() reduces the reference count by 1 for"
-                "lazy copies")
+AG_TEST_INIT(dispose_05, "ag_mblock_dispose() reduces the reference count by 1"
+                "for lazy copies")
 {
         int *i = ag_mblock_new(sizeof *i);
         ag_mblock_auto *j = ag_mblock_copy(i);
-        ag_mblock_free((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&i);
 
         AG_TEST_ASSERT (ag_mblock_refc(j) == 1);
 }
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(free_06, "ag_mblock_free() on a deep copy does not alter the"
+AG_TEST_INIT(dispose_06, "ag_mblock_dispose() on a deep copy does not alter the"
                 " reference count of the source")
 {
         ag_mblock_auto *i = ag_mblock_new(sizeof(int));
         ag_mblock_auto *j = ag_mblock_copy(i);
         ag_mblock *k = ag_mblock_copy_deep(j);
-        ag_mblock_free(&k);
+        ag_mblock_dispose(&k);
         
         AG_TEST_ASSERT (ag_mblock_refc(i) == 2);
 }
@@ -473,8 +474,8 @@ AG_TEST_INIT(cmp_01, "ag_mblock_cmp() returns AG_CMP_EQ for two int memory"
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_EQ);
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -488,8 +489,8 @@ AG_TEST_INIT(cmp_02, "ag_mblock_cmp() returns AG_CMP_EQ when comparing a"
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_EQ);
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -503,8 +504,8 @@ AG_TEST_INIT(cmp_03, "ag_mblock_cmp() returns AG_CMP_EQ when comparing a deep"
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_EQ);
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -521,8 +522,8 @@ AG_TEST_INIT(cmp_04, "ag_mblock_cmp() returns AG_CMP_EQ for two memory blocks"
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_EQ);
 
-        ag_mblock_free((ag_mblock **)&a);
-        ag_mblock_free((ag_mblock **)&b);
+        ag_mblock_dispose((ag_mblock **)&a);
+        ag_mblock_dispose((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -537,8 +538,8 @@ AG_TEST_INIT(cmp_05, "ag_mblock_cmp() returns AG_CMP_EQ when comparing a"
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_EQ);
 
-        ag_mblock_free((ag_mblock **)&a);
-        ag_mblock_free((ag_mblock **)&b);
+        ag_mblock_dispose((ag_mblock **)&a);
+        ag_mblock_dispose((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -553,8 +554,8 @@ AG_TEST_INIT(cmp_06, "ag_mblock_cmp() returns AG_CMP_EQ when comparing a deep"
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_EQ);
 
-        ag_mblock_free((ag_mblock **)&a);
-        ag_mblock_free((ag_mblock **)&b);
+        ag_mblock_dispose((ag_mblock **)&a);
+        ag_mblock_dispose((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -570,8 +571,8 @@ AG_TEST_INIT(cmp_07, "ag_mblock_cmp() returns AG_CMP_LT when comparing an int"
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_LT);
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -586,8 +587,8 @@ AG_TEST_INIT(cmp_08, "ag_mblock_cmp() returns AG_CMP_GT when comparing an int"
 
         AG_TEST_ASSERT(ag_mblock_cmp(i, j) == AG_CMP_GT);
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -605,8 +606,8 @@ AG_TEST_INIT(cmp_09, "ag_mblock_cmp() returns AG_CMP_LT when comparing a memory"
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_LT);
 
-        ag_mblock_free((ag_mblock **)&a);
-        ag_mblock_free((ag_mblock **)&b);
+        ag_mblock_dispose((ag_mblock **)&a);
+        ag_mblock_dispose((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -624,8 +625,8 @@ AG_TEST_INIT(cmp_10, "ag_mblock_cmp() returns AG_CMP_GT when comparing a memory"
 
         AG_TEST_ASSERT(ag_mblock_cmp(a, b) == AG_CMP_GT);
 
-        ag_mblock_free((ag_mblock **)&a);
-        ag_mblock_free((ag_mblock **)&b);
+        ag_mblock_dispose((ag_mblock **)&a);
+        ag_mblock_dispose((ag_mblock **)&b);
 }
 AG_TEST_EXIT();
 
@@ -640,8 +641,8 @@ AG_TEST_INIT(lt_01, "ag_mblock_lt() returns true for an int memory block with"
 
         AG_TEST_ASSERT (ag_mblock_lt(i, j));
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -656,8 +657,8 @@ AG_TEST_INIT(lt_02, "ag_mblock_lt() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_lt(i, j));
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -672,8 +673,8 @@ AG_TEST_INIT(lt_03, "ag_mblock_lt() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_lt(i, j));
         
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -688,8 +689,8 @@ AG_TEST_INIT(gt_01, "ag_mblock_gt() returns true for an int memory block with"
 
         AG_TEST_ASSERT (ag_mblock_gt(i, j));
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -704,8 +705,8 @@ AG_TEST_INIT(gt_02, "ag_mblock_gt() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_gt(i, j));
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -720,8 +721,8 @@ AG_TEST_INIT(gt_03, "ag_mblock_gt() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_gt(i, j));
         
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -736,8 +737,8 @@ AG_TEST_INIT(eq_01, "ag_mblock_eq() returns true for two int memory blocks with"
 
         AG_TEST_ASSERT (ag_mblock_eq(i, j));
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -752,8 +753,8 @@ AG_TEST_INIT(eq_02, "ag_mblock_eq() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_eq(i, j));
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -768,8 +769,8 @@ AG_TEST_INIT(eq_03, "ag_mblock_eq() returns false for an int memory block with"
 
         AG_TEST_ASSERT (!ag_mblock_eq(i, j));
         
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&j);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&j);
 }
 AG_TEST_EXIT();
 
@@ -780,7 +781,7 @@ AG_TEST_INIT(resize_01, "ag_mblock_resize() resizes an existing memory block")
 
         AG_TEST_ASSERT (ag_mblock_sz(bfr) == 15);
 
-        ag_mblock_free((ag_mblock **)&bfr);
+        ag_mblock_dispose((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -795,7 +796,7 @@ AG_TEST_INIT(resize_02, "ag_mblock_resize() preserves data when resizing to a"
 
         AG_TEST_ASSERT (!strcmp(bfr, "Hello"));
 
-        ag_mblock_free((ag_mblock **)&bfr);
+        ag_mblock_dispose((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -808,7 +809,7 @@ AG_TEST_INIT(resize_align_01, "ag_mblock_resize_align() resizes an existing"
 
         AG_TEST_ASSERT (ag_mblock_sz(bfr) == 15);
 
-        ag_mblock_free((ag_mblock **)&bfr);
+        ag_mblock_dispose((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -823,7 +824,7 @@ AG_TEST_INIT(resize_align_02, "ag_mblock_resize_align() preserves data when"
 
         AG_TEST_ASSERT (!strcmp(bfr, "Hello"));
 
-        ag_mblock_free((ag_mblock **)&bfr);
+        ag_mblock_dispose((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -838,7 +839,7 @@ AG_TEST_INIT(resize_align_03, "ag_mblock_resize_align() aligns to the requested"
 
         AG_TEST_ASSERT (ag_mblock_aligned(bfr, 32));
 
-        ag_mblock_free((ag_mblock **)&bfr);
+        ag_mblock_dispose((ag_mblock **)&bfr);
 }
 AG_TEST_EXIT();
 
@@ -851,8 +852,8 @@ AG_TEST_INIT(str_01, "ag_mblock_str() generates the string representation of a"
 
         AG_TEST_ASSERT (s && *s);
 
-        ag_mblock_free((ag_mblock **)&i);
-        ag_mblock_free((ag_mblock **)&s);
+        ag_mblock_dispose((ag_mblock **)&i);
+        ag_mblock_dispose((ag_mblock **)&s);
 }
 AG_TEST_EXIT();
 
@@ -869,12 +870,12 @@ extern ag_test_suite *ag_test_suite_mblock(void)
                 &copy_deep_04, &copy_deep_05, &copy_deep_06, &copy_deep_07,
                 &copy_deep_align_01, &copy_deep_align_02, &copy_deep_align_03,
                 &copy_deep_align_04, &copy_deep_align_05, &copy_deep_align_06,
-                &copy_deep_align_07, &copy_deep_align_08, &free_01, &free_02,
-                &free_03, &free_04, &free_05, &free_06, &cmp_01, &cmp_02,
-                &cmp_03, &cmp_04, &cmp_05, &cmp_06, &cmp_07, &cmp_08, &cmp_09,
-                &cmp_10, &lt_01, &lt_02, &lt_03, &gt_01, &gt_02, &gt_03, &eq_01,
-                &eq_02, &eq_03, &resize_01, &resize_02, &resize_align_01,
-                &resize_align_02, &resize_align_03, &str_01,
+                &copy_deep_align_07, &copy_deep_align_08, &dispose_01, 
+                &dispose_02, &dispose_03, &dispose_04, &dispose_05, &dispose_06,
+                &cmp_01, &cmp_02, &cmp_03, &cmp_04, &cmp_05, &cmp_06, &cmp_07,
+                &cmp_08, &cmp_09, &cmp_10, &lt_01, &lt_02, &lt_03, &gt_01,
+                &gt_02, &gt_03, &eq_01, &eq_02, &eq_03, &resize_01, &resize_02,
+                &resize_align_01, &resize_align_02, &resize_align_03, &str_01,
         };
 
         const char *desc[] = {
@@ -888,14 +889,14 @@ extern ag_test_suite *ag_test_suite_mblock(void)
                 copy_deep_align_01_desc, copy_deep_align_02_desc,
                 copy_deep_align_03_desc, copy_deep_align_04_desc,
                 copy_deep_align_05_desc, copy_deep_align_06_desc,
-                copy_deep_align_07_desc, copy_deep_align_08_desc, free_01_desc,
-                free_02_desc, free_03_desc, free_04_desc, free_05_desc,
-                free_06_desc, cmp_01_desc, cmp_02_desc, cmp_03_desc,
-                cmp_04_desc, cmp_05_desc, cmp_06_desc, cmp_07_desc, cmp_08_desc,
-                cmp_09_desc, cmp_10_desc, lt_01_desc, lt_02_desc, lt_03_desc,
-                gt_01_desc, gt_02_desc, gt_03_desc, eq_01_desc, eq_02_desc,
-                eq_03_desc, resize_01_desc, resize_02_desc,
-                resize_align_01_desc, resize_align_02_desc,
+                copy_deep_align_07_desc, copy_deep_align_08_desc,
+                dispose_01_desc, dispose_02_desc, dispose_03_desc,
+                dispose_04_desc, dispose_05_desc, dispose_06_desc, cmp_01_desc,
+                cmp_02_desc, cmp_03_desc, cmp_04_desc, cmp_05_desc, cmp_06_desc,
+                cmp_07_desc, cmp_08_desc, cmp_09_desc, cmp_10_desc, lt_01_desc,
+                lt_02_desc, lt_03_desc, gt_01_desc, gt_02_desc, gt_03_desc,
+                eq_01_desc, eq_02_desc, eq_03_desc, resize_01_desc,
+                resize_02_desc, resize_align_01_desc, resize_align_02_desc,
                 resize_align_03_desc, str_01_desc,
         };
 

--- a/test/mblock.c
+++ b/test/mblock.c
@@ -16,7 +16,7 @@ struct test2 {
 AG_TEST_INIT(new_01, "ag_mblock_new() allocates memory on the heap for"
                 " an int")
 {
-        ag_mblock_auto *m = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *m = ag_mblock_new(sizeof(int));
         AG_TEST_ASSERT (m);
 }
 AG_TEST_EXIT();
@@ -42,7 +42,7 @@ AG_TEST_EXIT();
 AG_TEST_INIT(new_03, "ag_mblock_new() returns a block with a reference count"
                 " of 1")
 {
-        ag_mblock_auto *m = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *m = ag_mblock_new(sizeof(int));
         AG_TEST_ASSERT (ag_mblock_refc(m) == 1);
 }
 AG_TEST_EXIT();
@@ -51,7 +51,7 @@ AG_TEST_EXIT();
 AG_TEST_INIT(new_04, "ag_mblock_new() returns a block with the requested data"
                 " size")
 {
-        ag_mblock_auto *m = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *m = ag_mblock_new(sizeof(int));
         AG_TEST_ASSERT (ag_mblock_sz(m) == sizeof(int));
 }
 AG_TEST_EXIT();
@@ -60,7 +60,7 @@ AG_TEST_EXIT();
 AG_TEST_INIT(new_05, "ag_mblock_new() returns a block with a total size >="
                 " requested data size")
 {
-        ag_mblock_auto *m = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *m = ag_mblock_new(sizeof(int));
         AG_TEST_ASSERT (ag_mblock_sz_total(m) >= sizeof(int));
 }
 AG_TEST_EXIT();
@@ -69,7 +69,7 @@ AG_TEST_EXIT();
 AG_TEST_INIT(new_align_01, "ag_mblock_new_align() allocates memory on the heap"
                 " for an int")
 {
-        ag_mblock_auto *m = ag_mblock_new_align(sizeof(int), 8);
+        AG_AUTO(ag_mblock) *m = ag_mblock_new_align(sizeof(int), 8);
         AG_TEST_ASSERT (m);
 }
 AG_TEST_EXIT();
@@ -94,7 +94,7 @@ AG_TEST_EXIT();
 AG_TEST_INIT(new_align_03, "ag_mblock_new_align() returns a block with a"
                 " reference count of 1")
 {
-        ag_mblock_auto *m = ag_mblock_new_align(sizeof(int), 8);
+        AG_AUTO(ag_mblock) *m = ag_mblock_new_align(sizeof(int), 8);
         AG_TEST_ASSERT (ag_mblock_refc(m) == 1);
 }
 AG_TEST_EXIT();
@@ -103,7 +103,7 @@ AG_TEST_EXIT();
 AG_TEST_INIT(new_align_04, "ag_mblock_new_align() returns a block with the"
                 " requested data size")
 {
-        ag_mblock_auto *m = ag_mblock_new_align(sizeof(int), 8);
+        AG_AUTO(ag_mblock) *m = ag_mblock_new_align(sizeof(int), 8);
         AG_TEST_ASSERT (ag_mblock_sz(m) == sizeof(int));
 }
 AG_TEST_EXIT();
@@ -112,7 +112,7 @@ AG_TEST_EXIT();
 AG_TEST_INIT(new_align_05, "ag_mblock_new_align() returns a block with a total"
                 " size >= requested data size")
 {
-        ag_mblock_auto *m = ag_mblock_new_align(sizeof(int), 8);
+        AG_AUTO(ag_mblock) *m = ag_mblock_new_align(sizeof(int), 8);
         AG_TEST_ASSERT (ag_mblock_sz_total(m) >= sizeof(int));
 }
 AG_TEST_EXIT();
@@ -121,7 +121,7 @@ AG_TEST_EXIT();
 AG_TEST_INIT(new_align_06, "ag_mblock_new_align() returns a block with the"
                 " required alignment")
 {
-        ag_mblock_auto *m = ag_mblock_new_align(sizeof(int), 32);
+        AG_AUTO(ag_mblock) *m = ag_mblock_new_align(sizeof(int), 32);
         AG_TEST_ASSERT (ag_mblock_aligned(m, 32));
 }
 AG_TEST_EXIT();
@@ -164,8 +164,8 @@ AG_TEST_EXIT();
 
 AG_TEST_INIT(copy_03, "ag_mblock_copy() returns a copy with another address")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_copy(src);
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *cp = ag_mblock_copy(src);
         AG_TEST_ASSERT (src != cp);
 }
 AG_TEST_EXIT();
@@ -174,8 +174,8 @@ AG_TEST_EXIT();
 AG_TEST_INIT(copy_04, "ag_mblock_copy() sets the reference count of the copy"
                 " to 1")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_copy(src);
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *cp = ag_mblock_copy(src);
         
         AG_TEST_ASSERT (ag_mblock_refc(cp) == 1);
 }
@@ -184,8 +184,8 @@ AG_TEST_EXIT();
 AG_TEST_INIT(copy_05, "ag_mblock_copy() does not change the reference count of"
                 " the source")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_copy(src);
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *cp = ag_mblock_copy(src);
         
         AG_TEST_ASSERT (ag_mblock_refc(src) == 1);
 }
@@ -194,8 +194,8 @@ AG_TEST_EXIT();
 
 AG_TEST_INIT(copy_06, "ag_mblock_copy() preserves the data size of the source")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_copy(src);
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *cp = ag_mblock_copy(src);
 
         AG_TEST_ASSERT (ag_mblock_sz(src) == ag_mblock_sz(cp));
 }
@@ -204,8 +204,8 @@ AG_TEST_EXIT();
 
 AG_TEST_INIT(copy_07, "ag_mblock_copy() maintains the total size of the source")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_copy(src);
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *cp = ag_mblock_copy(src);
 
         AG_TEST_ASSERT (ag_mblock_sz(src) >= ag_mblock_sz(cp));
 }
@@ -250,8 +250,8 @@ AG_TEST_EXIT();
 AG_TEST_INIT(copy_align_03, "ag_mblock_copy_align() returns a copy with another"
                 " address")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_copy_align(src, 8);
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *cp = ag_mblock_copy_align(src, 8);
         AG_TEST_ASSERT (src != cp);
 }
 AG_TEST_EXIT();
@@ -260,10 +260,10 @@ AG_TEST_EXIT();
 AG_TEST_INIT(copy_align_04, "ag_mblock_copy_align() sets the reference count of"
                 " the copy to 1")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
         ag_mblock_retain(src);
-        ag_mblock_auto *cp = src;
-        ag_mblock_auto *cp2 = ag_mblock_copy_align(cp, 8);
+        AG_AUTO(ag_mblock) *cp = src;
+        AG_AUTO(ag_mblock) *cp2 = ag_mblock_copy_align(cp, 8);
         
         AG_TEST_ASSERT (ag_mblock_refc(cp2) == 1);
 }
@@ -272,10 +272,10 @@ AG_TEST_EXIT();
 AG_TEST_INIT(copy_align_05, "ag_mblock_copy_align() does not change the"
                 " reference count of the source")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
         ag_mblock_retain(src);
-        ag_mblock_auto *cp = src;
-        ag_mblock_auto *cp2 = ag_mblock_copy_align(cp, 8);
+        AG_AUTO(ag_mblock) *cp = src;
+        AG_AUTO(ag_mblock) *cp2 = ag_mblock_copy_align(cp, 8);
         
         AG_TEST_ASSERT (ag_mblock_refc(src) == 2 && ag_mblock_refc(cp) == 2);
 }
@@ -285,8 +285,8 @@ AG_TEST_EXIT();
 AG_TEST_INIT(copy_align_06, "ag_mblock_copy_align() preserves the data size of"
                 " the source")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_copy_align(src, 8);
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *cp = ag_mblock_copy_align(src, 8);
 
         AG_TEST_ASSERT (ag_mblock_sz(src) == ag_mblock_sz(cp));
 }
@@ -296,8 +296,8 @@ AG_TEST_EXIT();
 AG_TEST_INIT(copy_align_07, "ag_mblock_copy_align() maintains the total size of"
                 " the source")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_copy_align(src, 8);
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *cp = ag_mblock_copy_align(src, 8);
 
         AG_TEST_ASSERT (ag_mblock_sz(src) >= ag_mblock_sz(cp));
 }
@@ -307,8 +307,8 @@ AG_TEST_EXIT();
 AG_TEST_INIT(copy_align_08, "ag_mblock_copy_align() honours its alignment"
                 " request")
 {
-        ag_mblock_auto *src = ag_mblock_new(sizeof(int));
-        ag_mblock_auto *cp = ag_mblock_copy_align(src, 32);
+        AG_AUTO(ag_mblock) *src = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *cp = ag_mblock_copy_align(src, 32);
 
         AG_TEST_ASSERT (ag_mblock_aligned(cp, 32));
 }
@@ -357,7 +357,7 @@ AG_TEST_INIT(release_05, "ag_mblock_release() reduces the reference count by 1"
 {
         int *i = ag_mblock_new(sizeof *i);
         ag_mblock_retain(i);
-        ag_mblock_auto *j = i;
+        AG_AUTO(ag_mblock) *j = i;
         ag_mblock_release((ag_mblock **)&i);
 
         AG_TEST_ASSERT (ag_mblock_refc(j) == 1);
@@ -368,9 +368,9 @@ AG_TEST_EXIT();
 AG_TEST_INIT(release_06, "ag_mblock_release() on a deep copy does not alter the"
                 " reference count of the source")
 {
-        ag_mblock_auto *i = ag_mblock_new(sizeof(int));
+        AG_AUTO(ag_mblock) *i = ag_mblock_new(sizeof(int));
         ag_mblock_retain(i);
-        ag_mblock_auto *j = i;
+        AG_AUTO(ag_mblock) *j = i;
         ag_mblock *k = ag_mblock_copy(j);
         ag_mblock_release(&k);
         

--- a/test/runner.c
+++ b/test/runner.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv)
         ag_test_harness_exec(th);
         ag_test_harness_log(th, stdout);
 
-        ag_test_harness_free(&th);
+        ag_test_harness_release(&th);
 
         ag_exit(EXIT_SUCCESS);
 

--- a/test/runner.c
+++ b/test/runner.c
@@ -14,14 +14,17 @@ int main(int argc, char **argv)
 
         ag_test_harness *th = ag_test_harness_new();
 
-        ag_test_suite *mblock = ag_test_suite_mblock();
         ag_test_suite *log = test_log();
+        ag_test_suite *mblock = ag_test_suite_mblock();
+        ag_test_suite *str = test_suite_str();
 
-        ag_test_harness_push(th, mblock);
         ag_test_harness_push(th, log);
+        ag_test_harness_push(th, mblock);
+        ag_test_harness_push(th, str);
 
-        ag_test_suite_release(&mblock);
         ag_test_suite_release(&log);
+        ag_test_suite_release(&mblock);
+        ag_test_suite_release(&str);
 
         ag_test_harness_exec(th);
         ag_test_harness_log(th, stdout);

--- a/test/runner.c
+++ b/test/runner.c
@@ -59,8 +59,8 @@ int main(int argc, char **argv)
         ag_test_harness_push(th, mblock);
         ag_test_harness_push(th, log);
 
-        ag_test_suite_free(&mblock);
-        ag_test_suite_free(&log);
+        ag_test_suite_release(&mblock);
+        ag_test_suite_release(&log);
 
         ag_test_harness_exec(th);
         ag_test_harness_log(th, stdout);

--- a/test/runner.c
+++ b/test/runner.c
@@ -5,49 +5,10 @@
 #include <malloc.h>
 
 
-/*static enum ag_test_status sample_1(ag_test_case *tc)
-{
-        ag_test_case_desc_set(tc, "sample 1 test case");
-        return ag_test_assert_debug (1);
-}
-
-
-static enum ag_test_status sample_2(ag_test_case *tc)
-{
-        ag_test_case_desc_set(tc, "sample 2 test case");
-        return ag_test_assert (0);
-}*/
-
-
 int main(int argc, char **argv)
 {
     (void) argc;
     (void) argv;
-
-    /*ag_test_memblock();
-    ag_test_string();
-    ag_test_object();
-    ag_test_log();
-    ag_test_value();*/
-
-        /*ag_test_case *tc1 = ag_test_case_new(&sample_1);
-        ag_test_case *tc2 = ag_test_case_new(&sample_2);
-
-        ag_test_suite *ts1 = ag_test_suite_new("sample 1 test suite");
-        ag_test_harness *th = ag_test_harness_new();
-
-        ag_test_suite_push(ts1, tc1);
-        ag_test_suite_push(ts1, tc2);
-        ag_test_harness_push(th, ts1);
-        
-        ag_test_harness_exec(th);
-        ag_test_harness_log(th, stdout);
-
-
-        ag_test_case_dispose(&tc1);
-        ag_test_case_dispose(&tc2);
-        ag_test_suite_dispose(&ts1);
-        ag_test_harness_dispose(&th);*/
 
         ag_init();
 

--- a/test/str.c
+++ b/test/str.c
@@ -487,10 +487,33 @@ AG_TEST_INIT(len_02, "ag_str_len() returns the length of an ASCII string") {
 } AG_TEST_EXIT();
 
 
-/* WARNING: This test indicates a possible bug with Devanagari characters */
 AG_TEST_INIT(len_03, "ag_str_len() returns the length of a Unicode string") {
         ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
         AG_TEST_ASSERT (ag_str_len(s) == 14);
+} AG_TEST_EXIT();
+
+
+/*
+ * The following tests check whether ag_str_sz() works as expected with empty,
+ * ASCII and Unicode strings.
+ */
+
+
+AG_TEST_INIT(sz_01, "ag_str_sz() returns 1 for an empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        AG_TEST_ASSERT (ag_str_sz(s) == 1);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(sz_02, "ag_str_sz() determines the size of an ASCII string") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_sz(s) == 14);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(sz_03, "ag_str_sz() determines the size of Unicode string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        AG_TEST_ASSERT (ag_str_sz(s) == 39);
 } AG_TEST_EXIT();
 
 
@@ -504,7 +527,7 @@ extern ag_test_suite *test_suite_str(void)
                 lt_03, lt_04, lt_05, lt_06, lt_07, lt_08, lt_09, eq_01, eq_02,
                 eq_03, eq_04, eq_05, eq_06, eq_07, eq_08, eq_09, gt_01, gt_02,
                 gt_03, gt_04, gt_05, gt_06, gt_07, gt_08, gt_09, empty_01,
-                empty_02, empty_03, len_01, len_02, len_03,
+                empty_02, empty_03, len_01, len_02, len_03, sz_01, sz_02, sz_03,
         };
 
         const char *desc[] = {
@@ -520,7 +543,7 @@ extern ag_test_suite *test_suite_str(void)
                 eq_09_desc, gt_01_desc, gt_02_desc, gt_03_desc, gt_04_desc,
                 gt_05_desc, gt_06_desc, gt_07_desc, gt_08_desc, gt_09_desc,
                 empty_01_desc, empty_02_desc, empty_03_desc, len_01_desc,
-                len_02_desc, len_03_desc,
+                len_02_desc, len_03_desc, sz_01_desc, sz_02_desc, sz_03_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/str.c
+++ b/test/str.c
@@ -661,6 +661,129 @@ AG_TEST_INIT(proper_02, "ag_str_proper() converts an ASCII string to proper"
 } AG_TEST_EXIT();
 
 
+/*
+ * The following test cases check whether ag_str_split() behaves as expected
+ * with different combinations of empty, ASCII and Unicode strings.
+ */
+
+
+AG_TEST_INIT(split_01, "ag_str_split() returns an empty string if applied on an"
+                " empty string") {
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_split(s, " wo");
+        AG_TEST_ASSERT (ag_str_empty(s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_02, "ag_str_split() returns the original string if the pivot"
+                " is an empty string") {
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_split(s, "");
+        AG_TEST_ASSERT (ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+AG_TEST_INIT(split_03, "ag_str_split() returns an empty string if both the"
+                " string and the pivot are empty") {
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_split(s, "");
+        AG_TEST_ASSERT (ag_str_eq(s2, ""));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_04, "ag_str_split() returns an empty string if the pivot is"
+                " not found") {
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_split(s, "xyz");
+        AG_TEST_ASSERT (ag_str_empty(s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_05, "ag_str_split() returns an empty string if both the"
+                " string and pivot are the same") {
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_split(s, s);
+        AG_TEST_ASSERT (ag_str_empty(s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_06, "ag_str_split() returns the left side of the pivot if it"
+                " exists in an ASCII string") {
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_split(s, " wo");
+        AG_TEST_ASSERT (ag_str_eq(s2, "Hello,"));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_07, "ag_str_split() returns the left side of the pivot if it"
+                " exists in a Unicode string") {
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_split(s, "या");
+        AG_TEST_ASSERT (ag_str_eq(s2, "नमस्ते दुनि"));
+} AG_TEST_EXIT();
+
+
+/*
+ * The following test cases check whether ag_str_split_right() behaves as
+ * expected with different combinations of empty, ASCII and Unicode strings.
+ */
+
+
+AG_TEST_INIT(split_right_01, "ag_str_split_right() returns an empty string if"
+                " applied on an empty string") {
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_split_right(s, " wo");
+        AG_TEST_ASSERT (ag_str_empty(s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_right_02, "ag_str_split_right() returns the original string"
+                " if the pivot is an empty string") {
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_split_right(s, "");
+        AG_TEST_ASSERT (ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_right_03, "ag_str_split_right() returns an empty string if"
+                " both the string and the pivot are empty") {
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_split(s, "");
+        AG_TEST_ASSERT (ag_str_eq(s2, ""));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_right_04, "ag_str_split_right() returns an empty string if"
+                " the pivot is not found") {
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_split_right(s, "xyz");
+        AG_TEST_ASSERT (ag_str_empty(s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_right_05, "ag_str_split_right() returns an empty string if"
+                " both the string and pivot are the same") {
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_split_right(s, s);
+        AG_TEST_ASSERT (ag_str_empty(s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_right_06, "ag_str_split_right() returns the right side of"
+                " the pivot if it exists in an ASCII string") {
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_split_right(s, " w");
+        AG_TEST_ASSERT (ag_str_eq(s2, "orld!"));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(split_right_07, "ag_str_split() returns the right side of the"
+                " pivot if it exists in a Unicode string") {
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_split_right(s, "स्ते");
+        AG_TEST_ASSERT (ag_str_eq(s2, " दुनिया!"));
+} AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_str(void)
 {
         ag_test *test[] = {
@@ -674,7 +797,10 @@ extern ag_test_suite *test_suite_str(void)
                 empty_02, empty_03, len_01, len_02, len_03, sz_01, sz_02, sz_03,
                 refc_01, refc_02, refc_03, has_01, has_02, has_03, has_04,
                 has_05, has_06, has_07, lower_01, lower_02, upper_01, upper_02,
-                proper_01, proper_02,
+                proper_01, proper_02, split_01, split_02, split_03, split_04,
+                split_05, split_06, split_07, split_right_01, split_right_02,
+                split_right_03, split_right_04, split_right_05, split_right_06,
+                split_right_07,
         };
 
         const char *desc[] = {
@@ -694,7 +820,11 @@ extern ag_test_suite *test_suite_str(void)
                 refc_01_desc, refc_02_desc, refc_03_desc, has_01_desc,
                 has_02_desc, has_03_desc, has_04_desc, has_05_desc, has_06_desc,
                 has_07_desc, lower_01_desc, lower_02_desc, upper_01_desc,
-                upper_02_desc, proper_01_desc, proper_02_desc,
+                upper_02_desc, proper_01_desc, proper_02_desc, split_01_desc,
+                split_02_desc, split_03_desc, split_04_desc, split_05_desc,
+                split_06_desc, split_07_desc, split_right_01_desc,
+                split_right_02_desc, split_right_03_desc, split_right_04_desc,
+                split_right_05_desc, split_right_06_desc, split_right_07_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/str.c
+++ b/test/str.c
@@ -443,6 +443,55 @@ AG_TEST_INIT(gt_09, "ag_str_gt() returns true when comparing a Unicode string"
 } AG_TEST_EXIT();
 
 
+/*
+ * The followint tests check whether ag_str_empty() behaves as expected with
+ * empty, ASCII and Unicode strings.
+ */
+
+
+AG_TEST_INIT(empty_01, "ag_str_empty() returns true for an empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        AG_TEST_ASSERT (ag_str_empty(s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(empty_02, "ag_str_empty() returns false for an ASCII string") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_empty(s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(empty_03, "ag_str_empty() returns false for a Unicode string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        AG_TEST_ASSERT (!ag_str_empty(s));
+} AG_TEST_EXIT();
+
+
+/*
+ * The following unit tests check whether ag_str_len() returns the correct
+ * lexicographical length for empty, ASCII and Unicode strings. The len_03 tests
+ * seems to indicate that there may be a possible bug when considering combined
+ * characters as in the Devenagari script. TODO: need to research more on this.
+ */
+
+
+AG_TEST_INIT(len_01, "ag_str_len() returns 0 for an empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        AG_TEST_ASSERT (!ag_str_len(s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(len_02, "ag_str_len() returns the length of an ASCII string") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_len(s) == 13);
+} AG_TEST_EXIT();
+
+
+/* WARNING: This test indicates a possible bug with Devanagari characters */
+AG_TEST_INIT(len_03, "ag_str_len() returns the length of a Unicode string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        AG_TEST_ASSERT (ag_str_len(s) == 14);
+} AG_TEST_EXIT();
 
 
 extern ag_test_suite *test_suite_str(void)
@@ -454,7 +503,8 @@ extern ag_test_suite *test_suite_str(void)
                 cmp_04, cmp_05, cmp_06, cmp_07, cmp_08, cmp_09, lt_01, lt_02,
                 lt_03, lt_04, lt_05, lt_06, lt_07, lt_08, lt_09, eq_01, eq_02,
                 eq_03, eq_04, eq_05, eq_06, eq_07, eq_08, eq_09, gt_01, gt_02,
-                gt_03, gt_04, gt_05, gt_06, gt_07, gt_08, gt_09,
+                gt_03, gt_04, gt_05, gt_06, gt_07, gt_08, gt_09, empty_01,
+                empty_02, empty_03, len_01, len_02, len_03,
         };
 
         const char *desc[] = {
@@ -469,6 +519,8 @@ extern ag_test_suite *test_suite_str(void)
                 eq_04_desc, eq_05_desc, eq_06_desc, eq_07_desc, eq_08_desc,
                 eq_09_desc, gt_01_desc, gt_02_desc, gt_03_desc, gt_04_desc,
                 gt_05_desc, gt_06_desc, gt_07_desc, gt_08_desc, gt_09_desc,
+                empty_01_desc, empty_02_desc, empty_03_desc, len_01_desc,
+                len_02_desc, len_03_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/str.c
+++ b/test/str.c
@@ -1,0 +1,149 @@
+#include "./test.h"
+
+
+/* 
+ * The following unit tests test out ag_str_new() with statically allocated
+ * empty, ASCII and Unicode strings.
+ */
+
+
+AG_TEST_INIT(new_01, "ag_str_new() can create an empty string") {
+        ag_str_auto *s = ag_str_new("");
+        AG_TEST_ASSERT (s && !*s);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(new_02, "ag_str_new() can create an ASCII string") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (s && *s && ag_str_eq(s, "Hello, world!"));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(new_03, "ag_str_new() can create a Unicode string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        AG_TEST_ASSERT (s && *s && ag_str_eq(s, "नमस्ते दुनिया!"));
+} AG_TEST_EXIT();
+
+
+/* This unit test checks whether ag_str_new_empty() behaves as expected. */
+AG_TEST_INIT(new_empty_01, "ag_str_new_empty() creates an empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+
+        AG_TEST_ASSERT (s && !*s);
+} AG_TEST_EXIT();
+
+
+/* 
+ * The following unit tests check whether ag_str_new_fmt() performs as expected
+ * with in the case of statically allocated empty and formatted ASCII and
+ * Unicode strings.
+ */
+
+
+AG_TEST_INIT(new_fmt_01, "ag_str_new_fmt() can create an empty string") {
+        ag_str_auto *s = ag_str_new_fmt("%s", "");
+        AG_TEST_ASSERT (s && !*s);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(new_fmt_02, "ag_str_new_fmt() can create a formatted ASCII"
+                " string") {
+        ag_str_auto *s = ag_str_new_fmt("%d. %s", 111, "Hello, world!");
+        AG_TEST_ASSERT (s && *s && ag_str_eq(s, "111. Hello, world!"));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(new_fmt_03, "ag_str_new_fmt() can create a formatted Unicode"
+                " string") {
+        ag_str_auto *s = ag_str_new_fmt("%d. %s", -12, "नमस्ते दुनिया!");
+        AG_TEST_ASSERT (s && *s && ag_str_eq(s, "-12. नमस्ते दुनिया!"));
+} AG_TEST_EXIT();
+
+
+/*
+ * The following unit tests check whether ag_str_copy() can create shallow
+ * copies of empty, ASCII and Unicode string instances.
+ */
+
+
+AG_TEST_INIT(copy_01, "ag_str_copy() can create a copy of an empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (s2 && !*s2);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(copy_02, "ag_str_copy() can create a copy of an ASCII string") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (s2 && *s2 && ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(copy_03, "ag_str_copy() can create a copy of a Unicode string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (s2 && *s2 && ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(copy_04, "ag_str_copy() increases the reference count by 1") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (ag_str_refc(s) == 2);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(release_01, "ag_str_release() performs a no-op if passed NULL") {
+        ag_str_release(NULL);
+        AG_TEST_ASSERT (true);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(release_02, "ag_str_release() perfroms a no-op if passed a handle"
+                " to NULL") {
+        ag_str *s = NULL;
+        ag_str_release(&s);
+        AG_TEST_ASSERT (true);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(release_03, "ag_str_release() disposes a single instance of a"
+                " string") {
+        ag_str *s = ag_str_new("Hello, world!");
+        ag_str_release(&s);
+        AG_TEST_ASSERT (!s);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(release_04, "ag_str_release() reduces the reference count by 1") {
+        ag_str *s = ag_str_new("Hello, world!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        ag_str_auto *s3 = ag_str_copy(s2);
+        ag_str_release(&s);
+        AG_TEST_ASSERT (!s && ag_str_refc(s2) == 2);
+} AG_TEST_EXIT();
+
+
+
+extern ag_test_suite *test_suite_str(void)
+{
+        ag_test *test[] = {
+                new_01, new_02, new_03, new_empty_01, new_fmt_01, new_fmt_02,
+                new_fmt_03, copy_01, copy_02, copy_03, copy_04, release_01,
+                release_02, release_03, release_04,
+        };
+
+        const char *desc[] = {
+                new_01_desc, new_02_desc, new_03_desc, new_empty_01_desc,
+                new_fmt_01_desc, new_fmt_02_desc, new_fmt_03_desc, copy_01_desc,
+                copy_02_desc, copy_03_desc, copy_04_desc, release_01_desc,
+                release_02_desc, release_03_desc, release_04_desc,
+        };
+
+        ag_test_suite *ctx = ag_test_suite_new("ag_str interface");
+        ag_test_suite_push_array(ctx, test, desc, sizeof test / sizeof *test);
+
+        return ctx;
+}
+

--- a/test/str.c
+++ b/test/str.c
@@ -546,6 +546,64 @@ AG_TEST_INIT(refc_03, "ag_str_refc() detects decremented reference counts") {
 } AG_TEST_EXIT();
 
 
+/*
+ * The following test cases check whether ag_str_has() performs as expected with
+ * different combinations of empty, ASCII and Unicode needles and haystacks.
+ */
+
+
+AG_TEST_INIT(has_01, "ag_str_has() returns true when both needle and haystack"
+                " are empty strings") {
+        ag_str_auto *h = ag_str_new_empty(), *n = ag_str_new_empty();
+        AG_TEST_ASSERT (ag_str_has(h, n));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(has_02, "ag_str_has() returns false when haystack is empty and"
+                " needle is not") {
+        ag_str_auto *h = ag_str_new_empty(), *n = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_has(h, n));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(has_03, "ag_str_has() returns false when haystack is not empty and"
+                " needle is") {
+        ag_str_auto *h = ag_str_new("Hello, world!"), *n = ag_str_new_empty();
+        AG_TEST_ASSERT (!ag_str_has(h, n));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(has_04, "ag_str_has() returns true if it finds an ASCII needle in"
+                " an ASCII haystack") {
+        ag_str_auto *h = ag_str_new("Hello, world!"), *n = ag_str_new("o, wo");
+        AG_TEST_ASSERT (ag_str_has(h, n));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(has_05, "ag_str_has() returns false if it doesn't find an ASCII"
+                " needle in an ASCII haystack") {
+        ag_str_auto *h = ag_str_new("Hello, world!"), *n = ag_str_new("o, w!");
+        AG_TEST_ASSERT (!ag_str_has(h, n));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(has_06, "ag_str_has() returns true if it finds a Unicode needle in"
+                " a Unicode haystack") {
+        ag_str_auto *h = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *n = ag_str_new("ते दुनि");
+        AG_TEST_ASSERT (ag_str_has(h, n));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(has_07, "ag_str_has() returns false if it doesn't find a Unicode"
+                " needle in a Unicode haystack") {
+        ag_str_auto *h = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *n = ag_str_new("तेदुनि");
+        AG_TEST_ASSERT (!ag_str_has(h, n));
+} AG_TEST_EXIT();
+
+
+
 extern ag_test_suite *test_suite_str(void)
 {
         ag_test *test[] = {
@@ -557,7 +615,8 @@ extern ag_test_suite *test_suite_str(void)
                 eq_03, eq_04, eq_05, eq_06, eq_07, eq_08, eq_09, gt_01, gt_02,
                 gt_03, gt_04, gt_05, gt_06, gt_07, gt_08, gt_09, empty_01,
                 empty_02, empty_03, len_01, len_02, len_03, sz_01, sz_02, sz_03,
-                refc_01, refc_02, refc_03,
+                refc_01, refc_02, refc_03, has_01, has_02, has_03, has_04,
+                has_05, has_06, has_07,
         };
 
         const char *desc[] = {
@@ -574,7 +633,9 @@ extern ag_test_suite *test_suite_str(void)
                 gt_05_desc, gt_06_desc, gt_07_desc, gt_08_desc, gt_09_desc,
                 empty_01_desc, empty_02_desc, empty_03_desc, len_01_desc,
                 len_02_desc, len_03_desc, sz_01_desc, sz_02_desc, sz_03_desc,
-                refc_01_desc, refc_02_desc, refc_03_desc,
+                refc_01_desc, refc_02_desc, refc_03_desc, has_01_desc,
+                has_02_desc, has_03_desc, has_04_desc, has_05_desc, has_06_desc,
+                has_07_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/str.c
+++ b/test/str.c
@@ -8,27 +8,26 @@
 
 
 AG_TEST_INIT(new_01, "ag_str_new() can create an empty string") {
-        ag_str_auto *s = ag_str_new("");
+        AG_AUTO(ag_str) *s = ag_str_new("");
         AG_TEST_ASSERT (s && !*s);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_02, "ag_str_new() can create an ASCII string") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (s && *s && ag_str_eq(s, "Hello, world!"));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_03, "ag_str_new() can create a Unicode string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
         AG_TEST_ASSERT (s && *s && ag_str_eq(s, "नमस्ते दुनिया!"));
 } AG_TEST_EXIT();
 
 
 /* This unit test checks whether ag_str_new_empty() behaves as expected. */
 AG_TEST_INIT(new_empty_01, "ag_str_new_empty() creates an empty string") {
-        ag_str_auto *s = ag_str_new_empty();
-
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
         AG_TEST_ASSERT (s && !*s);
 } AG_TEST_EXIT();
 
@@ -41,21 +40,21 @@ AG_TEST_INIT(new_empty_01, "ag_str_new_empty() creates an empty string") {
 
 
 AG_TEST_INIT(new_fmt_01, "ag_str_new_fmt() can create an empty string") {
-        ag_str_auto *s = ag_str_new_fmt("%s", "");
+        AG_AUTO(ag_str) *s = ag_str_new_fmt("%s", "");
         AG_TEST_ASSERT (s && !*s);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_fmt_02, "ag_str_new_fmt() can create a formatted ASCII"
                 " string") {
-        ag_str_auto *s = ag_str_new_fmt("%d. %s", 111, "Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new_fmt("%d. %s", 111, "Hello, world!");
         AG_TEST_ASSERT (s && *s && ag_str_eq(s, "111. Hello, world!"));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_fmt_03, "ag_str_new_fmt() can create a formatted Unicode"
                 " string") {
-        ag_str_auto *s = ag_str_new_fmt("%d. %s", -12, "नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s = ag_str_new_fmt("%d. %s", -12, "नमस्ते दुनिया!");
         AG_TEST_ASSERT (s && *s && ag_str_eq(s, "-12. नमस्ते दुनिया!"));
 } AG_TEST_EXIT();
 
@@ -67,29 +66,29 @@ AG_TEST_INIT(new_fmt_03, "ag_str_new_fmt() can create a formatted Unicode"
 
 
 AG_TEST_INIT(copy_01, "ag_str_copy() can create a copy of an empty string") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (s2 && !*s2);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(copy_02, "ag_str_copy() can create a copy of an ASCII string") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (s2 && *s2 && ag_str_eq(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(copy_03, "ag_str_copy() can create a copy of a Unicode string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (s2 && *s2 && ag_str_eq(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(copy_04, "ag_str_copy() increases the reference count by 1") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (ag_str_refc(s) == 2);
 } AG_TEST_EXIT();
 
@@ -124,8 +123,8 @@ AG_TEST_INIT(release_03, "ag_str_release() disposes a single instance of a"
 
 AG_TEST_INIT(release_04, "ag_str_release() reduces the reference count by 1") {
         ag_str *s = ag_str_new("Hello, world!");
-        ag_str_auto *s2 = ag_str_copy(s);
-        ag_str_auto *s3 = ag_str_copy(s2);
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s3 = ag_str_copy(s2);
         ag_str_release(&s);
         AG_TEST_ASSERT (!s && ag_str_refc(s2) == 2);
 } AG_TEST_EXIT();
@@ -139,72 +138,72 @@ AG_TEST_INIT(release_04, "ag_str_release() reduces the reference count by 1") {
 
 AG_TEST_INIT(cmp_01, "ag_str_cmp() returns AG_CMP_EQ when comparing two empty"
                 " strings") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new_empty();
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new_empty();
         AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_EQ);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_02, "ag_str_cmp() return AG_CMP_LT when comparing an empty"
                 " string with another string") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_LT);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_03, "ag_str_cmp() return AG_CMP_EQ when comparing two equal"
                 " ASCII strings") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_EQ);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_04, "ag_str_cmp() returns AG_CMP_LT when comparing an ASCII"
                 " string that is lexicographically less than another") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_LT);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_05, "ag_str_cmp() returns AG_CMP_GT when comparing an ASCII"
                 " string that is lexicographically greater than another") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_cmp(s2, s) == AG_CMP_GT);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_06, "ag_str_cmp() returns AG_CMP_GT when comparing an ASCII"
                 " string to an empty string") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_cmp(s2, s) == AG_CMP_GT);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_07, "ag_str_cmp() returns AG_CMP_EQ when comparing two equal"
                 " Unicode strings") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_EQ);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_08, "ag_str_cmp() returns AG_CMP_LT when comparing a Unicode"
                 " string that is lexicographically less than another") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
         AG_TEST_ASSERT (ag_str_cmp(s2, s) == AG_CMP_LT);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_09, "ag_str_cmp() returns AG_CMP_GT when comparing a Unicode"
                 " string that is lexicographically greater than another") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
         AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_GT);
 } AG_TEST_EXIT();
 
@@ -217,72 +216,72 @@ AG_TEST_INIT(cmp_09, "ag_str_cmp() returns AG_CMP_GT when comparing a Unicode"
 
 AG_TEST_INIT(lt_01, "ag_str_lt() returns false when comparing two empty"
                 " strings") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new_empty();
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new_empty();
         AG_TEST_ASSERT (!ag_str_lt(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_02, "ag_str_lt() returns true when comparing an empty string"
                 " with a non-empty string") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_lt(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_03, "ag_str_lt() returns false when comparing a string with an"
                 " empty string") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_lt(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_04, "ag_str_lt() returns true when comparing an ASCII string"
                 " that is lexicographically less than another string") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_lt(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_05, "ag_str_lt() returns false when comparing an ASCII string"
                 " that is lexicographically equal to another string") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (!ag_str_lt(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_06, "ag_str_lt() returns false when comparing an ASCII string"
                 " that is lexicographically greater than another string") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_lt(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_07, "ag_str_lt() returns true when comparing a Unicode string"
                 " that is lexicographically less than another string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
         AG_TEST_ASSERT (ag_str_lt(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_08, "ag_str_lt() returns false when comparing a Unicode string"
                 " that is lexicographically equal to another string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (!ag_str_lt(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_09, "ag_str_lt() returns false when comparing a Unicode string"
                 " that is lexicographically greater than another string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
         AG_TEST_ASSERT (!ag_str_lt(s, s2));
 } AG_TEST_EXIT();
 
@@ -295,72 +294,72 @@ AG_TEST_INIT(lt_09, "ag_str_lt() returns false when comparing a Unicode string"
 
 AG_TEST_INIT(eq_01, "ag_str_eq() returns true when comparing two empty"
                 " strings") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new_empty();
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new_empty();
         AG_TEST_ASSERT (ag_str_eq(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_02, "ag_str_eq() returns false when comparing an empty string"
                 " with a non-empty string") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_eq(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_03, "ag_str_eq() returns false when comparing a string with an"
                 " empty string") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_eq(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_04, "ag_str_eq() returns false when comparing an ASCII string"
                 " that is lexicographically less than another string") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_eq(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_05, "ag_str_eq() returns true when comparing an ASCII string"
                 " that is lexicographically equal to another string") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (ag_str_eq(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_06, "ag_str_eq() returns false when comparing an ASCII string"
                 " that is lexicographically greater than another string") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_eq(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_07, "ag_str_eq() returns false when comparing a Unicode string"
                 " that is lexicographically less than another string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
         AG_TEST_ASSERT (!ag_str_eq(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_08, "ag_str_eq() returns true when comparing a Unicode string"
                 " that is lexicographically equal to another string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (ag_str_eq(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_09, "ag_str_eq() returns false when comparing a Unicode string"
                 " that is lexicographically greater than another string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
         AG_TEST_ASSERT (!ag_str_eq(s, s2));
 } AG_TEST_EXIT();
 
@@ -373,72 +372,72 @@ AG_TEST_INIT(eq_09, "ag_str_eq() returns false when comparing a Unicode string"
 
 AG_TEST_INIT(gt_01, "ag_str_gt() returns false when comparing two empty"
                 " strings") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new_empty();
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new_empty();
         AG_TEST_ASSERT (!ag_str_gt(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_02, "ag_str_gt() returns false when comparing an empty string"
                 " with a non-empty string") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_gt(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_03, "ag_str_gt() returns true when comparing a string with an"
                 " empty string") {
-        ag_str_auto *s = ag_str_new_empty();
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_gt(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_04, "ag_str_gt() returns false when comparing an ASCII string"
                 " that is lexicographically less than another string") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_gt(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_05, "ag_str_gt() returns false when comparing an ASCII string"
                 " that is lexicographically equal to another string") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (!ag_str_gt(s, s2));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_06, "ag_str_gt() returns true when comparing an ASCII string"
                 " that is lexicographically greater than another string") {
-        ag_str_auto *s = ag_str_new("Goodbye, world!");
-        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Goodbye, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_gt(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_07, "ag_str_gt() returns false when comparing a Unicode string"
                 " that is lexicographically less than another string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
         AG_TEST_ASSERT (!ag_str_gt(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_08, "ag_str_gt() returns false when comparing a Unicode string"
                 " that is lexicographically equal to another string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
         AG_TEST_ASSERT (!ag_str_gt(s2, s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_09, "ag_str_gt() returns true when comparing a Unicode string"
                 " that is lexicographically greater than another string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
         AG_TEST_ASSERT (ag_str_gt(s, s2));
 } AG_TEST_EXIT();
 
@@ -450,19 +449,19 @@ AG_TEST_INIT(gt_09, "ag_str_gt() returns true when comparing a Unicode string"
 
 
 AG_TEST_INIT(empty_01, "ag_str_empty() returns true for an empty string") {
-        ag_str_auto *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
         AG_TEST_ASSERT (ag_str_empty(s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(empty_02, "ag_str_empty() returns false for an ASCII string") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_empty(s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(empty_03, "ag_str_empty() returns false for a Unicode string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
         AG_TEST_ASSERT (!ag_str_empty(s));
 } AG_TEST_EXIT();
 
@@ -476,19 +475,19 @@ AG_TEST_INIT(empty_03, "ag_str_empty() returns false for a Unicode string") {
 
 
 AG_TEST_INIT(len_01, "ag_str_len() returns 0 for an empty string") {
-        ag_str_auto *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
         AG_TEST_ASSERT (!ag_str_len(s));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(len_02, "ag_str_len() returns the length of an ASCII string") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_len(s) == 13);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(len_03, "ag_str_len() returns the length of a Unicode string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
         AG_TEST_ASSERT (ag_str_len(s) == 14);
 } AG_TEST_EXIT();
 
@@ -500,19 +499,19 @@ AG_TEST_INIT(len_03, "ag_str_len() returns the length of a Unicode string") {
 
 
 AG_TEST_INIT(sz_01, "ag_str_sz() returns 1 for an empty string") {
-        ag_str_auto *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
         AG_TEST_ASSERT (ag_str_sz(s) == 1);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(sz_02, "ag_str_sz() determines the size of an ASCII string") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_sz(s) == 14);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(sz_03, "ag_str_sz() determines the size of Unicode string") {
-        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *s = ag_str_new("नमस्ते दुनिया!");
         AG_TEST_ASSERT (ag_str_sz(s) == 39);
 } AG_TEST_EXIT();
 
@@ -524,24 +523,24 @@ AG_TEST_INIT(sz_03, "ag_str_sz() determines the size of Unicode string") {
 
 
 AG_TEST_INIT(refc_01, "ag_str_refc() returns 1 for a single instance") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (ag_str_refc(s) == 1);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(refc_02, "ag_str_refc() detects incremented reference counts") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
-        ag_str_auto *s2 = ag_str_copy(s);
-        ag_str_auto *s3 = ag_str_copy(s2);
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s2 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s3 = ag_str_copy(s2);
         AG_TEST_ASSERT (ag_str_refc(s) == 3);
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(refc_03, "ag_str_refc() detects decremented reference counts") {
-        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *s = ag_str_new("Hello, world!");
         ag_str *s2 = ag_str_copy(s);
         ag_str_release(&s2);
-        ag_str_auto *s3 = ag_str_copy(s);
+        AG_AUTO(ag_str) *s3 = ag_str_copy(s);
         AG_TEST_ASSERT (ag_str_refc(s) == 2);
 } AG_TEST_EXIT();
 
@@ -554,54 +553,57 @@ AG_TEST_INIT(refc_03, "ag_str_refc() detects decremented reference counts") {
 
 AG_TEST_INIT(has_01, "ag_str_has() returns true when both needle and haystack"
                 " are empty strings") {
-        ag_str_auto *h = ag_str_new_empty(), *n = ag_str_new_empty();
+        AG_AUTO(ag_str) *h = ag_str_new_empty(), *n = ag_str_new_empty();
         AG_TEST_ASSERT (ag_str_has(h, n));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(has_02, "ag_str_has() returns false when haystack is empty and"
                 " needle is not") {
-        ag_str_auto *h = ag_str_new_empty(), *n = ag_str_new("Hello, world!");
+        AG_AUTO(ag_str) *h = ag_str_new_empty(),
+                        *n = ag_str_new("Hello, world!");
         AG_TEST_ASSERT (!ag_str_has(h, n));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(has_03, "ag_str_has() returns false when haystack is not empty and"
                 " needle is") {
-        ag_str_auto *h = ag_str_new("Hello, world!"), *n = ag_str_new_empty();
+        AG_AUTO(ag_str) *h = ag_str_new("Hello, world!"), 
+                        *n = ag_str_new_empty();
         AG_TEST_ASSERT (!ag_str_has(h, n));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(has_04, "ag_str_has() returns true if it finds an ASCII needle in"
                 " an ASCII haystack") {
-        ag_str_auto *h = ag_str_new("Hello, world!"), *n = ag_str_new("o, wo");
+        AG_AUTO(ag_str) *h = ag_str_new("Hello, world!"),
+                        *n = ag_str_new("o, wo");
         AG_TEST_ASSERT (ag_str_has(h, n));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(has_05, "ag_str_has() returns false if it doesn't find an ASCII"
                 " needle in an ASCII haystack") {
-        ag_str_auto *h = ag_str_new("Hello, world!"), *n = ag_str_new("o, w!");
+        AG_AUTO(ag_str) *h = ag_str_new("Hello, world!"), 
+                        *n = ag_str_new("o, w!");
         AG_TEST_ASSERT (!ag_str_has(h, n));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(has_06, "ag_str_has() returns true if it finds a Unicode needle in"
                 " a Unicode haystack") {
-        ag_str_auto *h = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *n = ag_str_new("ते दुनि");
+        AG_AUTO(ag_str) *h = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *n = ag_str_new("ते दुनि");
         AG_TEST_ASSERT (ag_str_has(h, n));
 } AG_TEST_EXIT();
 
 
 AG_TEST_INIT(has_07, "ag_str_has() returns false if it doesn't find a Unicode"
                 " needle in a Unicode haystack") {
-        ag_str_auto *h = ag_str_new("नमस्ते दुनिया!");
-        ag_str_auto *n = ag_str_new("तेदुनि");
+        AG_AUTO(ag_str) *h = ag_str_new("नमस्ते दुनिया!");
+        AG_AUTO(ag_str) *n = ag_str_new("तेदुनि");
         AG_TEST_ASSERT (!ag_str_has(h, n));
 } AG_TEST_EXIT();
-
 
 
 extern ag_test_suite *test_suite_str(void)

--- a/test/str.c
+++ b/test/str.c
@@ -94,13 +94,19 @@ AG_TEST_INIT(copy_04, "ag_str_copy() increases the reference count by 1") {
 } AG_TEST_EXIT();
 
 
+/*
+ * The following unit tests check whether ag_str_release() releases a string
+ * correctly, or perform a safe no-op if provided invalid strings.
+ */
+
+
 AG_TEST_INIT(release_01, "ag_str_release() performs a no-op if passed NULL") {
         ag_str_release(NULL);
         AG_TEST_ASSERT (true);
 } AG_TEST_EXIT();
 
 
-AG_TEST_INIT(release_02, "ag_str_release() perfroms a no-op if passed a handle"
+AG_TEST_INIT(release_02, "ag_str_release() performs a no-op if passed a handle"
                 " to NULL") {
         ag_str *s = NULL;
         ag_str_release(&s);
@@ -125,20 +131,93 @@ AG_TEST_INIT(release_04, "ag_str_release() reduces the reference count by 1") {
 } AG_TEST_EXIT();
 
 
+AG_TEST_INIT(cmp_01, "ag_str_cmp() returns AG_CMP_EQ when comparing two empty"
+                " strings") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new_empty();
+        AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_EQ);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(cmp_02, "ag_str_cmp() return AG_CMP_LT when comparing an empty"
+                " string with another string") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_LT);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(cmp_03, "ag_str_cmp() return AG_CMP_EQ when comparing two equal"
+                " ASCII strings") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_EQ);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(cmp_04, "ag_str_cmp() returns AG_CMP_LT when comparing an ASCII"
+                " string that is lexicographically less than another") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_LT);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(cmp_05, "ag_str_cmp() returns AG_CMP_GT when comparing an ASCII"
+                " string that is lexicographically greater than another") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_cmp(s2, s) == AG_CMP_GT);
+} AG_TEST_EXIT();
+
+AG_TEST_INIT(cmp_06, "ag_str_cmp() returns AG_CMP_GT when comparing an ASCII"
+                " string to an empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_cmp(s2, s) == AG_CMP_GT);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(cmp_07, "ag_str_cmp() returns AG_CMP_EQ when comparing two equal"
+                " Unicode strings") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_EQ);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(cmp_08, "ag_str_cmp() returns AG_CMP_LT when comparing a Unicode"
+                " string that is lexicographically less than another") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_TEST_ASSERT (ag_str_cmp(s2, s) == AG_CMP_LT);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(cmp_09, "ag_str_cmp() return AG_CMP_GT when comparing a Unicode"
+                " string that is lexicographically greater than another") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_GT);
+} AG_TEST_EXIT();
+
 
 extern ag_test_suite *test_suite_str(void)
 {
         ag_test *test[] = {
                 new_01, new_02, new_03, new_empty_01, new_fmt_01, new_fmt_02,
                 new_fmt_03, copy_01, copy_02, copy_03, copy_04, release_01,
-                release_02, release_03, release_04,
+                release_02, release_03, release_04, cmp_01, cmp_02, cmp_03,
+                cmp_04, cmp_05, cmp_06, cmp_07, cmp_08, cmp_09,
         };
 
         const char *desc[] = {
                 new_01_desc, new_02_desc, new_03_desc, new_empty_01_desc,
                 new_fmt_01_desc, new_fmt_02_desc, new_fmt_03_desc, copy_01_desc,
                 copy_02_desc, copy_03_desc, copy_04_desc, release_01_desc,
-                release_02_desc, release_03_desc, release_04_desc,
+                release_02_desc, release_03_desc, release_04_desc, cmp_01_desc,
+                cmp_02_desc, cmp_03_desc, cmp_04_desc, cmp_05_desc, cmp_06_desc,
+                cmp_07_desc, cmp_08_desc, cmp_09_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/str.c
+++ b/test/str.c
@@ -287,6 +287,84 @@ AG_TEST_INIT(lt_09, "ag_str_lt() returns false when comparing a Unicode string"
 } AG_TEST_EXIT();
 
 
+/*
+ * The following unit tests check whether ag_str_eq() works as expected with
+ * different combinations of empty, ASCII and Unicode strings.
+ */
+
+
+AG_TEST_INIT(eq_01, "ag_str_eq() returns true when comparing two empty"
+                " strings") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new_empty();
+        AG_TEST_ASSERT (ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_02, "ag_str_eq() returns false when comparing an empty string"
+                " with a non-empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_03, "ag_str_eq() returns false when comparing a string with an"
+                " empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_eq(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_04, "ag_str_eq() returns false when comparing an ASCII string"
+                " that is lexicographically less than another string") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_05, "ag_str_eq() returns true when comparing an ASCII string"
+                " that is lexicographically equal to another string") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_06, "ag_str_eq() returns false when comparing an ASCII string"
+                " that is lexicographically greater than another string") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_eq(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_07, "ag_str_eq() returns false when comparing a Unicode string"
+                " that is lexicographically less than another string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_TEST_ASSERT (!ag_str_eq(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_08, "ag_str_eq() returns true when comparing a Unicode string"
+                " that is lexicographically equal to another string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (ag_str_eq(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_09, "ag_str_eq() returns false when comparing a Unicode string"
+                " that is lexicographically greater than another string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_TEST_ASSERT (!ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_str(void)
 {
         ag_test *test[] = {
@@ -294,7 +372,8 @@ extern ag_test_suite *test_suite_str(void)
                 new_fmt_03, copy_01, copy_02, copy_03, copy_04, release_01,
                 release_02, release_03, release_04, cmp_01, cmp_02, cmp_03,
                 cmp_04, cmp_05, cmp_06, cmp_07, cmp_08, cmp_09, lt_01, lt_02,
-                lt_03, lt_04, lt_05, lt_06, lt_07, lt_08, lt_09,
+                lt_03, lt_04, lt_05, lt_06, lt_07, lt_08, lt_09, eq_01, eq_02,
+                eq_03, eq_04, eq_05, eq_06, eq_07, eq_08, eq_09,
         };
 
         const char *desc[] = {
@@ -305,7 +384,9 @@ extern ag_test_suite *test_suite_str(void)
                 cmp_02_desc, cmp_03_desc, cmp_04_desc, cmp_05_desc, cmp_06_desc,
                 cmp_07_desc, cmp_08_desc, cmp_09_desc, lt_01_desc, lt_02_desc,
                 lt_03_desc, lt_04_desc, lt_05_desc, lt_06_desc, lt_07_desc,
-                lt_08_desc, lt_09_desc,
+                lt_08_desc, lt_09_desc, eq_01_desc, eq_02_desc, eq_03_desc,
+                eq_04_desc, eq_05_desc, eq_06_desc, eq_07_desc, eq_08_desc,
+                eq_09_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/str.c
+++ b/test/str.c
@@ -365,6 +365,86 @@ AG_TEST_INIT(eq_09, "ag_str_eq() returns false when comparing a Unicode string"
 } AG_TEST_EXIT();
 
 
+/*
+ * The following unit tests check whether ag_str_gt() works as expected with
+ * different combinations of empty, ASCII and Unicode strings.
+ */
+
+
+AG_TEST_INIT(gt_01, "ag_str_gt() returns false when comparing two empty"
+                " strings") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new_empty();
+        AG_TEST_ASSERT (!ag_str_gt(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_02, "ag_str_gt() returns false when comparing an empty string"
+                " with a non-empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_gt(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_03, "ag_str_gt() returns true when comparing a string with an"
+                " empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_gt(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_04, "ag_str_gt() returns false when comparing an ASCII string"
+                " that is lexicographically less than another string") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_gt(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_05, "ag_str_gt() returns false when comparing an ASCII string"
+                " that is lexicographically equal to another string") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (!ag_str_gt(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_06, "ag_str_gt() returns true when comparing an ASCII string"
+                " that is lexicographically greater than another string") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_gt(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_07, "ag_str_gt() returns false when comparing a Unicode string"
+                " that is lexicographically less than another string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_TEST_ASSERT (!ag_str_gt(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_08, "ag_str_gt() returns false when comparing a Unicode string"
+                " that is lexicographically equal to another string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (!ag_str_gt(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_09, "ag_str_gt() returns true when comparing a Unicode string"
+                " that is lexicographically greater than another string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_TEST_ASSERT (ag_str_gt(s, s2));
+} AG_TEST_EXIT();
+
+
+
+
 extern ag_test_suite *test_suite_str(void)
 {
         ag_test *test[] = {
@@ -373,7 +453,8 @@ extern ag_test_suite *test_suite_str(void)
                 release_02, release_03, release_04, cmp_01, cmp_02, cmp_03,
                 cmp_04, cmp_05, cmp_06, cmp_07, cmp_08, cmp_09, lt_01, lt_02,
                 lt_03, lt_04, lt_05, lt_06, lt_07, lt_08, lt_09, eq_01, eq_02,
-                eq_03, eq_04, eq_05, eq_06, eq_07, eq_08, eq_09,
+                eq_03, eq_04, eq_05, eq_06, eq_07, eq_08, eq_09, gt_01, gt_02,
+                gt_03, gt_04, gt_05, gt_06, gt_07, gt_08, gt_09,
         };
 
         const char *desc[] = {
@@ -386,7 +467,8 @@ extern ag_test_suite *test_suite_str(void)
                 lt_03_desc, lt_04_desc, lt_05_desc, lt_06_desc, lt_07_desc,
                 lt_08_desc, lt_09_desc, eq_01_desc, eq_02_desc, eq_03_desc,
                 eq_04_desc, eq_05_desc, eq_06_desc, eq_07_desc, eq_08_desc,
-                eq_09_desc,
+                eq_09_desc, gt_01_desc, gt_02_desc, gt_03_desc, gt_04_desc,
+                gt_05_desc, gt_06_desc, gt_07_desc, gt_08_desc, gt_09_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/str.c
+++ b/test/str.c
@@ -517,6 +517,35 @@ AG_TEST_INIT(sz_03, "ag_str_sz() determines the size of Unicode string") {
 } AG_TEST_EXIT();
 
 
+/*
+ * The following unit tests check whether ag_str_refc() returns the correct
+ * reference count depending on the current number of soft copies.
+ */
+
+
+AG_TEST_INIT(refc_01, "ag_str_refc() returns 1 for a single instance") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_refc(s) == 1);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(refc_02, "ag_str_refc() detects incremented reference counts") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        ag_str_auto *s3 = ag_str_copy(s2);
+        AG_TEST_ASSERT (ag_str_refc(s) == 3);
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(refc_03, "ag_str_refc() detects decremented reference counts") {
+        ag_str_auto *s = ag_str_new("Hello, world!");
+        ag_str *s2 = ag_str_copy(s);
+        ag_str_release(&s2);
+        ag_str_auto *s3 = ag_str_copy(s);
+        AG_TEST_ASSERT (ag_str_refc(s) == 2);
+} AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_str(void)
 {
         ag_test *test[] = {
@@ -528,6 +557,7 @@ extern ag_test_suite *test_suite_str(void)
                 eq_03, eq_04, eq_05, eq_06, eq_07, eq_08, eq_09, gt_01, gt_02,
                 gt_03, gt_04, gt_05, gt_06, gt_07, gt_08, gt_09, empty_01,
                 empty_02, empty_03, len_01, len_02, len_03, sz_01, sz_02, sz_03,
+                refc_01, refc_02, refc_03,
         };
 
         const char *desc[] = {
@@ -544,6 +574,7 @@ extern ag_test_suite *test_suite_str(void)
                 gt_05_desc, gt_06_desc, gt_07_desc, gt_08_desc, gt_09_desc,
                 empty_01_desc, empty_02_desc, empty_03_desc, len_01_desc,
                 len_02_desc, len_03_desc, sz_01_desc, sz_02_desc, sz_03_desc,
+                refc_01_desc, refc_02_desc, refc_03_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/str.c
+++ b/test/str.c
@@ -470,7 +470,9 @@ AG_TEST_INIT(empty_03, "ag_str_empty() returns false for a Unicode string") {
  * The following unit tests check whether ag_str_len() returns the correct
  * lexicographical length for empty, ASCII and Unicode strings. The len_03 tests
  * seems to indicate that there may be a possible bug when considering combined
- * characters as in the Devenagari script. TODO: need to research more on this.
+ * characters as in the Devenagari script.
+ *
+ * TODO: Research more on Devanagari string lengths.
  */
 
 
@@ -606,6 +608,59 @@ AG_TEST_INIT(has_07, "ag_str_has() returns false if it doesn't find a Unicode"
 } AG_TEST_EXIT();
 
 
+/*
+ * The following test cases check whether the case transformation functions of
+ * the string interface perform as expected. Note that these test cases are only
+ * for empty and ASCII strings since the case transformation functions are not
+ * yet Unicode friendly.
+ * 
+ * TODO: Add Unicode tests for string case transformation functions.
+ */
+
+
+AG_TEST_INIT(lower_01, "ag_str_lower() has no effect on an empty string") {
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_lower(s);
+        AG_TEST_ASSERT (ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lower_02, "ag_str_lower() converts an ASCII string to lowercase") {
+        AG_AUTO(ag_str) *s = ag_str_new("HElLo, WOrlD!");
+        AG_AUTO(ag_str) *s2 = ag_str_lower(s);
+        AG_TEST_ASSERT (ag_str_eq(s2, "hello, world!"));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(upper_01, "ag_str_upper() has no effect on an empty string") {
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_upper(s);
+        AG_TEST_ASSERT (ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(upper_02, "ag_str_upper() converts an ASCII string to uppercase") {
+        AG_AUTO(ag_str) *s = ag_str_new("heLlO, woRLd!");
+        AG_AUTO(ag_str) *s2 = ag_str_upper(s);
+        AG_TEST_ASSERT (ag_str_eq(s2, "HELLO, WORLD!"));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(proper_01, "ag_str_proper() has no effect on an empty string") {
+        AG_AUTO(ag_str) *s = ag_str_new_empty();
+        AG_AUTO(ag_str) *s2 = ag_str_proper(s);
+        AG_TEST_ASSERT (ag_str_eq(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(proper_02, "ag_str_proper() converts an ASCII string to proper"
+                " case") {
+        AG_AUTO(ag_str) *s = ag_str_new("tHIS isN'T.iN pRopER cASe.");
+        AG_AUTO(ag_str) *s2 = ag_str_proper(s);
+        AG_TEST_ASSERT (ag_str_eq(s2, "This Isn't.In Proper Case."));
+} AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_str(void)
 {
         ag_test *test[] = {
@@ -618,7 +673,8 @@ extern ag_test_suite *test_suite_str(void)
                 gt_03, gt_04, gt_05, gt_06, gt_07, gt_08, gt_09, empty_01,
                 empty_02, empty_03, len_01, len_02, len_03, sz_01, sz_02, sz_03,
                 refc_01, refc_02, refc_03, has_01, has_02, has_03, has_04,
-                has_05, has_06, has_07,
+                has_05, has_06, has_07, lower_01, lower_02, upper_01, upper_02,
+                proper_01, proper_02,
         };
 
         const char *desc[] = {
@@ -637,7 +693,8 @@ extern ag_test_suite *test_suite_str(void)
                 len_02_desc, len_03_desc, sz_01_desc, sz_02_desc, sz_03_desc,
                 refc_01_desc, refc_02_desc, refc_03_desc, has_01_desc,
                 has_02_desc, has_03_desc, has_04_desc, has_05_desc, has_06_desc,
-                has_07_desc,
+                has_07_desc, lower_01_desc, lower_02_desc, upper_01_desc,
+                upper_02_desc, proper_01_desc, proper_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/str.c
+++ b/test/str.c
@@ -131,6 +131,12 @@ AG_TEST_INIT(release_04, "ag_str_release() reduces the reference count by 1") {
 } AG_TEST_EXIT();
 
 
+/*
+ * The following test cases check whenter ag_str_cmp() behaves as expected with
+ * different combinations of empty, ASCII and Unicode strings.
+ */
+
+
 AG_TEST_INIT(cmp_01, "ag_str_cmp() returns AG_CMP_EQ when comparing two empty"
                 " strings") {
         ag_str_auto *s = ag_str_new_empty();
@@ -170,6 +176,7 @@ AG_TEST_INIT(cmp_05, "ag_str_cmp() returns AG_CMP_GT when comparing an ASCII"
         AG_TEST_ASSERT (ag_str_cmp(s2, s) == AG_CMP_GT);
 } AG_TEST_EXIT();
 
+
 AG_TEST_INIT(cmp_06, "ag_str_cmp() returns AG_CMP_GT when comparing an ASCII"
                 " string to an empty string") {
         ag_str_auto *s = ag_str_new_empty();
@@ -194,11 +201,89 @@ AG_TEST_INIT(cmp_08, "ag_str_cmp() returns AG_CMP_LT when comparing a Unicode"
 } AG_TEST_EXIT();
 
 
-AG_TEST_INIT(cmp_09, "ag_str_cmp() return AG_CMP_GT when comparing a Unicode"
+AG_TEST_INIT(cmp_09, "ag_str_cmp() returns AG_CMP_GT when comparing a Unicode"
                 " string that is lexicographically greater than another") {
         ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
         ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
         AG_TEST_ASSERT (ag_str_cmp(s, s2) == AG_CMP_GT);
+} AG_TEST_EXIT();
+
+
+/*
+ * The following unit tests check whether ag_str_lt() works as expected with
+ * different combinations of empty, ASCII and Unicode strings.
+ */
+
+
+AG_TEST_INIT(lt_01, "ag_str_lt() returns false when comparing two empty"
+                " strings") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new_empty();
+        AG_TEST_ASSERT (!ag_str_lt(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_02, "ag_str_lt() returns true when comparing an empty string"
+                " with a non-empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_lt(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_03, "ag_str_lt() returns false when comparing a string with an"
+                " empty string") {
+        ag_str_auto *s = ag_str_new_empty();
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_lt(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_04, "ag_str_lt() returns true when comparing an ASCII string"
+                " that is lexicographically less than another string") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (ag_str_lt(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_05, "ag_str_lt() returns false when comparing an ASCII string"
+                " that is lexicographically equal to another string") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (!ag_str_lt(s, s2));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_06, "ag_str_lt() returns false when comparing an ASCII string"
+                " that is lexicographically greater than another string") {
+        ag_str_auto *s = ag_str_new("Goodbye, world!");
+        ag_str_auto *s2 = ag_str_new("Hello, world!");
+        AG_TEST_ASSERT (!ag_str_lt(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_07, "ag_str_lt() returns true when comparing a Unicode string"
+                " that is lexicographically less than another string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_TEST_ASSERT (ag_str_lt(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_08, "ag_str_lt() returns false when comparing a Unicode string"
+                " that is lexicographically equal to another string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_copy(s);
+        AG_TEST_ASSERT (!ag_str_lt(s2, s));
+} AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_09, "ag_str_lt() returns false when comparing a Unicode string"
+                " that is lexicographically greater than another string") {
+        ag_str_auto *s = ag_str_new("नमस्ते दुनिया!");
+        ag_str_auto *s2 = ag_str_new("अभिषेक बहुत बुरा गाता है।");
+        AG_TEST_ASSERT (!ag_str_lt(s, s2));
 } AG_TEST_EXIT();
 
 
@@ -208,7 +293,8 @@ extern ag_test_suite *test_suite_str(void)
                 new_01, new_02, new_03, new_empty_01, new_fmt_01, new_fmt_02,
                 new_fmt_03, copy_01, copy_02, copy_03, copy_04, release_01,
                 release_02, release_03, release_04, cmp_01, cmp_02, cmp_03,
-                cmp_04, cmp_05, cmp_06, cmp_07, cmp_08, cmp_09,
+                cmp_04, cmp_05, cmp_06, cmp_07, cmp_08, cmp_09, lt_01, lt_02,
+                lt_03, lt_04, lt_05, lt_06, lt_07, lt_08, lt_09,
         };
 
         const char *desc[] = {
@@ -217,7 +303,9 @@ extern ag_test_suite *test_suite_str(void)
                 copy_02_desc, copy_03_desc, copy_04_desc, release_01_desc,
                 release_02_desc, release_03_desc, release_04_desc, cmp_01_desc,
                 cmp_02_desc, cmp_03_desc, cmp_04_desc, cmp_05_desc, cmp_06_desc,
-                cmp_07_desc, cmp_08_desc, cmp_09_desc,
+                cmp_07_desc, cmp_08_desc, cmp_09_desc, lt_01_desc, lt_02_desc,
+                lt_03_desc, lt_04_desc, lt_05_desc, lt_06_desc, lt_07_desc,
+                lt_08_desc, lt_09_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_str interface");

--- a/test/test.h
+++ b/test/test.h
@@ -16,6 +16,7 @@ extern void ag_test_value(void);*/
 
 extern ag_test_suite *test_log(void);
 extern ag_test_suite *ag_test_suite_mblock(void);
+extern ag_test_suite *test_suite_str(void);
 
 
 #endif /* !__ARGENT_TEST_H__ */


### PR DESCRIPTION
The string interface has been rewritten using the reference counting features provided by the new memory block interface. It is hoped that this makes the string implementation a bit cleaner and easier to maintain since the plumbing work associated with reference counting is taken care of by the memory block module.

The string interface has also been expanded, and the following functions are now available:
  -  `ag_str_new()`
  - `ag_str_new_fmt()`
  - `ag_str_new_empty()`
  - `ag_str_copy()`
  - `ag_str_release()`
  - `ag_str_cmp()`
  - `ag_str_lt()`
  - `ag_str_eq()`
  - `ag_str_gt()`
  - `ag_str_len()`
  - `ag_str_sz()`
  - `ag_str_refc()`
  - `ag_str_has()`
  - `ag_str_empty()`
  - `ag_str_lower()`
  - `ag_str_upper()`
  - `ag_str_proper()`
  - `ag_str_split()`
  - `ag_str_split_right()`

Of these functions, only `ag_str_lower()`, `ag_str_upper()` and `ag_str_proper()` are *not* Unicode-safe as of now; full Unicode support has been left for a future date. There is also a caveat regarding whether `ag_str_len()` correctly counts accounts for combined glyphs as in the case of the Devanagari script.

Along with the development of the new string module, the new memory block interface has been  provided with the functions `ag_mblock_retain()` and `ag_mblock_release()` to explicitly increment and decrement the reference count. `ag_mblock_release()` disposes the memory block automatically if the reference count falls to 0. It would seem that the `ag_mblock_dispose()` function is no longer required, but it has been kept for the time being; if found completely vestigial it will be removed at a later date. Additionally, the AG_AUTO() macro has been introduced to help simplify the declaration of pointers that are decorated with a cleanup attribute.

The testing module now uses the revised string module, and provides better logging of test statistics.

This PR closes #44.