### PR TITLE
Create generic list interface

### DIFF
--- a/include/argent.h
+++ b/include/argent.h
@@ -35,6 +35,7 @@
 #include "./uuid.h"
 #include "./object.h"
 #include "./value.h"
+#include "./list.h"
 #include "./test.h"
 #include "./manager.h"
 

--- a/include/exception.h
+++ b/include/exception.h
@@ -32,6 +32,7 @@
 #include "./argent.h"
 
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 

--- a/include/list.h
+++ b/include/list.h
@@ -49,10 +49,13 @@ typedef void            (ag_list_iterator_mutable)(ag_value **, void *);
 /*
  * Declare the manager interface for ag_list. Since ag_list is a specialisation
  * of ag_object, ag_list_copy(), ag_list_clone() and ag_list_release() are
- * simply aliases for their object counterparts.
+ * simply aliases for their object counterparts. __ag_list_register()__ is a
+ * special utility function that registers the list type with the object
+ * registry.
  */
 
 
+extern void __ag_list_register__(void);
 extern ag_list *ag_list_new(void);
 
 

--- a/include/list.h
+++ b/include/list.h
@@ -1,0 +1,154 @@
+#ifndef __ARGENT_LIST_H__
+#define __ARGENT_LIST_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#include "./argent.h"
+
+
+typedef ag_object ag_list;
+
+extern ag_list *ag_list_new(void);
+
+inline ag_list *ag_list_copy(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_copy(ctx);
+}
+
+inline ag_list *ag_list_clone(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_clone(ctx);
+}
+
+inline void ag_list_release(ag_list **ctx)
+{
+        ag_object_release(ctx);
+}
+
+
+inline enum ag_cmp ag_list_cmp(const ag_list *ctx, const ag_list *cmp)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT_PTR (cmp);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+        AG_ASSERT (ag_object_typeid(cmp) == AG_TYPEID_LIST);
+
+        return ag_object_cmp(ctx, cmp);
+}
+
+inline bool ag_list_lt(const ag_list *ctx, const ag_list *cmp)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT_PTR (cmp);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+        AG_ASSERT (ag_object_typeid(cmp) == AG_TYPEID_LIST);
+
+        return ag_object_lt(ctx, cmp);
+}
+
+inline bool ag_list_eq(const ag_list *ctx, const ag_list *cmp)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT_PTR (cmp);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+        AG_ASSERT (ag_object_typeid(cmp) == AG_TYPEID_LIST);
+
+        return ag_object_eq(ctx, cmp);
+}
+
+inline bool ag_list_gt(const ag_list *ctx, const ag_list *cmp)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_gt(ctx, cmp);
+}
+
+inline bool ag_list_empty(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_empty(ctx);
+}
+
+inline ag_typeid ag_list_typeid(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_typeid(ctx);
+}
+
+inline ag_uuid *ag_list_uuid(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_uuid(ctx);
+}
+
+inline bool ag_list_valid(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_valid(ctx);
+}
+
+inline size_t ag_list_sz(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_sz(ctx);
+}
+
+inline size_t ag_list_refc(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_refc(ctx);
+}
+
+inline size_t ag_list_len(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_len(ctx);
+}
+
+inline ag_hash ag_list_hash(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_hash(ctx);
+}
+
+inline ag_string *ag_list_str(const ag_list *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_object_str(ctx);
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !__ARGENT_LIST_H__ */
+

--- a/include/list.h
+++ b/include/list.h
@@ -243,7 +243,7 @@ extern void ag_list_map(const ag_list *, ag_list_iterator *, void *);
 
 
 /*
- * Decalre the mutator interface for ag_list. ag_list_set() and ag_list_set_at()
+ * Declare the mutator interface for ag_list. ag_list_set() and ag_list_set_at()
  * are used to set a value in a list, ag_list_push() is used to push a value to
  * the end of a list, ag_list_map_mutable() is used to iterate across a mutable
  * list, ag_list_start() and ag_list_next() are used to traverse across a list.

--- a/include/list.h
+++ b/include/list.h
@@ -251,7 +251,7 @@ extern void ag_list_map(const ag_list *, ag_list_iterator *, void *);
 
 
 extern void ag_list_set(ag_list **, const ag_value *);
-extern void ag_list_set_at(ag_list **, size_t, const ag_value *);
+extern void ag_list_set_at(ag_list **, const ag_value *, size_t);
 extern void ag_list_map_mutable(ag_list **, ag_list_iterator_mutable *, void *);
 extern void ag_list_start(ag_list **);
 extern bool ag_list_next(ag_list **);

--- a/include/list.h
+++ b/include/list.h
@@ -56,7 +56,8 @@ typedef void            (ag_list_iterator_mutable)(ag_value **, void *);
 extern ag_list *ag_list_new(void);
 
 
-inline ag_list *ag_list_copy(const ag_list *ctx)
+inline ag_list *
+ag_list_copy(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -65,7 +66,8 @@ inline ag_list *ag_list_copy(const ag_list *ctx)
 }
 
 
-inline ag_list *ag_list_clone(const ag_list *ctx)
+inline ag_list *
+ag_list_clone(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -74,7 +76,8 @@ inline ag_list *ag_list_clone(const ag_list *ctx)
 }
 
 
-inline void ag_list_release(ag_list **ctx)
+inline void
+ag_list_release(ag_list **ctx)
 {
         ag_object_release(ctx);
 }
@@ -87,7 +90,8 @@ inline void ag_list_release(ag_list **ctx)
  */
 
 
-inline enum ag_cmp ag_list_cmp(const ag_list *ctx, const ag_list *cmp)
+inline enum ag_cmp
+ag_list_cmp(const ag_list *ctx, const ag_list *cmp)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT_PTR (cmp);
@@ -98,7 +102,8 @@ inline enum ag_cmp ag_list_cmp(const ag_list *ctx, const ag_list *cmp)
 }
 
 
-inline bool ag_list_lt(const ag_list *ctx, const ag_list *cmp)
+inline bool
+ag_list_lt(const ag_list *ctx, const ag_list *cmp)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT_PTR (cmp);
@@ -109,7 +114,8 @@ inline bool ag_list_lt(const ag_list *ctx, const ag_list *cmp)
 }
 
 
-inline bool ag_list_eq(const ag_list *ctx, const ag_list *cmp)
+inline bool
+ag_list_eq(const ag_list *ctx, const ag_list *cmp)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT_PTR (cmp);
@@ -120,7 +126,8 @@ inline bool ag_list_eq(const ag_list *ctx, const ag_list *cmp)
 }
 
 
-inline bool ag_list_gt(const ag_list *ctx, const ag_list *cmp)
+inline bool
+ag_list_gt(const ag_list *ctx, const ag_list *cmp)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -137,7 +144,8 @@ inline bool ag_list_gt(const ag_list *ctx, const ag_list *cmp)
  */
 
 
-inline bool ag_list_empty(const ag_list *ctx)
+inline bool
+ag_list_empty(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -145,7 +153,9 @@ inline bool ag_list_empty(const ag_list *ctx)
         return ag_object_empty(ctx);
 }
 
-inline ag_typeid ag_list_typeid(const ag_list *ctx)
+
+inline ag_typeid
+ag_list_typeid(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -153,7 +163,9 @@ inline ag_typeid ag_list_typeid(const ag_list *ctx)
         return ag_object_typeid(ctx);
 }
 
-inline ag_uuid *ag_list_uuid(const ag_list *ctx)
+
+inline ag_uuid *
+ag_list_uuid(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -161,7 +173,9 @@ inline ag_uuid *ag_list_uuid(const ag_list *ctx)
         return ag_object_uuid(ctx);
 }
 
-inline bool ag_list_valid(const ag_list *ctx)
+
+inline bool
+ag_list_valid(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -169,7 +183,9 @@ inline bool ag_list_valid(const ag_list *ctx)
         return ag_object_valid(ctx);
 }
 
-inline size_t ag_list_sz(const ag_list *ctx)
+
+inline size_t
+ag_list_sz(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -177,7 +193,9 @@ inline size_t ag_list_sz(const ag_list *ctx)
         return ag_object_sz(ctx);
 }
 
-inline size_t ag_list_refc(const ag_list *ctx)
+
+inline size_t
+ag_list_refc(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -185,7 +203,9 @@ inline size_t ag_list_refc(const ag_list *ctx)
         return ag_object_refc(ctx);
 }
 
-inline size_t ag_list_len(const ag_list *ctx)
+
+inline size_t
+ag_list_len(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -193,7 +213,9 @@ inline size_t ag_list_len(const ag_list *ctx)
         return ag_object_len(ctx);
 }
 
-inline ag_hash ag_list_hash(const ag_list *ctx)
+
+inline ag_hash
+ag_list_hash(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
@@ -201,13 +223,16 @@ inline ag_hash ag_list_hash(const ag_list *ctx)
         return ag_object_hash(ctx);
 }
 
-inline ag_string *ag_list_str(const ag_list *ctx)
+
+inline ag_string *
+ag_list_str(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
 
         return ag_object_str(ctx);
 }
+
 
 extern ag_value *ag_list_get(const ag_list *);
 extern ag_value *ag_list_get_at(const ag_list *, size_t);

--- a/include/list.h
+++ b/include/list.h
@@ -1,3 +1,26 @@
+/*-
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Argent - infrastructure for building web services
+ * Copyright (C) 2020 Abhishek Chakravarti
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTIBILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
+ */
+
+
 #ifndef __ARGENT_LIST_H__
 #define __ARGENT_LIST_H__
 

--- a/include/list.h
+++ b/include/list.h
@@ -9,7 +9,10 @@ extern "C" {
 #include "./argent.h"
 
 
-typedef ag_object ag_list;
+typedef ag_object       ag_list;
+typedef void            (ag_list_iterator)(const ag_value *, void *);
+typedef void            (ag_list_iterator_mutable)(ag_value **, void *);
+
 
 extern ag_list *ag_list_new(void);
 
@@ -144,6 +147,17 @@ inline ag_string *ag_list_str(const ag_list *ctx)
 
         return ag_object_str(ctx);
 }
+
+extern ag_value *ag_list_get(const ag_list *);
+extern ag_value *ag_list_get_at(const ag_list *, size_t);
+extern void ag_list_map(const ag_list *, ag_list_iterator *, void *);
+
+extern void ag_list_set(ag_list **, const ag_value *);
+extern void ag_list_set_at(ag_list **, size_t, const ag_value *);
+extern void ag_list_map_mutable(ag_list **, ag_list_iterator_mutable *, void *);
+extern void ag_list_start(ag_list **);
+extern bool ag_list_next(ag_list **);
+extern void ag_list_push(ag_list **, const ag_value *);
 
 
 #ifdef __cplusplus

--- a/include/list.h
+++ b/include/list.h
@@ -32,12 +32,29 @@ extern "C" {
 #include "./argent.h"
 
 
+/*
+ * Declare the types associated with the list interface. ag_list is an opaque
+ * object representing a list that can hold any value type. For convenience, we
+ * have also typedef'd two callback functions that serve as iterators to a list.
+ * ag_list_iterator is a callback that iterates through an immutable list, and
+ * ag_list_iterator_mutable is a callback that iterates through a mutable list.
+ */
+
+
 typedef ag_object       ag_list;
 typedef void            (ag_list_iterator)(const ag_value *, void *);
 typedef void            (ag_list_iterator_mutable)(ag_value **, void *);
 
 
+/*
+ * Declare the manager interface for ag_list. Since ag_list is a specialisation
+ * of ag_object, ag_list_copy(), ag_list_clone() and ag_list_release() are
+ * simply aliases for their object counterparts.
+ */
+
+
 extern ag_list *ag_list_new(void);
+
 
 inline ag_list *ag_list_copy(const ag_list *ctx)
 {
@@ -47,6 +64,7 @@ inline ag_list *ag_list_copy(const ag_list *ctx)
         return ag_object_copy(ctx);
 }
 
+
 inline ag_list *ag_list_clone(const ag_list *ctx)
 {
         AG_ASSERT_PTR (ctx);
@@ -55,10 +73,18 @@ inline ag_list *ag_list_clone(const ag_list *ctx)
         return ag_object_clone(ctx);
 }
 
+
 inline void ag_list_release(ag_list **ctx)
 {
         ag_object_release(ctx);
 }
+
+
+/*
+ * Declare the comparator interface for ag_list. Again, we can take advantage of
+ * the fact that ag_list instances are specialised instances of ag_object to
+ * simply provided aliased counterparts.
+ */
 
 
 inline enum ag_cmp ag_list_cmp(const ag_list *ctx, const ag_list *cmp)
@@ -71,6 +97,7 @@ inline enum ag_cmp ag_list_cmp(const ag_list *ctx, const ag_list *cmp)
         return ag_object_cmp(ctx, cmp);
 }
 
+
 inline bool ag_list_lt(const ag_list *ctx, const ag_list *cmp)
 {
         AG_ASSERT_PTR (ctx);
@@ -80,6 +107,7 @@ inline bool ag_list_lt(const ag_list *ctx, const ag_list *cmp)
 
         return ag_object_lt(ctx, cmp);
 }
+
 
 inline bool ag_list_eq(const ag_list *ctx, const ag_list *cmp)
 {
@@ -91,6 +119,7 @@ inline bool ag_list_eq(const ag_list *ctx, const ag_list *cmp)
         return ag_object_eq(ctx, cmp);
 }
 
+
 inline bool ag_list_gt(const ag_list *ctx, const ag_list *cmp)
 {
         AG_ASSERT_PTR (ctx);
@@ -98,6 +127,15 @@ inline bool ag_list_gt(const ag_list *ctx, const ag_list *cmp)
 
         return ag_object_gt(ctx, cmp);
 }
+
+
+/*
+ * Declare the accessor interface for ag_list. The inline functions are all
+ * aliases of their ag_object counterparts. ag_list_get() and ag_list_get_at()
+ * are used to retrieve a value from a list, and ag_list_map() is used to run an
+ * iterator across an immutable list instance.
+ */
+
 
 inline bool ag_list_empty(const ag_list *ctx)
 {
@@ -174,6 +212,15 @@ inline ag_string *ag_list_str(const ag_list *ctx)
 extern ag_value *ag_list_get(const ag_list *);
 extern ag_value *ag_list_get_at(const ag_list *, size_t);
 extern void ag_list_map(const ag_list *, ag_list_iterator *, void *);
+
+
+/*
+ * Decalre the mutator interface for ag_list. ag_list_set() and ag_list_set_at()
+ * are used to set a value in a list, ag_list_push() is used to push a value to
+ * the end of a list, ag_list_map_mutable() is used to iterate across a mutable
+ * list, ag_list_start() and ag_list_next() are used to traverse across a list.
+ */
+
 
 extern void ag_list_set(ag_list **, const ag_value *);
 extern void ag_list_set_at(ag_list **, size_t, const ag_value *);

--- a/include/test.h
+++ b/include/test.h
@@ -79,7 +79,7 @@ enum ag_test_status {
 
 typedef enum ag_test_status (ag_test)(void);
 
-#define AG_TEST_INIT(n, d)                                              \
+#define AG_TEST_CASE(n, d)                                              \
         static const char *n##_desc = d;                                \
         static enum ag_test_status n(void) {                            \
         enum ag_test_status __ck__ = AG_TEST_STATUS_WAIT;

--- a/include/test.h
+++ b/include/test.h
@@ -86,9 +86,6 @@ typedef enum ag_test_status (ag_test)(void);
 
 #define AG_TEST_EXIT() return __ck__; }
 
-#define AG_TEST_ASSERT(p)                                               \
-        __ck__ = ((p) ? AG_TEST_STATUS_OK : AG_TEST_STATUS_FAIL)
-
 #ifdef NDEBUG
 #       define AG_TEST_ASSERT_DEBUG(p)                                  \
                 __ck__ = AG_TEST_STATUS_SKIP

--- a/include/test.h
+++ b/include/test.h
@@ -97,6 +97,11 @@ typedef enum ag_test_status (ag_test)(void);
 #endif
 
 
+#define AG_TEST(p)                                                      \
+        __ck__ = ((p) ? AG_TEST_STATUS_OK : AG_TEST_STATUS_FAIL);       \
+        } return __ck__;
+
+
 /*-
  * Interface: Test Suite
  */

--- a/include/typeid.h
+++ b/include/typeid.h
@@ -9,7 +9,8 @@ extern "C" {
 typedef int ag_typeid;
 
 
-#define AG_TYPEID_OBJECT ((ag_typeid) 0)
+#define AG_TYPEID_OBJECT        ((ag_typeid) 0)
+#define AG_TYPEID_LIST          ((ag_typeid) -1)
 
 
 #ifdef __cplusplus

--- a/include/value.h
+++ b/include/value.h
@@ -52,6 +52,8 @@ inline bool ag_value_gt(const ag_value *ctx, const ag_value *cmp)
 
 extern enum ag_value_type        ag_value_type(const ag_value *);
 extern bool                      ag_value_valid(const ag_value *);
+extern ag_hash                   ag_value_hash(const ag_value *);
+extern size_t                    ag_value_sz(const ag_value *);
 extern ag_int                    ag_value_int(const ag_value *);
 extern ag_uint                   ag_value_uint(const ag_value *);
 extern ag_float                  ag_value_float(const ag_value *);

--- a/include/value.h
+++ b/include/value.h
@@ -22,13 +22,13 @@ typedef void ag_value;
 
 
 
-extern ag_value *ag_value_new_int(ag_int);
-extern ag_value *ag_value_new_uint(ag_uint);
-extern ag_value *ag_value_new_float(ag_float);
-extern ag_value *ag_value_new_string(const ag_string *);
-extern ag_value *ag_value_new_object(const ag_object *);
-extern ag_value *ag_value_copy(const ag_value *);
-extern void ag_value_release(ag_value **);
+extern ag_value         *ag_value_new_int(ag_int);
+extern ag_value         *ag_value_new_uint(ag_uint);
+extern ag_value         *ag_value_new_float(ag_float);
+extern ag_value         *ag_value_new_string(const ag_string *);
+extern ag_value         *ag_value_new_object(const ag_object *);
+extern ag_value         *ag_value_copy(const ag_value *);
+extern void              ag_value_release(ag_value **);
 
 
 
@@ -50,7 +50,13 @@ inline bool ag_value_gt(const ag_value *ctx, const ag_value *cmp)
 }
 
 
-extern enum ag_value_type ag_value_type(const ag_value *);
+extern enum ag_value_type        ag_value_type(const ag_value *);
+extern bool                      ag_value_valid(const ag_value *);
+extern ag_int                    ag_value_int(const ag_value *);
+extern ag_uint                   ag_value_uint(const ag_value *);
+extern ag_float                  ag_value_float(const ag_value *);
+extern ag_string                *ag_value_string(const ag_value *);
+extern ag_object                *ag_value_object(const ag_value *);
 
 inline bool ag_value_type_int(const ag_value *ctx)
 {
@@ -76,13 +82,6 @@ inline bool ag_value_type_object(const ag_value *ctx)
 {
         return ag_value_type(ctx) == AG_VALUE_TYPE_OBJECT;
 }
-
-
-extern ag_int ag_value_int(const ag_value *);
-extern ag_uint ag_value_uint(const ag_value *);
-extern ag_float ag_value_float(const ag_value *);
-extern ag_string *ag_value_string(const ag_value *);
-extern ag_object *ag_value_object(const ag_value *);
 
 
 #ifdef __cplusplus

--- a/src/list.c
+++ b/src/list.c
@@ -165,7 +165,7 @@ ag_list_get(const ag_list *ctx)
         AG_ASSERT (!ag_list_empty(ctx));
 
         const struct payload *p = ag_object_payload(ctx);
-        return ag_object_copy(p->itr->val);
+        return ag_value_copy(p->itr->val);
 }
 
 
@@ -187,7 +187,7 @@ ag_list_get_at(const ag_list *ctx, size_t idx)
         for (register size_t i = 1; i < idx; i++)
                 n = n->nxt;
 
-        return ag_object_copy(n->val);
+        return ag_value_copy(n->val);
 }
 
 

--- a/src/list.c
+++ b/src/list.c
@@ -238,7 +238,7 @@ ag_list_set(ag_list **ctx, const ag_value *val)
 
 
 extern void
-ag_list_set_at(ag_list **ctx, size_t idx, const ag_value *val)
+ag_list_set_at(ag_list **ctx, const ag_value *val, size_t idx)
 {
         AG_ASSERT_PTR (ctx && *ctx);
         AG_ASSERT_PTR (val);

--- a/src/list.c
+++ b/src/list.c
@@ -40,8 +40,8 @@ struct node {
 /*
  * Define the object payload of a list. We choose to keep a pointer to the last
  * node in order to speed up push operations. Again, in order to avoid having to
- * iterate through the entire list, we maintain the lenght and cumulative size
- * of the list.
+ * iterate through the entire list, we maintain the length and cumulative size
+ * of the list. 
  */
 
 
@@ -52,6 +52,29 @@ struct payload {
         size_t           len;  /* number of items           */
         size_t           sz;   /* cumulative size           */
 };
+
+
+/*
+ * Declare the prototypes for the node helper functions. node_new() helps create
+ * a new node, and node_release() helps destroy an existing one.
+ */
+
+
+static inline struct node       *node_new(const ag_value *);
+static inline struct node       *node_release(struct node *);
+                                
+
+
+/*
+ * Declare the prototypes for the payload helper functions. payload_new() helps
+ * create a new payload instance, either empty or filled with the values cloned
+ * from another payload instance. payload_push() helps push a new node to the
+ * end of the list.
+ */
+
+
+static struct payload   *payload_new(const struct node *);
+static void              payload_push(struct payload *, const ag_value *);
 
 
 /*
@@ -217,6 +240,73 @@ ag_list_push(ag_list **ctx, const ag_value *val)
 {
         AG_ASSERT_PTR (ctx && *ctx);
         AG_ASSERT_PTR (val);
+}
+
+
+/*
+ * Define the node_new() helper function. The node_new() function is responsible
+ * for creating a new node on the heap. By default, the pointer to the next node
+ * will always be NULL when a new node is created. Since we're performing a
+ * shallow copy using ag_value_copy(), creating a new node is relatively
+ * inexpensive.
+ */
+
+
+static inline struct node*
+node_new(const ag_value *val)
+{
+        AG_ASSERT_PTR (val);
+
+        struct node *n = ag_memblock_new(sizeof *n);
+        n->val = ag_value_copy(val);
+        n->nxt = NULL;
+
+        return n;
+}
+
+
+/*
+ * Define the node_new() helper function. We release the heap memory allocated
+ * to a node and return a pointer to the next node (which may be NULL). By
+ * returning a pointer to the next node, we make it easier to iterate through
+ * the list with this function. Note that we're taking care to avoid casting to
+ * (void **) in the call to ag_memblock_release() in order to avoid potential
+ * undefined behaviour.
+ */
+
+
+static inline struct node*
+node_release(struct node *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+
+        struct node *nxt = ctx->nxt;
+        void *ptr = ctx;
+        ag_memblock_release(&ptr);
+
+        return nxt;
+}
+
+
+/*
+ * Define the payload_new() helper function.
+ */
+
+
+static struct payload*
+payload_new(const struct node *head)
+{
+}
+
+
+/*
+ * Define the payload_push() helper function.
+ */
+
+
+static void
+payload_push(struct payload *ctx, const ag_value *val)
+{
 }
 
 

--- a/src/list.c
+++ b/src/list.c
@@ -154,7 +154,11 @@ ag_list_new(void)
 
 
 /*
- * Define the ag_list_get() interface function.
+ * Define the ag_list_get() interface function. We use this function to get the
+ * value at the currently iterated node, provided that the node exists. Note
+ * that it's **not** safe to call this function on an empty list.
+ *
+ * TODO: explore null values to make this function safer.
  */
 
 
@@ -170,7 +174,12 @@ ag_list_get(const ag_list *ctx)
 
 
 /*
- * Define the ag_list_get_at() interface function.
+ * Define the ag_list_get_at() interface function. This function gets the value
+ * at a given index, provided that a node exists at that index. Note that the
+ * index is 1-based, and that currently it's **not** safe to call this function
+ * on empty lists or with invalid index values.
+ *
+ * TODO: explore null values to make this function safer.
  */
 
 
@@ -215,7 +224,12 @@ ag_list_map(const ag_list *ctx, ag_list_iterator *itr, void *opt)
 
 
 /*
- * Define the ag_list_set() interface function.
+ * Define the ag_list_set() interface function. This function sets the value at
+ * the currently iterated node of the list, provided that a value already exists
+ * at the current node. Note that this function is **not** safe to call on empty
+ * lists.
+ *
+ * TODO: consider making this function safer.
  */
 
 
@@ -233,7 +247,13 @@ ag_list_set(ag_list **ctx, const ag_value *val)
 
 
 /*
- * Define the ag_list_set_at() interface function.
+ * Define the ag_list_set_at() interface function. This function sets the value
+ * at a given index in a list, assuming that there is already a value existing
+ * at that index. Note that the index is 1-based, and that the internal iterator
+ * is not affected by a call to this function. This function is **not** safe to
+ * call on empty lists or with invalid index values.
+ *
+ * TODO: consider making this function safer.
  */
 
 
@@ -281,7 +301,9 @@ ag_list_map_mutable(ag_list **ctx, ag_list_iterator_mutable *itr, void *opt)
 
 
 /*
- * Define the ag_list_start() interface function.
+ * Define the ag_list_start() interface function. This function resets the
+ * internal iterator of a list to the beginning of the list. It's safe to call
+ * this function on an empty list.
  */
 
 
@@ -296,7 +318,11 @@ ag_list_start(ag_list **ctx)
 
 
 /*
- * Define the ag_list_next() interface function.
+ * Define the ag_list_next() interface function. This function moves the
+ * internal iterator of a list to the next node of the list, if possible. The
+ * Boolean value returned indicates whether or not further iteration is
+ * possible; in case the tail node has been reached, then false is returned.
+ * This function is safe to call even on empty lists.
  */
 
 
@@ -317,7 +343,9 @@ ag_list_next(ag_list **ctx)
 
 
 /*
- * Define the ag_list_push() interface function.
+ * Define the ag_list_push() interface function. This function is responsible
+ * for pushing a new value to the tail of a list. We use the payload_push()
+ * helper function to perform the actual push operation.
  */
 
 

--- a/src/list.c
+++ b/src/list.c
@@ -113,6 +113,7 @@ ag_list_new(void)
 extern ag_value *
 ag_list_get(const ag_list *ctx)
 {
+        AG_ASSERT_PTR (ctx);
 }
 
 
@@ -124,6 +125,8 @@ ag_list_get(const ag_list *ctx)
 extern ag_value *
 ag_list_get_at(const ag_list *ctx, size_t idx)
 {
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT (idx >= 1 && idx <= ag_list_len(ctx));
 }
 
 
@@ -135,6 +138,8 @@ ag_list_get_at(const ag_list *ctx, size_t idx)
 extern void
 ag_list_map(const ag_list *ctx, ag_list_iterator *itr, void *opt)
 {
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT_PTR (itr);
 }
 
 
@@ -146,6 +151,8 @@ ag_list_map(const ag_list *ctx, ag_list_iterator *itr, void *opt)
 extern void
 ag_list_set(ag_list **ctx, const ag_value *val)
 {
+        AG_ASSERT_PTR (ctx && *ctx);
+        AG_ASSERT_PTR (val);
 }
 
 
@@ -155,8 +162,11 @@ ag_list_set(ag_list **ctx, const ag_value *val)
 
 
 extern void
-ag_list_set_at(ag_list **ctx, size_t idx, const ag_value *opt)
+ag_list_set_at(ag_list **ctx, size_t idx, const ag_value *val)
 {
+        AG_ASSERT_PTR (ctx && *ctx);
+        AG_ASSERT_PTR (val);
+        AG_ASSERT (idx >= 1 && idx <= ag_list_len(*ctx));
 }
 
 
@@ -168,6 +178,8 @@ ag_list_set_at(ag_list **ctx, size_t idx, const ag_value *opt)
 extern void
 ag_list_map_mutable(ag_list **ctx, ag_list_iterator_mutable *itr, void *opt)
 {
+        AG_ASSERT_PTR (ctx && *ctx);
+        AG_ASSERT_PTR (itr);
 }
 
 
@@ -179,6 +191,7 @@ ag_list_map_mutable(ag_list **ctx, ag_list_iterator_mutable *itr, void *opt)
 extern void
 ag_list_start(ag_list **ctx)
 {
+        AG_ASSERT_PTR (ctx && *ctx);
 }
 
 
@@ -190,6 +203,7 @@ ag_list_start(ag_list **ctx)
 extern bool
 ag_list_next(ag_list **ctx)
 {
+        AG_ASSERT_PTR (ctx && *ctx);
 }
 
 
@@ -201,6 +215,8 @@ ag_list_next(ag_list **ctx)
 extern void
 ag_list_push(ag_list **ctx, const ag_value *val)
 {
+        AG_ASSERT_PTR (ctx && *ctx);
+        AG_ASSERT_PTR (val);
 }
 
 
@@ -213,6 +229,7 @@ ag_list_push(ag_list **ctx, const ag_value *val)
 static ag_memblock *
 virt_clone(const ag_memblock *ctx)
 {
+        AG_ASSERT_PTR (ctx);
 }
 
 
@@ -225,6 +242,7 @@ virt_clone(const ag_memblock *ctx)
 static void
 virt_release(ag_memblock *ctx)
 {
+        AG_ASSERT_PTR (ctx);
 }
 
 
@@ -237,6 +255,7 @@ virt_release(ag_memblock *ctx)
 static enum ag_cmp
 virt_cmp(const ag_object *ctx, const ag_object *cmp)
 {
+        AG_ASSERT_PTR (ctx);
 }
 
 
@@ -249,6 +268,7 @@ virt_cmp(const ag_object *ctx, const ag_object *cmp)
 static bool
 virt_valid(const ag_object *ctx)
 {
+        AG_ASSERT_PTR (ctx);
 }
 
 
@@ -261,6 +281,7 @@ virt_valid(const ag_object *ctx)
 static size_t
 virt_sz(const ag_object *ctx)
 {
+        AG_ASSERT_PTR (ctx);
 }
 
 
@@ -273,6 +294,7 @@ virt_sz(const ag_object *ctx)
 static size_t
 virt_len(const ag_object *ctx)
 {
+        AG_ASSERT_PTR (ctx);
 }
 
 
@@ -285,6 +307,7 @@ virt_len(const ag_object *ctx)
 static ag_hash
 virt_hash(const ag_object *ctx)
 {
+        AG_ASSERT_PTR (ctx);
 }
 
 
@@ -297,5 +320,6 @@ virt_hash(const ag_object *ctx)
 static ag_string
 *virt_str(const ag_object *ctx)
 {
+        AG_ASSERT_PTR (ctx);
 }
 

--- a/src/list.c
+++ b/src/list.c
@@ -192,7 +192,9 @@ ag_list_get_at(const ag_list *ctx, size_t idx)
 
 
 /*
- * Define the ag_list_map() interface function.
+ * Define the ag_list_map() interface function. This function allows an iterator
+ * to run through an immutable list, supplying it with the value at the
+ * currently iterated node and optional data.
  */
 
 
@@ -201,6 +203,14 @@ ag_list_map(const ag_list *ctx, ag_list_iterator *itr, void *opt)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT_PTR (itr);
+
+        const struct payload *p = ag_object_payload(ctx);
+        register const struct node *n = p->head;
+
+        while (n) {
+                itr(ag_value_copy(n->val), opt);
+                n = n->nxt;
+        }
 }
 
 
@@ -247,7 +257,10 @@ ag_list_set_at(ag_list **ctx, size_t idx, const ag_value *val)
 
 
 /*
- * Define the ag_list_map_mutable_list() interface function.
+ * Define the ag_list_map_mutable_list() interface function. This function is
+ * similar to ag_list_map() in that it allows an iterator callback function to
+ * walk through a list. However, unlike ag_list_map(), this function allows the
+ * currently iterated value to be modified.
  */
 
 
@@ -256,6 +269,14 @@ ag_list_map_mutable(ag_list **ctx, ag_list_iterator_mutable *itr, void *opt)
 {
         AG_ASSERT_PTR (ctx && *ctx);
         AG_ASSERT_PTR (itr);
+
+        struct payload *p = ag_object_payload_mutable(ctx);
+        register struct node *n = p->head;
+
+        while (n) {
+                itr(&n->val, opt);
+                n = n->nxt;
+        }
 }
 
 

--- a/src/list.c
+++ b/src/list.c
@@ -1,0 +1,49 @@
+/*-
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Argent - infrastructure for building web services
+ * Copyright (C) 2020 Abhishek Chakravarti
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTIBILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
+ */
+
+
+
+#include "../include/argent.h"
+
+
+/*
+ * Declare the prototypes for the inline functions of the ag_list interface.
+ * These inline functions are the aliases of their object counterparts.
+ */
+
+
+extern inline ag_list           *ag_list_copy(const ag_list *);
+extern inline ag_list           *ag_list_clone(const ag_list *);
+extern inline void               ag_list_release(ag_list **);
+extern inline enum ag_cmp        ag_list_cmp(const ag_list *, const ag_list *);
+extern inline bool               ag_list_lt(const ag_list *, const ag_list *);
+extern inline bool               ag_list_eq(const ag_list *, const ag_list *);
+extern inline bool               ag_list_gt(const ag_list *, const ag_list *);
+extern inline bool               ag_list_empty(const ag_list *);
+extern inline ag_typeid          ag_list_typeid(const ag_list *);
+extern inline ag_uuid           *ag_list_uuid(const ag_list *);
+extern inline bool               ag_list_valid(const ag_list *);
+extern inline size_t             ag_list_sz(const ag_list *);
+extern inline size_t             ag_list_refc(const ag_list *);
+extern inline size_t             ag_list_len(const ag_list *);
+extern inline ag_hash            ag_list_hash(const ag_list *);
+extern inline ag_string         *ag_list_str(const ag_list *);

--- a/src/list.c
+++ b/src/list.c
@@ -119,6 +119,27 @@ extern inline ag_string         *ag_list_str(const ag_list *);
 
 
 /*
+ * Define the __ag_list_register__() utility function. This is a special
+ * function that is *not* part of the public list interface. It is invoked by
+ * the Argent manager to register the dynamic dispatch callback functions for
+ * the list type with the object registry.
+ */
+
+
+extern void
+__ag_list_register__(void)
+{
+        struct ag_object_vtable vt = {
+                .clone = virt_clone, .release = virt_release, .cmp = virt_cmp,
+                .valid = virt_valid, .sz = virt_sz,           .len = virt_len,
+                .hash = virt_hash,   .str = virt_str,
+        };
+
+        ag_object_registry_set(AG_TYPEID_LIST, &vt);
+}
+
+
+/*
  * Define the ag_list_new() interface function.
  */
 
@@ -533,6 +554,8 @@ virt_hash(const ag_object *ctx)
 /*
  * Define the virt_str() dynamic dispatch callback function. This function is
  * called by ag_object_str() when ag_list_str() is invoked.
+ *
+ * TODO: Improve definition
  */
 
 
@@ -541,5 +564,7 @@ static ag_string
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT (ag_object_typeid(ctx) == AG_TYPEID_LIST);
+
+        return ag_string_new_fmt("list len = %lu", ag_object_len(ctx));
 }
 

--- a/src/list.c
+++ b/src/list.c
@@ -26,6 +26,51 @@
 
 
 /*
+ * Define the node of a list. Our lists are singly-linked, so we only need to
+ * maintain a pointer to the next node.
+ */
+
+
+struct node {
+        ag_value        *val; /* node value */
+        struct node     *nxt; /* next node  */
+};
+
+
+/*
+ * Define the object payload of a list. We choose to keep a pointer to the last
+ * node in order to speed up push operations. Again, in order to avoid having to
+ * iterate through the entire list, we maintain the lenght and cumulative size
+ * of the list.
+ */
+
+
+struct payload {
+        struct node     *head; /* start of list             */
+        struct node     *tail; /* end of list               */
+        struct node     *itr;  /* current iterator position */
+        size_t           len;  /* number of items           */
+        size_t           sz;   /* cumulative size           */
+};
+
+
+/*
+ * Declare the proptotypes of the dynamic dispatch callbacks for ag_list. We are
+ * providing callbacks for all polymorphic object functions.
+ */
+
+
+static ag_memblock *virt_clone(const ag_memblock *);
+static void         virt_release(ag_memblock *);
+static enum ag_cmp  virt_cmp(const ag_object *, const ag_object *);
+static bool         virt_valid(const ag_object *);
+static size_t       virt_sz(const ag_object *);
+static size_t       virt_len(const ag_object *);
+static ag_hash      virt_hash(const ag_object *);
+static ag_string   *virt_str(const ag_object *);
+
+
+/*
  * Declare the prototypes for the inline functions of the ag_list interface.
  * These inline functions are the aliases of their object counterparts.
  */
@@ -47,3 +92,210 @@ extern inline size_t             ag_list_refc(const ag_list *);
 extern inline size_t             ag_list_len(const ag_list *);
 extern inline ag_hash            ag_list_hash(const ag_list *);
 extern inline ag_string         *ag_list_str(const ag_list *);
+
+
+/*
+ * Define the ag_list_new() interface function.
+ */
+
+
+extern ag_list *
+ag_list_new(void)
+{
+}
+
+
+/*
+ * Define the ag_list_get() interface function.
+ */
+
+
+extern ag_value *
+ag_list_get(const ag_list *ctx)
+{
+}
+
+
+/*
+ * Define the ag_list_get_at() interface function.
+ */
+
+
+extern ag_value *
+ag_list_get_at(const ag_list *ctx, size_t idx)
+{
+}
+
+
+/*
+ * Define the ag_list_map() interface function.
+ */
+
+
+extern void
+ag_list_map(const ag_list *ctx, ag_list_iterator *itr, void *opt)
+{
+}
+
+
+/*
+ * Define the ag_list_set() interface function.
+ */
+
+
+extern void
+ag_list_set(ag_list **ctx, const ag_value *val)
+{
+}
+
+
+/*
+ * Define the ag_list_set_at() interface function.
+ */
+
+
+extern void
+ag_list_set_at(ag_list **ctx, size_t idx, const ag_value *opt)
+{
+}
+
+
+/*
+ * Define the ag_list_map_mutable_list() interface function.
+ */
+
+
+extern void
+ag_list_map_mutable(ag_list **ctx, ag_list_iterator_mutable *itr, void *opt)
+{
+}
+
+
+/*
+ * Define the ag_list_start() interface function.
+ */
+
+
+extern void
+ag_list_start(ag_list **ctx)
+{
+}
+
+
+/*
+ * Define the ag_list_next() interface function.
+ */
+
+
+extern bool
+ag_list_next(ag_list **ctx)
+{
+}
+
+
+/*
+ * Define the ag_list_push() interface function.
+ */
+
+
+extern void
+ag_list_push(ag_list **ctx, const ag_value *val)
+{
+}
+
+
+/*
+ * Define the virt_clone() dynamic dispatch callback function. This function is
+ * called by ab_object_clone() when ag_list_clone() is invoked.
+ */
+
+
+static ag_memblock *
+virt_clone(const ag_memblock *ctx)
+{
+}
+
+
+/*
+ * Define the virt_release() dynamic dispatch callback function. This function
+ * is called by ag_object_release() when ag_list_release() is invoked.
+ */
+
+
+static void
+virt_release(ag_memblock *ctx)
+{
+}
+
+
+/*
+ * Define the virt_cmp() dynamic dispatch callback function. This function is
+ * called by ag_object_cmp() when ag_list_cmp() is invoked.
+ */
+
+
+static enum ag_cmp
+virt_cmp(const ag_object *ctx, const ag_object *cmp)
+{
+}
+
+
+/*
+ * Define the virt_valid() dynamic dispatch callback function. This function is
+ * called by ag_object_valid() when ag_list_valid() is invoked.
+ */
+
+
+static bool
+virt_valid(const ag_object *ctx)
+{
+}
+
+
+/*
+ * Define the virt_sz() dynamic dispatch callback function. This function is
+ * called by ag_object_sz() when ag_list_sz() is invoked.
+ */
+
+
+static size_t
+virt_sz(const ag_object *ctx)
+{
+}
+
+
+/*
+ * Define the virt_len() dynamic dispatch callback function. This function is
+ * called by ag_object_len() when ag_list_len() is invoked.
+ */
+
+
+static size_t
+virt_len(const ag_object *ctx)
+{
+}
+
+
+/*
+ * Define the virt_hash() dynamic dispatch callback function. This function is
+ * called by ag_object_hash() when ag_list_hash() is invoked.
+ */
+
+
+static ag_hash
+virt_hash(const ag_object *ctx)
+{
+}
+
+
+/*
+ * Define the virt_str() dynamic dispatch callback function. This function is
+ * called by ag_object_str() when ag_list_str() is invoked.
+ */
+
+
+static ag_string
+*virt_str(const ag_object *ctx)
+{
+}
+

--- a/src/list.c
+++ b/src/list.c
@@ -140,13 +140,16 @@ __ag_list_register__(void)
 
 
 /*
- * Define the ag_list_new() interface function.
+ * Define the ag_list_new() interface function. Since lists are objects, we use
+ * the ag_object_new() function to create a new list, passing along the type ID
+ * and the payload specific to list instances.
  */
 
 
 extern ag_list *
 ag_list_new(void)
 {
+        return ag_object_new(AG_TYPEID_LIST, payload_new(NULL));
 }
 
 

--- a/src/manager.c
+++ b/src/manager.c
@@ -31,6 +31,8 @@ ag_init(void)
                 n = list[i];
                 ag_exception_registry_set(n.erno, n.msg, n.hnd);
         }
+
+        __ag_list_register__();
 }
 
 

--- a/src/value.c
+++ b/src/value.c
@@ -169,6 +169,18 @@ ag_value_type(const ag_value *ctx)
 }
 
 
+/*
+ * Define the ag_value_valid() interface function. This function checks whether
+ * a value is valid. Numeric values are always considered to be valid, string
+ * values are valid if they're not empty, and object values are valid if calling
+ * ag_object_valid() with them returns true. Note that as of now we're not
+ * considering NaN as an invalid float value, but perhaps we should do so in
+ * future.
+ *
+ * TODO: should NaN be an invalid float value?
+ */
+
+
 extern bool
 ag_value_valid(const ag_value *ctx)
 {

--- a/src/value.c
+++ b/src/value.c
@@ -234,6 +234,38 @@ ag_value_hash(const ag_value *ctx)
 }
 
 
+/*
+ * Define the ag_value_sz() interface function. This function returns the size
+ * in bytes of the value that it is holding. The size of the numeric values is
+ * determined at compile-time, whereas the size of object and string values is
+ * determined at runtime.
+ */
+
+
+extern size_t
+ag_value_sz(const ag_value *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+        
+        switch (ag_value_type(ctx)) {
+        case AG_VALUE_TYPE_STRING:
+                return ag_string_sz(ag_value_string(ctx));
+                break;
+        case AG_VALUE_TYPE_OBJECT:
+                return ag_object_sz(ag_value_object(ctx));
+                break;
+        case AG_VALUE_TYPE_UINT:
+                return sizeof(ag_uint);
+                break;
+        case AG_VALUE_TYPE_FLOAT:
+                return sizeof(ag_float);
+                break;
+        default:
+                return sizeof(ag_int);
+        }
+}
+
+
 extern ag_int
 ag_value_int(const ag_value *ctx)
 {

--- a/src/value.c
+++ b/src/value.c
@@ -132,7 +132,6 @@ ag_value_cmp(const ag_value *ctx, const ag_value *cmp)
 {
         AG_ASSERT_PTR (ctx);
         AG_ASSERT_PTR (cmp);
-
         AG_ASSERT (ag_value_type(ctx) == ag_value_type(cmp));
 
         switch (ag_value_type(ctx)) {
@@ -167,6 +166,24 @@ ag_value_type(const ag_value *ctx)
                 return (AG_VALUE_TYPE_UINT);
 
         return (bits & MASK_TAG);
+}
+
+
+extern bool
+ag_value_valid(const ag_value *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+
+        switch (ag_value_type(ctx)) {
+        case AG_VALUE_TYPE_STRING:
+                return !ag_string_empty(ag_value_string(ctx));
+                break;
+        case AG_VALUE_TYPE_OBJECT:
+                return ag_object_valid(ag_value_object(ctx));
+                break;
+        default:
+                return true;
+        };
 }
 
 

--- a/src/value.c
+++ b/src/value.c
@@ -199,6 +199,41 @@ ag_value_valid(const ag_value *ctx)
 }
 
 
+/*
+ * Define the ag_value_hash() interface function. This function returns the hash
+ * of a value, generating the result according to the type. In the case of
+ * object values, we call ag_object_hash() to determine the hash. The hash of
+ * string values are determined by ag_hash_new_str(), and that of numeric values
+ * by ag_hash_new().
+ *
+ * TODO: research about the hashes of negative and floating point numbers.
+ */
+
+
+extern ag_hash
+ag_value_hash(const ag_value *ctx)
+{
+        AG_ASSERT_PTR (ctx);
+
+        switch (ag_value_type(ctx)) {
+        case AG_VALUE_TYPE_STRING:
+                return ag_hash_new_str(ag_value_string(ctx));
+                break;
+        case AG_VALUE_TYPE_OBJECT:
+                return ag_object_hash(ag_value_object(ctx));
+                break;
+        case AG_VALUE_TYPE_UINT:
+                return ag_hash_new(ag_value_uint(ctx));
+                break;
+        case AG_VALUE_TYPE_FLOAT:
+                return ag_hash_new(ag_value_float(ctx));
+                break;
+        default:
+                return ag_hash_new(ag_value_int(ctx));
+        }
+}
+
+
 extern ag_int
 ag_value_int(const ag_value *ctx)
 {

--- a/test/list.c
+++ b/test/list.c
@@ -434,6 +434,22 @@ AG_TEST_CASE(map_02, "ag_list_map() iterates through a non-empty list")
 }
 
 
+AG_TEST_CASE(set_01, "ag_list_get() sets the currently iterated value")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_value) *v = ag_value_new_int(1234);
+
+        ag_list_start(&l);
+        ag_list_next(&l);
+        ag_list_next(&l);
+
+        ag_list_set(&l, v);
+        AG_AUTO(ag_value) *v2 = ag_list_get(l);
+
+        AG_TEST (ag_value_int(v2) == 1234);
+}
+
+
 
 
 extern ag_test_suite *test_suite_list(void)
@@ -460,6 +476,7 @@ extern ag_test_suite *test_suite_list(void)
                 get_01,
                 get_at_01,
                 map_01,         map_02,
+                set_01,
         };
 
         const char *desc[] = {
@@ -486,6 +503,7 @@ extern ag_test_suite *test_suite_list(void)
                 get_01_desc,
                 get_at_01_desc,
                 map_01_desc,            map_02_desc,
+                set_01_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -1,0 +1,57 @@
+#include "./test.h"
+
+
+static ag_list *sample_int(void)
+{
+        AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
+        AG_AUTO(ag_value) *v2 = ag_value_new_int(0);
+        AG_AUTO(ag_value) *v3 = ag_value_new_int(456);
+
+        AG_AUTO(ag_list) *l = ag_list_new();
+        ag_list_push(&l, v1);
+        ag_list_push(&l, v2);
+        ag_list_push(&l, v3);
+
+        return ag_list_copy(l);
+}
+
+
+static ag_list *sample_int_2(void)
+{
+        AG_AUTO(ag_value) *v1 = ag_value_new_int(-666);
+        AG_AUTO(ag_value) *v2 = ag_value_new_int(0);
+        AG_AUTO(ag_value) *v3 = ag_value_new_int(555);
+        AG_AUTO(ag_value) *v4 = ag_value_new_int(734);
+
+        AG_AUTO(ag_list) *l = ag_list_new();
+        ag_list_push(&l, v1);
+        ag_list_push(&l, v2);
+        ag_list_push(&l, v3);
+        ag_list_push(&l, v4);
+
+        return ag_list_copy(l);
+}
+
+
+AG_TEST_INIT(new_01, "ag_list_new() can create a new sample list") {
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_TEST_ASSERT (l && ag_list_len(l) == 3);
+} AG_TEST_EXIT();
+
+
+extern ag_test_suite *test_suite_list(void)
+{
+        ag_test *test[] = {
+                new_01,
+        };
+
+        const char *desc[] = {
+                new_01_desc,
+        };
+
+        ag_test_suite *ctx = ag_test_suite_new("ag_list interface");
+        ag_test_suite_push_array(ctx, test, desc, sizeof test / sizeof *test);
+
+        return ctx;
+}
+

--- a/test/list.c
+++ b/test/list.c
@@ -335,6 +335,27 @@ AG_TEST_INIT(sz_02, "ag_list_sz() returns the cumulative size of an int list")
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(refc_01, "ag_list_refc() returns 1 for a single instance")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+
+        AG_TEST_ASSERT (ag_list_refc(l) == 1);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(refc_02,
+    "ag_list_refc() returns the reference count of a shallow copy")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l2 = ag_list_copy(l);
+        AG_AUTO(ag_list) *l3 = ag_list_copy(l2);
+
+        AG_TEST_ASSERT (ag_list_refc(l) == 3);
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -361,6 +382,8 @@ extern ag_test_suite *test_suite_list(void)
                 valid_01, valid_02,
 
                 sz_01, sz_02,
+
+                refc_01, refc_02,
         };
 
         const char *desc[] = {
@@ -390,6 +413,8 @@ extern ag_test_suite *test_suite_list(void)
                 valid_01_desc, valid_02_desc,
 
                 sz_01_desc, sz_02_desc,
+
+                refc_01_desc, refc_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -190,6 +190,42 @@ AG_TEST_INIT(lt_03,
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(gt_01, 
+    "ag_list_lt() returns true if a list is lexicographically greater than"
+    " another")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l2 = sample_int_2();
+
+        AG_TEST_ASSERT (ag_list_gt(l2, l));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_02, 
+    "ag_list_gt() returns false if a list is lexicographically equal to"
+     " another")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l2 = sample_int();
+
+        AG_TEST_ASSERT (!ag_list_gt(l, l2));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(gt_03,
+    "ag_list_gt() returns false if a list is lexicographically less than"
+    " another")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_list) *l2 = sample_int();
+
+        AG_TEST_ASSERT (!ag_list_gt(l2, l));
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -204,6 +240,8 @@ extern ag_test_suite *test_suite_list(void)
                 release_04,
 
                 lt_01, lt_02, lt_03,
+                
+                gt_01, gt_02, gt_03,
         };
 
         const char *desc[] = {
@@ -219,6 +257,9 @@ extern ag_test_suite *test_suite_list(void)
 
                 lt_01_desc, lt_02_desc,
                 lt_03_desc,
+                
+                gt_01_desc, gt_02_desc,
+                gt_03_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -33,20 +33,51 @@ static ag_list *sample_int_2(void)
 }
 
 
-AG_TEST_INIT(new_01, "ag_list_new() can create a new sample list") {
+AG_TEST_INIT(new_01, "ag_list_new() can create a new sample list")
+{
         AG_AUTO(ag_list) *l = sample_int();
         AG_TEST_ASSERT (l && ag_list_len(l) == 3);
-} AG_TEST_EXIT();
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(new_02, "ag_list_new() can create a new empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+        AG_TEST_ASSERT (l && ag_list_empty(l));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(copy_01, "ag_list_copy() creates a shallow copy of a sample list")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l2 = ag_list_copy(l);
+        AG_TEST_ASSERT (l2 == l);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(copy_02, "ag_list_copy() increases the reference count by 1")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l2 = ag_list_copy(l);
+        AG_TEST_ASSERT (ag_list_refc(l) == 2);
+}
+AG_TEST_EXIT();
+
 
 
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
-                new_01,
+                new_01, new_02, copy_01,
+                copy_02,
         };
 
         const char *desc[] = {
-                new_01_desc,
+                new_01_desc, new_02_desc, copy_01_desc,
+                copy_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -39,6 +39,15 @@ static ag_list *sample_int_2(void)
 }
 
 
+static void iterator(const ag_value *val, void *opt)
+{
+        ag_int *s = opt;
+        ag_int i = ag_value_int(val);
+        *s += i;
+
+}
+
+
 AG_TEST_CASE(new_01, "ag_list_new() can create a new sample list")
 {
         AG_AUTO(ag_list) *l = sample_int();
@@ -405,6 +414,28 @@ AG_TEST_CASE(get_at_01, "ag_list_get_at() gets the value at a given index")
 }
 
 
+AG_TEST_CASE(map_01, "ag_list_map() has no effect on an empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+        ag_int sum = 0;
+        ag_list_map(l, iterator, &sum);
+
+        AG_TEST (!sum);
+}
+
+
+AG_TEST_CASE(map_02, "ag_list_map() iterates through a non-empty list")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        ag_int sum = 0;
+        ag_list_map(l, iterator, &sum);
+
+        AG_TEST (sum == 956);
+}
+
+
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -428,6 +459,7 @@ extern ag_test_suite *test_suite_list(void)
                 str_01,         str_02,
                 get_01,
                 get_at_01,
+                map_01,         map_02,
         };
 
         const char *desc[] = {
@@ -453,6 +485,7 @@ extern ag_test_suite *test_suite_list(void)
                 str_01_desc,            str_02_desc,
                 get_01_desc,
                 get_at_01_desc,
+                map_01_desc,            map_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -375,6 +375,26 @@ AG_TEST_INIT(len_02,
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(hash_01, "ag_list_hash() returns 0 for an empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+
+        AG_TEST_ASSERT (!ag_list_hash(l));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(hash_02,
+    "ag_list_hash() returns the cumulative hash for an int list")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        ag_hash h = ag_hash_new(-123) + ag_hash_new(0) + ag_hash_new(456);
+
+        AG_TEST_ASSERT (ag_list_hash(l) == h);
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -405,6 +425,8 @@ extern ag_test_suite *test_suite_list(void)
                 refc_01, refc_02,
 
                 len_01, len_02,
+
+                hash_01, hash_02,
         };
 
         const char *desc[] = {
@@ -438,6 +460,8 @@ extern ag_test_suite *test_suite_list(void)
                 refc_01_desc, refc_02_desc,
 
                 len_01_desc, len_02_desc,
+
+                hash_01_desc, hash_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -317,6 +317,24 @@ AG_TEST_INIT(valid_02, "ag_list_valid() returns true for an int list")
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(sz_01, "ag_list_sz() returns 0 for an empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+
+        AG_TEST_ASSERT (!ag_list_sz(l));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(sz_02, "ag_list_sz() returns the cumulative size of an int list")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+
+        AG_TEST_ASSERT (ag_list_sz(l) == sizeof(ag_int) * 7);
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -341,6 +359,8 @@ extern ag_test_suite *test_suite_list(void)
                 typeid_01, uuid_01,
 
                 valid_01, valid_02,
+
+                sz_01, sz_02,
         };
 
         const char *desc[] = {
@@ -368,6 +388,8 @@ extern ag_test_suite *test_suite_list(void)
                 typeid_01_desc, uuid_01_desc,
 
                 valid_01_desc, valid_02_desc,
+
+                sz_01_desc, sz_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -42,26 +42,24 @@ static ag_list *sample_int_2(void)
 AG_TEST_INIT(new_01, "ag_list_new() can create a new sample list")
 {
         AG_AUTO(ag_list) *l = sample_int();
-        AG_TEST_ASSERT (l && ag_list_len(l) == 3);
+        AG_TEST (l && ag_list_len(l) == 3);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_02, "ag_list_new() can create a new empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
-        AG_TEST_ASSERT (l && ag_list_empty(l));
+        AG_TEST (l && ag_list_empty(l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(copy_01, "ag_list_copy() creates a shallow copy of a sample list")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = ag_list_copy(l);
-        AG_TEST_ASSERT (l2 == l);
+        
+        AG_TEST (l2 == l);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(copy_02, "ag_list_copy() increases the reference count by 1")
@@ -69,9 +67,8 @@ AG_TEST_INIT(copy_02, "ag_list_copy() increases the reference count by 1")
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_list) *l2 = ag_list_copy(l);
         
-        AG_TEST_ASSERT (ag_list_refc(l) == 2);
+        AG_TEST (ag_list_refc(l) == 2);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_01, "ag_list_clone() creates a clone of an empty list")
@@ -79,9 +76,8 @@ AG_TEST_INIT(clone_01, "ag_list_clone() creates a clone of an empty list")
         AG_AUTO(ag_list) *l = ag_list_new();
         AG_AUTO(ag_list) *l2 = ag_list_clone(l);
 
-        AG_TEST_ASSERT (l2 && l != l2);
+        AG_TEST (l2 && l != l2);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_02, "ag_list_clone() creates a clone of a sample list")
@@ -89,9 +85,8 @@ AG_TEST_INIT(clone_02, "ag_list_clone() creates a clone of a sample list")
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = ag_list_clone(l);
 
-        AG_TEST_ASSERT (l2 && l != l2);
+        AG_TEST (l2 && l != l2);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_03, "ag_list_clone() has the same items as its parent")
@@ -99,9 +94,8 @@ AG_TEST_INIT(clone_03, "ag_list_clone() has the same items as its parent")
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = ag_list_clone(l);
 
-        AG_TEST_ASSERT (ag_list_eq(l, l2));
+        AG_TEST (ag_list_eq(l, l2));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_04, "ag_list_clone() does not change the reference count")
@@ -109,9 +103,8 @@ AG_TEST_INIT(clone_04, "ag_list_clone() does not change the reference count")
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = ag_list_clone(l);
 
-        AG_TEST_ASSERT (ag_list_refc(l) == 1);
+        AG_TEST (ag_list_refc(l) == 1);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_04, "ag_list_dispose() reduces the reference count by 1")
@@ -121,17 +114,16 @@ AG_TEST_INIT(release_04, "ag_list_dispose() reduces the reference count by 1")
         AG_AUTO(ag_list) *l3 = ag_list_copy(l2);
         ag_list_release(&l);
 
-        AG_TEST_ASSERT (!l && ag_list_refc(l2) == 2);
+        AG_TEST (!l && ag_list_refc(l2) == 2);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_01, "ag_list_release() performs a no-op if passed NULL")
 {
         ag_list_release(NULL);
-        AG_TEST_ASSERT (true);
+        
+        AG_TEST (true);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_02, 
@@ -139,9 +131,9 @@ AG_TEST_INIT(release_02,
 {
         ag_list *l = NULL;
         ag_list_release(&l);
-        AG_TEST_ASSERT (true);
+        
+        AG_TEST (true);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_03,
@@ -149,9 +141,9 @@ AG_TEST_INIT(release_03,
 {
         ag_list *l = sample_int();
         ag_list_release(&l);
-        AG_TEST_ASSERT (!l);
+        
+        AG_TEST (!l);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_01, 
@@ -161,9 +153,8 @@ AG_TEST_INIT(lt_01,
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_list) *l2 = sample_int_2();
 
-        AG_TEST_ASSERT (ag_list_lt(l, l2));
+        AG_TEST (ag_list_lt(l, l2));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_02, 
@@ -173,9 +164,8 @@ AG_TEST_INIT(lt_02,
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_list) *l2 = sample_int();
 
-        AG_TEST_ASSERT (!ag_list_lt(l, l2));
+        AG_TEST (!ag_list_lt(l, l2));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_03,
@@ -185,9 +175,8 @@ AG_TEST_INIT(lt_03,
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = sample_int();
 
-        AG_TEST_ASSERT (!ag_list_lt(l, l2));
+        AG_TEST (!ag_list_lt(l, l2));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_01, 
@@ -196,9 +185,8 @@ AG_TEST_INIT(eq_01,
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_list) *l2 = sample_int();
 
-        AG_TEST_ASSERT (ag_list_eq(l, l2));
+        AG_TEST (ag_list_eq(l, l2));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_02, 
@@ -208,9 +196,8 @@ AG_TEST_INIT(eq_02,
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_list) *l2 = sample_int_2();
 
-        AG_TEST_ASSERT (!ag_list_eq(l, l2));
+        AG_TEST (!ag_list_eq(l, l2));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_03,
@@ -220,9 +207,8 @@ AG_TEST_INIT(eq_03,
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = sample_int();
 
-        AG_TEST_ASSERT (!ag_list_eq(l2, l));
+        AG_TEST (!ag_list_eq(l2, l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_01, 
@@ -232,9 +218,8 @@ AG_TEST_INIT(gt_01,
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_list) *l2 = sample_int_2();
 
-        AG_TEST_ASSERT (ag_list_gt(l2, l));
+        AG_TEST (ag_list_gt(l2, l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_02, 
@@ -244,9 +229,8 @@ AG_TEST_INIT(gt_02,
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_list) *l2 = sample_int();
 
-        AG_TEST_ASSERT (!ag_list_gt(l, l2));
+        AG_TEST (!ag_list_gt(l, l2));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_03,
@@ -256,36 +240,32 @@ AG_TEST_INIT(gt_03,
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = sample_int();
 
-        AG_TEST_ASSERT (!ag_list_gt(l2, l));
+        AG_TEST (!ag_list_gt(l2, l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(empty_01, "ag_list_empty() returns true for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
-        AG_TEST_ASSERT (ag_list_empty(l));
+        AG_TEST (ag_list_empty(l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(empty_02, "ag_list_empty() returns false for a non-empty list")
 {
         AG_AUTO(ag_list) *l = sample_int();
 
-        AG_TEST_ASSERT (!ag_list_empty(l));
+        AG_TEST (!ag_list_empty(l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(typeid_01, "ag_list_typeid() returns AG_TYPEID_LIST")
 {
         AG_AUTO(ag_list) *l = sample_int();
 
-        AG_TEST_ASSERT (ag_list_typeid(l) == AG_TYPEID_LIST);
+        AG_TEST (ag_list_typeid(l) == AG_TYPEID_LIST);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(uuid_01, "ag_list_uuid() returns the UUID of a list")
@@ -294,54 +274,48 @@ AG_TEST_INIT(uuid_01, "ag_list_uuid() returns the UUID of a list")
         AG_AUTO(ag_uuid) *u = ag_list_uuid(l);
         AG_AUTO(ag_string) *s = ag_uuid_str(u);
 
-        AG_TEST_ASSERT (!ag_string_empty(s));
+        AG_TEST (!ag_string_empty(s));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(valid_01, "ag_list_valid() returns false for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
-        AG_TEST_ASSERT (!ag_list_valid(l));
+        AG_TEST (!ag_list_valid(l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(valid_02, "ag_list_valid() returns true for an int list")
 {
         AG_AUTO(ag_list) *l = sample_int();
 
-        AG_TEST_ASSERT (ag_list_valid(l));
+        AG_TEST (ag_list_valid(l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(sz_01, "ag_list_sz() returns 0 for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
-        AG_TEST_ASSERT (!ag_list_sz(l));
+        AG_TEST (!ag_list_sz(l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(sz_02, "ag_list_sz() returns the cumulative size of an int list")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
 
-        AG_TEST_ASSERT (ag_list_sz(l) == sizeof(ag_int) * 7);
+        AG_TEST (ag_list_sz(l) == sizeof(ag_int) * 7);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(refc_01, "ag_list_refc() returns 1 for a single instance")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
-        AG_TEST_ASSERT (ag_list_refc(l) == 1);
+        AG_TEST (ag_list_refc(l) == 1);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(refc_02,
@@ -351,18 +325,16 @@ AG_TEST_INIT(refc_02,
         AG_AUTO(ag_list) *l2 = ag_list_copy(l);
         AG_AUTO(ag_list) *l3 = ag_list_copy(l2);
 
-        AG_TEST_ASSERT (ag_list_refc(l) == 3);
+        AG_TEST (ag_list_refc(l) == 3);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(len_01, "ag_list_len() returns 0 for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
         
-        AG_TEST_ASSERT (!ag_list_len(l));
+        AG_TEST (!ag_list_len(l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(len_02,
@@ -370,18 +342,16 @@ AG_TEST_INIT(len_02,
 {
         AG_AUTO(ag_list) *l = sample_int_2();
 
-        AG_TEST_ASSERT (ag_list_len(l) == 7);
+        AG_TEST (ag_list_len(l) == 7);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(hash_01, "ag_list_hash() returns 0 for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
-        AG_TEST_ASSERT (!ag_list_hash(l));
+        AG_TEST (!ag_list_hash(l));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(hash_02,
@@ -390,9 +360,8 @@ AG_TEST_INIT(hash_02,
         AG_AUTO(ag_list) *l = sample_int();
         ag_hash h = ag_hash_new(-123) + ag_hash_new(0) + ag_hash_new(456);
 
-        AG_TEST_ASSERT (ag_list_hash(l) == h);
+        AG_TEST (ag_list_hash(l) == h);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(str_01,
@@ -401,9 +370,8 @@ AG_TEST_INIT(str_01,
         AG_AUTO(ag_list) *l = ag_list_new();
         AG_AUTO(ag_string) *s = ag_list_str(l);
 
-        AG_TEST_ASSERT (!ag_string_empty(s));
+        AG_TEST (!ag_string_empty(s));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(str_02,

--- a/test/list.c
+++ b/test/list.c
@@ -62,7 +62,60 @@ AG_TEST_INIT(copy_02, "ag_list_copy() increases the reference count by 1")
 {
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_list) *l2 = ag_list_copy(l);
+        
         AG_TEST_ASSERT (ag_list_refc(l) == 2);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(clone_01, "ag_list_clone() creates a clone of an empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+        AG_AUTO(ag_list) *l2 = ag_list_clone(l);
+
+        AG_TEST_ASSERT (l2 && l != l2);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(clone_02, "ag_list_clone() creates a clone of a sample list")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_list) *l2 = ag_list_clone(l);
+
+        AG_TEST_ASSERT (l2 && l != l2);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(clone_03, "ag_list_clone() has the same items as its parent")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_list) *l2 = ag_list_clone(l);
+
+        AG_TEST_ASSERT (ag_list_eq(l, l2));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(clone_04, "ag_list_clone() does not change the reference count")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_list) *l2 = ag_list_clone(l);
+
+        AG_TEST_ASSERT (ag_list_refc(l) == 1);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(release_04, "ag_list_dispose() reduces the reference count by 1")
+{
+        ag_list *l = sample_int();
+        AG_AUTO(ag_list) *l2 = ag_list_copy(l);
+        AG_AUTO(ag_list) *l3 = ag_list_copy(l2);
+        ag_list_release(&l);
+
+        AG_TEST_ASSERT (!l && ag_list_refc(l2) == 2);
 }
 AG_TEST_EXIT();
 
@@ -95,30 +148,29 @@ AG_TEST_INIT(release_03,
 AG_TEST_EXIT();
 
 
-AG_TEST_INIT(release_04, "ag_list_dispose() reduces the reference count by 1")
-{
-        ag_list *l = sample_int();
-        AG_AUTO(ag_list) *l2 = ag_list_copy(l);
-        AG_AUTO(ag_list) *l3 = ag_list_copy(l2);
-        ag_list_release(&l);
-
-        AG_TEST_ASSERT (!l && ag_list_refc(l2) == 2);
-}
-AG_TEST_EXIT();
-
-
-
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
-                new_01, new_02, copy_01,
-                copy_02, release_01, release_02,
-                release_03, release_04,
+                new_01, new_02, 
+                
+                copy_01, copy_02, 
+
+                clone_01, clone_02, clone_03,
+                clone_04,
+                
+                release_01, release_02, release_03, 
+                release_04,
         };
 
         const char *desc[] = {
-                new_01_desc, new_02_desc, copy_01_desc,
-                copy_02_desc, release_01_desc, release_02_desc,
+                new_01_desc, new_02_desc, 
+                
+                copy_01_desc, copy_02_desc, 
+                
+                clone_01_desc, clone_02_desc, 
+                clone_03_desc, clone_04_desc,
+                
+                release_01_desc, release_02_desc,
                 release_03_desc, release_04_desc,
         };
 

--- a/test/list.c
+++ b/test/list.c
@@ -299,6 +299,24 @@ AG_TEST_INIT(uuid_01, "ag_list_uuid() returns the UUID of a list")
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(valid_01, "ag_list_valid() returns false for an empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+
+        AG_TEST_ASSERT (!ag_list_valid(l));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(valid_02, "ag_list_valid() returns true for an int list")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+
+        AG_TEST_ASSERT (ag_list_valid(l));
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -321,6 +339,8 @@ extern ag_test_suite *test_suite_list(void)
                 empty_01, empty_02,
 
                 typeid_01, uuid_01,
+
+                valid_01, valid_02,
         };
 
         const char *desc[] = {
@@ -346,6 +366,8 @@ extern ag_test_suite *test_suite_list(void)
                 empty_01_desc, empty_02_desc,
 
                 typeid_01_desc, uuid_01_desc,
+
+                valid_01_desc, valid_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -412,9 +412,8 @@ AG_TEST_INIT(str_02,
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_string) *s = ag_list_str(l);
 
-        AG_TEST_ASSERT (!ag_string_empty(s));
+        AG_TEST (!ag_string_empty(s));
 }
-AG_TEST_EXIT();
 
 
 extern ag_test_suite *test_suite_list(void)

--- a/test/list.c
+++ b/test/list.c
@@ -190,6 +190,41 @@ AG_TEST_INIT(lt_03,
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(eq_01, 
+    "ag_list_eq() returns true if two lists are lexicographically equal")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l2 = sample_int();
+
+        AG_TEST_ASSERT (ag_list_eq(l, l2));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_02, 
+    "ag_list_eq() returns false if a list is lexicographically less than"
+     " another")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l2 = sample_int_2();
+
+        AG_TEST_ASSERT (!ag_list_eq(l, l2));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(eq_03,
+    "ag_list_eq() returns false if a list is lexicographically greater than"
+    " another")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_list) *l2 = sample_int();
+
+        AG_TEST_ASSERT (!ag_list_eq(l2, l));
+}
+AG_TEST_EXIT();
+
+
 AG_TEST_INIT(gt_01, 
     "ag_list_lt() returns true if a list is lexicographically greater than"
     " another")
@@ -241,6 +276,8 @@ extern ag_test_suite *test_suite_list(void)
 
                 lt_01, lt_02, lt_03,
                 
+                eq_01, eq_02, eq_03,
+                
                 gt_01, gt_02, gt_03,
         };
 
@@ -257,6 +294,9 @@ extern ag_test_suite *test_suite_list(void)
 
                 lt_01_desc, lt_02_desc,
                 lt_03_desc,
+                
+                eq_01_desc, eq_02_desc,
+                eq_03_desc,
                 
                 gt_01_desc, gt_02_desc,
                 gt_03_desc,

--- a/test/list.c
+++ b/test/list.c
@@ -39,21 +39,21 @@ static ag_list *sample_int_2(void)
 }
 
 
-AG_TEST_INIT(new_01, "ag_list_new() can create a new sample list")
+AG_TEST_CASE(new_01, "ag_list_new() can create a new sample list")
 {
         AG_AUTO(ag_list) *l = sample_int();
         AG_TEST (l && ag_list_len(l) == 3);
 }
 
 
-AG_TEST_INIT(new_02, "ag_list_new() can create a new empty list")
+AG_TEST_CASE(new_02, "ag_list_new() can create a new empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
         AG_TEST (l && ag_list_empty(l));
 }
 
 
-AG_TEST_INIT(copy_01, "ag_list_copy() creates a shallow copy of a sample list")
+AG_TEST_CASE(copy_01, "ag_list_copy() creates a shallow copy of a sample list")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = ag_list_copy(l);
@@ -62,7 +62,7 @@ AG_TEST_INIT(copy_01, "ag_list_copy() creates a shallow copy of a sample list")
 }
 
 
-AG_TEST_INIT(copy_02, "ag_list_copy() increases the reference count by 1")
+AG_TEST_CASE(copy_02, "ag_list_copy() increases the reference count by 1")
 {
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_list) *l2 = ag_list_copy(l);
@@ -71,7 +71,7 @@ AG_TEST_INIT(copy_02, "ag_list_copy() increases the reference count by 1")
 }
 
 
-AG_TEST_INIT(clone_01, "ag_list_clone() creates a clone of an empty list")
+AG_TEST_CASE(clone_01, "ag_list_clone() creates a clone of an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
         AG_AUTO(ag_list) *l2 = ag_list_clone(l);
@@ -80,7 +80,7 @@ AG_TEST_INIT(clone_01, "ag_list_clone() creates a clone of an empty list")
 }
 
 
-AG_TEST_INIT(clone_02, "ag_list_clone() creates a clone of a sample list")
+AG_TEST_CASE(clone_02, "ag_list_clone() creates a clone of a sample list")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = ag_list_clone(l);
@@ -89,7 +89,7 @@ AG_TEST_INIT(clone_02, "ag_list_clone() creates a clone of a sample list")
 }
 
 
-AG_TEST_INIT(clone_03, "ag_list_clone() has the same items as its parent")
+AG_TEST_CASE(clone_03, "ag_list_clone() has the same items as its parent")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = ag_list_clone(l);
@@ -98,7 +98,7 @@ AG_TEST_INIT(clone_03, "ag_list_clone() has the same items as its parent")
 }
 
 
-AG_TEST_INIT(clone_04, "ag_list_clone() does not change the reference count")
+AG_TEST_CASE(clone_04, "ag_list_clone() does not change the reference count")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = ag_list_clone(l);
@@ -107,7 +107,7 @@ AG_TEST_INIT(clone_04, "ag_list_clone() does not change the reference count")
 }
 
 
-AG_TEST_INIT(release_04, "ag_list_dispose() reduces the reference count by 1")
+AG_TEST_CASE(release_04, "ag_list_dispose() reduces the reference count by 1")
 {
         ag_list *l = sample_int();
         AG_AUTO(ag_list) *l2 = ag_list_copy(l);
@@ -118,7 +118,7 @@ AG_TEST_INIT(release_04, "ag_list_dispose() reduces the reference count by 1")
 }
 
 
-AG_TEST_INIT(release_01, "ag_list_release() performs a no-op if passed NULL")
+AG_TEST_CASE(release_01, "ag_list_release() performs a no-op if passed NULL")
 {
         ag_list_release(NULL);
         
@@ -126,7 +126,7 @@ AG_TEST_INIT(release_01, "ag_list_release() performs a no-op if passed NULL")
 }
 
 
-AG_TEST_INIT(release_02, 
+AG_TEST_CASE(release_02, 
     "ag_list_release() performs a no-op if passed a handle to NULL")
 {
         ag_list *l = NULL;
@@ -136,7 +136,7 @@ AG_TEST_INIT(release_02,
 }
 
 
-AG_TEST_INIT(release_03,
+AG_TEST_CASE(release_03,
     "ag_list_reelease() disposes a single instance of a list")
 {
         ag_list *l = sample_int();
@@ -146,7 +146,7 @@ AG_TEST_INIT(release_03,
 }
 
 
-AG_TEST_INIT(lt_01, 
+AG_TEST_CASE(lt_01, 
     "ag_list_lt() returns true if a list is lexicographically smaller than"
     " another")
 {
@@ -157,7 +157,7 @@ AG_TEST_INIT(lt_01,
 }
 
 
-AG_TEST_INIT(lt_02, 
+AG_TEST_CASE(lt_02, 
     "ag_list_lt() returns false if a list is lexicographically equal to"
      " another")
 {
@@ -168,7 +168,7 @@ AG_TEST_INIT(lt_02,
 }
 
 
-AG_TEST_INIT(lt_03,
+AG_TEST_CASE(lt_03,
     "ag_list_lt() returns false if a list is lexicographically greater than"
     " another")
 {
@@ -179,7 +179,7 @@ AG_TEST_INIT(lt_03,
 }
 
 
-AG_TEST_INIT(eq_01, 
+AG_TEST_CASE(eq_01, 
     "ag_list_eq() returns true if two lists are lexicographically equal")
 {
         AG_AUTO(ag_list) *l = sample_int();
@@ -189,7 +189,7 @@ AG_TEST_INIT(eq_01,
 }
 
 
-AG_TEST_INIT(eq_02, 
+AG_TEST_CASE(eq_02, 
     "ag_list_eq() returns false if a list is lexicographically less than"
      " another")
 {
@@ -200,7 +200,7 @@ AG_TEST_INIT(eq_02,
 }
 
 
-AG_TEST_INIT(eq_03,
+AG_TEST_CASE(eq_03,
     "ag_list_eq() returns false if a list is lexicographically greater than"
     " another")
 {
@@ -211,7 +211,7 @@ AG_TEST_INIT(eq_03,
 }
 
 
-AG_TEST_INIT(gt_01, 
+AG_TEST_CASE(gt_01, 
     "ag_list_lt() returns true if a list is lexicographically greater than"
     " another")
 {
@@ -222,7 +222,7 @@ AG_TEST_INIT(gt_01,
 }
 
 
-AG_TEST_INIT(gt_02, 
+AG_TEST_CASE(gt_02, 
     "ag_list_gt() returns false if a list is lexicographically equal to"
      " another")
 {
@@ -233,7 +233,7 @@ AG_TEST_INIT(gt_02,
 }
 
 
-AG_TEST_INIT(gt_03,
+AG_TEST_CASE(gt_03,
     "ag_list_gt() returns false if a list is lexicographically less than"
     " another")
 {
@@ -244,7 +244,7 @@ AG_TEST_INIT(gt_03,
 }
 
 
-AG_TEST_INIT(empty_01, "ag_list_empty() returns true for an empty list")
+AG_TEST_CASE(empty_01, "ag_list_empty() returns true for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
@@ -252,7 +252,7 @@ AG_TEST_INIT(empty_01, "ag_list_empty() returns true for an empty list")
 }
 
 
-AG_TEST_INIT(empty_02, "ag_list_empty() returns false for a non-empty list")
+AG_TEST_CASE(empty_02, "ag_list_empty() returns false for a non-empty list")
 {
         AG_AUTO(ag_list) *l = sample_int();
 
@@ -260,7 +260,7 @@ AG_TEST_INIT(empty_02, "ag_list_empty() returns false for a non-empty list")
 }
 
 
-AG_TEST_INIT(typeid_01, "ag_list_typeid() returns AG_TYPEID_LIST")
+AG_TEST_CASE(typeid_01, "ag_list_typeid() returns AG_TYPEID_LIST")
 {
         AG_AUTO(ag_list) *l = sample_int();
 
@@ -268,7 +268,7 @@ AG_TEST_INIT(typeid_01, "ag_list_typeid() returns AG_TYPEID_LIST")
 }
 
 
-AG_TEST_INIT(uuid_01, "ag_list_uuid() returns the UUID of a list")
+AG_TEST_CASE(uuid_01, "ag_list_uuid() returns the UUID of a list")
 {
         AG_AUTO(ag_list) *l = sample_int();
         AG_AUTO(ag_uuid) *u = ag_list_uuid(l);
@@ -278,7 +278,7 @@ AG_TEST_INIT(uuid_01, "ag_list_uuid() returns the UUID of a list")
 }
 
 
-AG_TEST_INIT(valid_01, "ag_list_valid() returns false for an empty list")
+AG_TEST_CASE(valid_01, "ag_list_valid() returns false for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
@@ -286,7 +286,7 @@ AG_TEST_INIT(valid_01, "ag_list_valid() returns false for an empty list")
 }
 
 
-AG_TEST_INIT(valid_02, "ag_list_valid() returns true for an int list")
+AG_TEST_CASE(valid_02, "ag_list_valid() returns true for an int list")
 {
         AG_AUTO(ag_list) *l = sample_int();
 
@@ -294,7 +294,7 @@ AG_TEST_INIT(valid_02, "ag_list_valid() returns true for an int list")
 }
 
 
-AG_TEST_INIT(sz_01, "ag_list_sz() returns 0 for an empty list")
+AG_TEST_CASE(sz_01, "ag_list_sz() returns 0 for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
@@ -302,7 +302,7 @@ AG_TEST_INIT(sz_01, "ag_list_sz() returns 0 for an empty list")
 }
 
 
-AG_TEST_INIT(sz_02, "ag_list_sz() returns the cumulative size of an int list")
+AG_TEST_CASE(sz_02, "ag_list_sz() returns the cumulative size of an int list")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
 
@@ -310,7 +310,7 @@ AG_TEST_INIT(sz_02, "ag_list_sz() returns the cumulative size of an int list")
 }
 
 
-AG_TEST_INIT(refc_01, "ag_list_refc() returns 1 for a single instance")
+AG_TEST_CASE(refc_01, "ag_list_refc() returns 1 for a single instance")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
@@ -318,7 +318,7 @@ AG_TEST_INIT(refc_01, "ag_list_refc() returns 1 for a single instance")
 }
 
 
-AG_TEST_INIT(refc_02,
+AG_TEST_CASE(refc_02,
     "ag_list_refc() returns the reference count of a shallow copy")
 {
         AG_AUTO(ag_list) *l = sample_int();
@@ -329,7 +329,7 @@ AG_TEST_INIT(refc_02,
 }
 
 
-AG_TEST_INIT(len_01, "ag_list_len() returns 0 for an empty list")
+AG_TEST_CASE(len_01, "ag_list_len() returns 0 for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
         
@@ -337,7 +337,7 @@ AG_TEST_INIT(len_01, "ag_list_len() returns 0 for an empty list")
 }
 
 
-AG_TEST_INIT(len_02,
+AG_TEST_CASE(len_02,
     "ag_list_len() returns the number of values in a non empty list")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
@@ -346,7 +346,7 @@ AG_TEST_INIT(len_02,
 }
 
 
-AG_TEST_INIT(hash_01, "ag_list_hash() returns 0 for an empty list")
+AG_TEST_CASE(hash_01, "ag_list_hash() returns 0 for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
 
@@ -354,7 +354,7 @@ AG_TEST_INIT(hash_01, "ag_list_hash() returns 0 for an empty list")
 }
 
 
-AG_TEST_INIT(hash_02,
+AG_TEST_CASE(hash_02,
     "ag_list_hash() returns the cumulative hash for an int list")
 {
         AG_AUTO(ag_list) *l = sample_int();
@@ -364,7 +364,7 @@ AG_TEST_INIT(hash_02,
 }
 
 
-AG_TEST_INIT(str_01,
+AG_TEST_CASE(str_01,
     "ag_list_str() generates a string representation for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
@@ -374,7 +374,7 @@ AG_TEST_INIT(str_01,
 }
 
 
-AG_TEST_INIT(str_02,
+AG_TEST_CASE(str_02,
     "ag_list_str() generates a string representation of an int list")
 {
         AG_AUTO(ag_list) *l = sample_int_2();

--- a/test/list.c
+++ b/test/list.c
@@ -396,6 +396,15 @@ AG_TEST_CASE(get_01, "ag_list_get() gets the currently iterated value")
 }
 
 
+AG_TEST_CASE(get_at_01, "ag_list_get_at() gets the value at a given index")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_value) *v = ag_list_get_at(l, 7);
+
+        AG_TEST (ag_value_int(v) == 734);
+}
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -418,6 +427,7 @@ extern ag_test_suite *test_suite_list(void)
                 hash_01,        hash_02,
                 str_01,         str_02,
                 get_01,
+                get_at_01,
         };
 
         const char *desc[] = {
@@ -442,6 +452,7 @@ extern ag_test_suite *test_suite_list(void)
                 hash_01_desc,           hash_02_desc,
                 str_01_desc,            str_02_desc,
                 get_01_desc,
+                get_at_01_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -18,16 +18,22 @@ static ag_list *sample_int(void)
 
 static ag_list *sample_int_2(void)
 {
-        AG_AUTO(ag_value) *v1 = ag_value_new_int(-666);
+        AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(0);
-        AG_AUTO(ag_value) *v3 = ag_value_new_int(555);
-        AG_AUTO(ag_value) *v4 = ag_value_new_int(734);
+        AG_AUTO(ag_value) *v3 = ag_value_new_int(456);
+        AG_AUTO(ag_value) *v4 = ag_value_new_int(-666);
+        AG_AUTO(ag_value) *v5 = ag_value_new_int(0);
+        AG_AUTO(ag_value) *v6 = ag_value_new_int(555);
+        AG_AUTO(ag_value) *v7 = ag_value_new_int(734);
 
         AG_AUTO(ag_list) *l = ag_list_new();
         ag_list_push(&l, v1);
         ag_list_push(&l, v2);
         ag_list_push(&l, v3);
         ag_list_push(&l, v4);
+        ag_list_push(&l, v5);
+        ag_list_push(&l, v6);
+        ag_list_push(&l, v7);
 
         return ag_list_copy(l);
 }
@@ -148,6 +154,42 @@ AG_TEST_INIT(release_03,
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(lt_01, 
+    "ag_list_lt() returns true if a list is lexicographically smaller than"
+    " another")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l2 = sample_int_2();
+
+        AG_TEST_ASSERT (ag_list_lt(l, l2));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_02, 
+    "ag_list_lt() returns false if a list is lexicographically equal to"
+     " another")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l2 = sample_int();
+
+        AG_TEST_ASSERT (!ag_list_lt(l, l2));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(lt_03,
+    "ag_list_lt() returns false if a list is lexicographically greater than"
+    " another")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_list) *l2 = sample_int();
+
+        AG_TEST_ASSERT (!ag_list_lt(l, l2));
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -160,6 +202,8 @@ extern ag_test_suite *test_suite_list(void)
                 
                 release_01, release_02, release_03, 
                 release_04,
+
+                lt_01, lt_02, lt_03,
         };
 
         const char *desc[] = {
@@ -172,6 +216,9 @@ extern ag_test_suite *test_suite_list(void)
                 
                 release_01_desc, release_02_desc,
                 release_03_desc, release_04_desc,
+
+                lt_01_desc, lt_02_desc,
+                lt_03_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -384,6 +384,18 @@ AG_TEST_CASE(str_02,
 }
 
 
+AG_TEST_CASE(get_01, "ag_list_get() gets the currently iterated value")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        ag_list_start(&l);
+        ag_list_next(&l);
+        ag_list_next(&l);
+        AG_AUTO(ag_value) *v = ag_list_get(l);
+
+        AG_TEST (ag_value_int(v) == 456);
+}
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -405,6 +417,7 @@ extern ag_test_suite *test_suite_list(void)
                 len_01,         len_02,
                 hash_01,        hash_02,
                 str_01,         str_02,
+                get_01,
         };
 
         const char *desc[] = {
@@ -428,6 +441,7 @@ extern ag_test_suite *test_suite_list(void)
                 len_01_desc,            len_02_desc,
                 hash_01_desc,           hash_02_desc,
                 str_01_desc,            str_02_desc,
+                get_01_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -434,7 +434,7 @@ AG_TEST_CASE(map_02, "ag_list_map() iterates through a non-empty list")
 }
 
 
-AG_TEST_CASE(set_01, "ag_list_get() sets the currently iterated value")
+AG_TEST_CASE(set_01, "ag_list_set() sets the currently iterated value")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_value) *v = ag_value_new_int(1234);
@@ -450,7 +450,16 @@ AG_TEST_CASE(set_01, "ag_list_get() sets the currently iterated value")
 }
 
 
+AG_TEST_CASE(set_at_01, "ag_list_set_at() sets the value at a given index")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_value) *v = ag_value_new_int(1234);
+        
+        ag_list_set_at(&l, v, 3);
+        AG_AUTO(ag_value) *v2 = ag_list_get_at(l, 3);
 
+        AG_TEST (ag_value_int(v2) == 1234);
+}
 
 extern ag_test_suite *test_suite_list(void)
 {
@@ -477,6 +486,7 @@ extern ag_test_suite *test_suite_list(void)
                 get_at_01,
                 map_01,         map_02,
                 set_01,
+                set_at_01,
         };
 
         const char *desc[] = {
@@ -504,6 +514,7 @@ extern ag_test_suite *test_suite_list(void)
                 get_at_01_desc,
                 map_01_desc,            map_02_desc,
                 set_01_desc,
+                set_at_01_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -279,6 +279,26 @@ AG_TEST_INIT(empty_02, "ag_list_empty() returns false for a non-empty list")
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(typeid_01, "ag_list_typeid() returns AG_TYPEID_LIST")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+
+        AG_TEST_ASSERT (ag_list_typeid(l) == AG_TYPEID_LIST);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(uuid_01, "ag_list_uuid() returns the UUID of a list")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_uuid) *u = ag_list_uuid(l);
+        AG_AUTO(ag_string) *s = ag_uuid_str(u);
+
+        AG_TEST_ASSERT (!ag_string_empty(s));
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -299,6 +319,8 @@ extern ag_test_suite *test_suite_list(void)
                 gt_01, gt_02, gt_03,
 
                 empty_01, empty_02,
+
+                typeid_01, uuid_01,
         };
 
         const char *desc[] = {
@@ -322,6 +344,8 @@ extern ag_test_suite *test_suite_list(void)
                 gt_03_desc,
 
                 empty_01_desc, empty_02_desc,
+
+                typeid_01_desc, uuid_01_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -395,6 +395,28 @@ AG_TEST_INIT(hash_02,
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(str_01,
+    "ag_list_str() generates a string representation for an empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+        AG_AUTO(ag_string) *s = ag_list_str(l);
+
+        AG_TEST_ASSERT (!ag_string_empty(s));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(str_02,
+    "ag_list_str() generates a string representation of an int list")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+        AG_AUTO(ag_string) *s = ag_list_str(l);
+
+        AG_TEST_ASSERT (!ag_string_empty(s));
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -427,6 +449,8 @@ extern ag_test_suite *test_suite_list(void)
                 len_01, len_02,
 
                 hash_01, hash_02,
+
+                str_01, str_02,
         };
 
         const char *desc[] = {
@@ -462,6 +486,8 @@ extern ag_test_suite *test_suite_list(void)
                 len_01_desc, len_02_desc,
 
                 hash_01_desc, hash_02_desc,
+
+                str_01_desc, str_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -48,6 +48,16 @@ static void iterator(const ag_value *val, void *opt)
 }
 
 
+static void iterator_mutable(ag_value **val, void *opt)
+{
+        (void)opt;
+        
+        AG_AUTO(ag_value) *v = ag_value_new_int(5);
+        ag_value_release(val);
+        *val = ag_value_copy(v);
+}
+
+
 AG_TEST_CASE(new_01, "ag_list_new() can create a new sample list")
 {
         AG_AUTO(ag_list) *l = sample_int();
@@ -461,6 +471,33 @@ AG_TEST_CASE(set_at_01, "ag_list_set_at() sets the value at a given index")
         AG_TEST (ag_value_int(v2) == 1234);
 }
 
+
+AG_TEST_CASE(map_mutable_01, 
+    "ag_list_map_mutable() has no effect on an empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+        ag_int sum = 0;
+
+        ag_list_map_mutable(&l, iterator_mutable, NULL);
+        ag_list_map(l, iterator, &sum);
+
+        AG_TEST (!sum);
+}
+
+
+AG_TEST_CASE(map_mutable_02, 
+    "ag_list_map_mutable() iterates through a non-empty list")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+        ag_int sum = 0;
+
+        ag_list_map_mutable(&l, iterator_mutable, NULL);
+        ag_list_map(l, iterator, &sum);
+
+        AG_TEST (sum == 15);
+}
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -487,6 +524,7 @@ extern ag_test_suite *test_suite_list(void)
                 map_01,         map_02,
                 set_01,
                 set_at_01,
+                map_mutable_01, map_mutable_02,
         };
 
         const char *desc[] = {
@@ -515,6 +553,7 @@ extern ag_test_suite *test_suite_list(void)
                 map_01_desc,            map_02_desc,
                 set_01_desc,
                 set_at_01_desc,
+                map_mutable_01_desc,    map_mutable_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -261,6 +261,24 @@ AG_TEST_INIT(gt_03,
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(empty_01, "ag_list_empty() returns true for an empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+
+        AG_TEST_ASSERT (ag_list_empty(l));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(empty_02, "ag_list_empty() returns false for a non-empty list")
+{
+        AG_AUTO(ag_list) *l = sample_int();
+
+        AG_TEST_ASSERT (!ag_list_empty(l));
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -279,6 +297,8 @@ extern ag_test_suite *test_suite_list(void)
                 eq_01, eq_02, eq_03,
                 
                 gt_01, gt_02, gt_03,
+
+                empty_01, empty_02,
         };
 
         const char *desc[] = {
@@ -300,6 +320,8 @@ extern ag_test_suite *test_suite_list(void)
                 
                 gt_01_desc, gt_02_desc,
                 gt_03_desc,
+
+                empty_01_desc, empty_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -387,74 +387,47 @@ AG_TEST_CASE(str_02,
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
-                new_01, new_02, 
-                
-                copy_01, copy_02, 
-
-                clone_01, clone_02, clone_03,
+                new_01,         new_02, 
+                copy_01,        copy_02, 
+                clone_01,       clone_02,       clone_03,
                 clone_04,
-                
-                release_01, release_02, release_03, 
+                release_01,     release_02,     release_03,
                 release_04,
-
-                lt_01, lt_02, lt_03,
-                
-                eq_01, eq_02, eq_03,
-                
-                gt_01, gt_02, gt_03,
-
-                empty_01, empty_02,
-
-                typeid_01, uuid_01,
-
-                valid_01, valid_02,
-
-                sz_01, sz_02,
-
-                refc_01, refc_02,
-
-                len_01, len_02,
-
-                hash_01, hash_02,
-
-                str_01, str_02,
+                lt_01,          lt_02,          lt_03,
+                eq_01,          eq_02,          eq_03,
+                gt_01,          gt_02,          gt_03,
+                empty_01,       empty_02,
+                typeid_01, 
+                uuid_01,
+                valid_01,       valid_02,
+                sz_01,          sz_02,
+                refc_01,        refc_02,
+                len_01,         len_02,
+                hash_01,        hash_02,
+                str_01,         str_02,
         };
 
         const char *desc[] = {
-                new_01_desc, new_02_desc, 
-                
-                copy_01_desc, copy_02_desc, 
-                
-                clone_01_desc, clone_02_desc, 
-                clone_03_desc, clone_04_desc,
-                
-                release_01_desc, release_02_desc,
-                release_03_desc, release_04_desc,
-
-                lt_01_desc, lt_02_desc,
+                new_01_desc,            new_02_desc, 
+                copy_01_desc,           copy_02_desc, 
+                clone_01_desc,          clone_02_desc, 
+                clone_03_desc,          clone_04_desc,
+                release_01_desc,        release_02_desc,
+                release_03_desc,        release_04_desc,
+                lt_01_desc,             lt_02_desc,
                 lt_03_desc,
-                
-                eq_01_desc, eq_02_desc,
+                eq_01_desc,             eq_02_desc,
                 eq_03_desc,
-                
-                gt_01_desc, gt_02_desc,
+                gt_01_desc,             gt_02_desc,
                 gt_03_desc,
-
-                empty_01_desc, empty_02_desc,
-
-                typeid_01_desc, uuid_01_desc,
-
-                valid_01_desc, valid_02_desc,
-
-                sz_01_desc, sz_02_desc,
-
-                refc_01_desc, refc_02_desc,
-
-                len_01_desc, len_02_desc,
-
-                hash_01_desc, hash_02_desc,
-
-                str_01_desc, str_02_desc,
+                empty_01_desc,          empty_02_desc,
+                typeid_01_desc,         uuid_01_desc,
+                valid_01_desc,          valid_02_desc,
+                sz_01_desc,             sz_02_desc,
+                refc_01_desc,           refc_02_desc,
+                len_01_desc,            len_02_desc,
+                hash_01_desc,           hash_02_desc,
+                str_01_desc,            str_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -1,61 +1,53 @@
+/*-
+ * SPDX-License-Identifier: GPL-3.0-only
+ *
+ * Argent - infrastructure for building web services
+ * Copyright (C) 2020 Abhishek Chakravarti
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTIBILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
+ */
+
+
 #include "./test.h"
 
 
-static ag_list *sample_int(void)
-{
-        AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
-        AG_AUTO(ag_value) *v2 = ag_value_new_int(0);
-        AG_AUTO(ag_value) *v3 = ag_value_new_int(456);
-
-        AG_AUTO(ag_list) *l = ag_list_new();
-        ag_list_push(&l, v1);
-        ag_list_push(&l, v2);
-        ag_list_push(&l, v3);
-
-        return ag_list_copy(l);
-}
+/* 
+ * Declare the prototypes for generating sample integer lists. Both functions
+ * generate sample integer lists, but with differing lengths.
+ */
 
 
-static ag_list *sample_int_2(void)
-{
-        AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
-        AG_AUTO(ag_value) *v2 = ag_value_new_int(0);
-        AG_AUTO(ag_value) *v3 = ag_value_new_int(456);
-        AG_AUTO(ag_value) *v4 = ag_value_new_int(-666);
-        AG_AUTO(ag_value) *v5 = ag_value_new_int(0);
-        AG_AUTO(ag_value) *v6 = ag_value_new_int(555);
-        AG_AUTO(ag_value) *v7 = ag_value_new_int(734);
-
-        AG_AUTO(ag_list) *l = ag_list_new();
-        ag_list_push(&l, v1);
-        ag_list_push(&l, v2);
-        ag_list_push(&l, v3);
-        ag_list_push(&l, v4);
-        ag_list_push(&l, v5);
-        ag_list_push(&l, v6);
-        ag_list_push(&l, v7);
-
-        return ag_list_copy(l);
-}
+static ag_list *sample_int(void);
+static ag_list *sample_int_2(void);
 
 
-static void iterator(const ag_value *val, void *opt)
-{
-        ag_int *s = opt;
-        ag_int i = ag_value_int(val);
-        *s += i;
-
-}
+/*
+ * Declare the protoptypes for the iterator functions that are used to test out
+ * the map functions of lists. iterator() helps test out ag_list_map(), whereas
+ * iterator_mutable helps test ag_list_map_mutable().
+ */
 
 
-static void iterator_mutable(ag_value **val, void *opt)
-{
-        (void)opt;
-        
-        AG_AUTO(ag_value) *v = ag_value_new_int(5);
-        ag_value_release(val);
-        *val = ag_value_copy(v);
-}
+static void iterator(const ag_value *, void *);
+static void iterator_mutable(ag_value **, void *);
+
+
+/* 
+ * Define the test cases for ag_list_new(). 
+ */
 
 
 AG_TEST_CASE(new_01, "ag_list_new() can create a new sample list")
@@ -70,6 +62,11 @@ AG_TEST_CASE(new_02, "ag_list_new() can create a new empty list")
         AG_AUTO(ag_list) *l = ag_list_new();
         AG_TEST (l && ag_list_empty(l));
 }
+
+
+/* 
+ * Define the test cases for ag_list_copy(). 
+ */
 
 
 AG_TEST_CASE(copy_01, "ag_list_copy() creates a shallow copy of a sample list")
@@ -88,6 +85,11 @@ AG_TEST_CASE(copy_02, "ag_list_copy() increases the reference count by 1")
         
         AG_TEST (ag_list_refc(l) == 2);
 }
+
+
+/*
+ * Define the test cases for ag_list_clone().
+ */
 
 
 AG_TEST_CASE(clone_01, "ag_list_clone() creates a clone of an empty list")
@@ -124,6 +126,11 @@ AG_TEST_CASE(clone_04, "ag_list_clone() does not change the reference count")
 
         AG_TEST (ag_list_refc(l) == 1);
 }
+
+
+/*
+ * Define the test cases for ag_list_release().
+ */
 
 
 AG_TEST_CASE(release_04, "ag_list_dispose() reduces the reference count by 1")
@@ -165,6 +172,12 @@ AG_TEST_CASE(release_03,
 }
 
 
+/*
+ * Define the the test cases for ag_list_lt(). Note that since ag_list_lt() is a
+ * specialised case of ag_list_cmp(), it helps to test test ag_list_cmp() too.
+ */
+
+
 AG_TEST_CASE(lt_01, 
     "ag_list_lt() returns true if a list is lexicographically smaller than"
     " another")
@@ -198,6 +211,13 @@ AG_TEST_CASE(lt_03,
 }
 
 
+/*
+ * Define the test cases for ag_list_eq(). Since ag_list_eq() is a specialised
+ * case of ag_list_cmp(), this these test cases also indirectly help test out
+ * ag_list_cmp().
+ */
+
+
 AG_TEST_CASE(eq_01, 
     "ag_list_eq() returns true if two lists are lexicographically equal")
 {
@@ -228,6 +248,13 @@ AG_TEST_CASE(eq_03,
 
         AG_TEST (!ag_list_eq(l2, l));
 }
+
+
+/*
+ * Define the test cases for ag_list_gt(). Together with the test cases for
+ * ag_list_lt() and ag_list_eq(), the test cases for ag_list_gt() help test out
+ * ag_list_cmp() in a reasonably complete manner.
+ */
 
 
 AG_TEST_CASE(gt_01, 
@@ -263,6 +290,11 @@ AG_TEST_CASE(gt_03,
 }
 
 
+/*
+ * Define the test cases for ag_list_empty().
+ */
+
+
 AG_TEST_CASE(empty_01, "ag_list_empty() returns true for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
@@ -279,12 +311,22 @@ AG_TEST_CASE(empty_02, "ag_list_empty() returns false for a non-empty list")
 }
 
 
+/*
+ * Define the test case for ag_list_typeid().
+ */
+
+
 AG_TEST_CASE(typeid_01, "ag_list_typeid() returns AG_TYPEID_LIST")
 {
         AG_AUTO(ag_list) *l = sample_int();
 
         AG_TEST (ag_list_typeid(l) == AG_TYPEID_LIST);
 }
+
+
+/*
+ * Define the test case for ag_list_uuid().
+ */
 
 
 AG_TEST_CASE(uuid_01, "ag_list_uuid() returns the UUID of a list")
@@ -295,6 +337,11 @@ AG_TEST_CASE(uuid_01, "ag_list_uuid() returns the UUID of a list")
 
         AG_TEST (!ag_string_empty(s));
 }
+
+
+/*
+ * Define the test cases for ag_list_valid().
+ */
 
 
 AG_TEST_CASE(valid_01, "ag_list_valid() returns false for an empty list")
@@ -313,6 +360,11 @@ AG_TEST_CASE(valid_02, "ag_list_valid() returns true for an int list")
 }
 
 
+/*
+ * Define the test cases for ag_list_sz().
+ */
+
+
 AG_TEST_CASE(sz_01, "ag_list_sz() returns 0 for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
@@ -327,6 +379,11 @@ AG_TEST_CASE(sz_02, "ag_list_sz() returns the cumulative size of an int list")
 
         AG_TEST (ag_list_sz(l) == sizeof(ag_int) * 7);
 }
+
+
+/*
+ * Define the test cases for ag_list_refc().
+ */
 
 
 AG_TEST_CASE(refc_01, "ag_list_refc() returns 1 for a single instance")
@@ -348,6 +405,11 @@ AG_TEST_CASE(refc_02,
 }
 
 
+/*
+ * Define the test cases for ag_list_len().
+ */
+
+
 AG_TEST_CASE(len_01, "ag_list_len() returns 0 for an empty list")
 {
         AG_AUTO(ag_list) *l = ag_list_new();
@@ -363,6 +425,11 @@ AG_TEST_CASE(len_02,
 
         AG_TEST (ag_list_len(l) == 7);
 }
+
+
+/*
+ * Define the test cases for ag_list_hash().
+ */
 
 
 AG_TEST_CASE(hash_01, "ag_list_hash() returns 0 for an empty list")
@@ -381,6 +448,11 @@ AG_TEST_CASE(hash_02,
 
         AG_TEST (ag_list_hash(l) == h);
 }
+
+
+/*
+ * Define the test cases for ag_list_str().
+ */
 
 
 AG_TEST_CASE(str_01,
@@ -403,6 +475,11 @@ AG_TEST_CASE(str_02,
 }
 
 
+/*
+ * Define the test case for ag_list_get().
+ */
+
+
 AG_TEST_CASE(get_01, "ag_list_get() gets the currently iterated value")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
@@ -415,6 +492,11 @@ AG_TEST_CASE(get_01, "ag_list_get() gets the currently iterated value")
 }
 
 
+/*
+ * Define the test case for ag_list_get_at().
+ */
+
+
 AG_TEST_CASE(get_at_01, "ag_list_get_at() gets the value at a given index")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
@@ -422,6 +504,11 @@ AG_TEST_CASE(get_at_01, "ag_list_get_at() gets the value at a given index")
 
         AG_TEST (ag_value_int(v) == 734);
 }
+
+
+/*
+ * Define the test cases for ag_list_map().
+ */
 
 
 AG_TEST_CASE(map_01, "ag_list_map() has no effect on an empty list")
@@ -444,6 +531,11 @@ AG_TEST_CASE(map_02, "ag_list_map() iterates through a non-empty list")
 }
 
 
+/*
+ * Define the test case for ag_list_set().
+ */
+
+
 AG_TEST_CASE(set_01, "ag_list_set() sets the currently iterated value")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
@@ -460,6 +552,11 @@ AG_TEST_CASE(set_01, "ag_list_set() sets the currently iterated value")
 }
 
 
+/*
+ * Define the test case for ag_list_set_at().
+ */
+
+
 AG_TEST_CASE(set_at_01, "ag_list_set_at() sets the value at a given index")
 {
         AG_AUTO(ag_list) *l = sample_int_2();
@@ -470,6 +567,11 @@ AG_TEST_CASE(set_at_01, "ag_list_set_at() sets the value at a given index")
 
         AG_TEST (ag_value_int(v2) == 1234);
 }
+
+
+/*
+ * Define the test cases for ag_list_map_mutable().
+ */
 
 
 AG_TEST_CASE(map_mutable_01, 
@@ -496,6 +598,14 @@ AG_TEST_CASE(map_mutable_02,
 
         AG_TEST (sum == 15);
 }
+
+
+/*
+ * Define the test_suite_list() testing interface function. This function is
+ * responsible for creating a test suite from the test cases defined above.
+ *
+ * TODO: figure out how to get rid of this function.
+ */
 
 
 extern ag_test_suite *test_suite_list(void)
@@ -560,5 +670,88 @@ extern ag_test_suite *test_suite_list(void)
         ag_test_suite_push_array(ctx, test, desc, sizeof test / sizeof *test);
 
         return ctx;
+}
+
+
+/*
+ * Define the sample_int() helper function. This function is used by the test
+ * cases defined above to generate a new sample integer list with 3 values.
+ */
+
+
+static ag_list *sample_int(void)
+{
+        AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
+        AG_AUTO(ag_value) *v2 = ag_value_new_int(0);
+        AG_AUTO(ag_value) *v3 = ag_value_new_int(456);
+
+        AG_AUTO(ag_list) *l = ag_list_new();
+        ag_list_push(&l, v1);
+        ag_list_push(&l, v2);
+        ag_list_push(&l, v3);
+
+        return ag_list_copy(l);
+}
+
+
+/*
+ * Define the sample_int_2() helper function. This function is similar to the
+ * sample_int() helper function, generating a sample integer list with 7 values.
+ */
+
+
+static ag_list *sample_int_2(void)
+{
+        AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
+        AG_AUTO(ag_value) *v2 = ag_value_new_int(0);
+        AG_AUTO(ag_value) *v3 = ag_value_new_int(456);
+        AG_AUTO(ag_value) *v4 = ag_value_new_int(-666);
+        AG_AUTO(ag_value) *v5 = ag_value_new_int(0);
+        AG_AUTO(ag_value) *v6 = ag_value_new_int(555);
+        AG_AUTO(ag_value) *v7 = ag_value_new_int(734);
+
+        AG_AUTO(ag_list) *l = ag_list_new();
+        ag_list_push(&l, v1);
+        ag_list_push(&l, v2);
+        ag_list_push(&l, v3);
+        ag_list_push(&l, v4);
+        ag_list_push(&l, v5);
+        ag_list_push(&l, v6);
+        ag_list_push(&l, v7);
+
+        return ag_list_copy(l);
+}
+
+
+/*
+ * Define the iterator() helper function. This function is the callback function
+ * used to test out ag_list_map(). This function leads to summation of the
+ * integer values contained within a list.
+ */
+
+
+static void iterator(const ag_value *val, void *opt)
+{
+        ag_int *s = opt;
+        ag_int i = ag_value_int(val);
+        *s += i;
+
+}
+
+
+/*
+ * Define the iterator_mutable() helper function. This function is the iterator
+ * callback function used to test out ag_list_map_mutable(). This function
+ * modifies the value of the node it is applied on it, setting it to 5.
+ */
+
+
+static void iterator_mutable(ag_value **val, void *opt)
+{
+        (void)opt;
+        
+        AG_AUTO(ag_value) *v = ag_value_new_int(5);
+        ag_value_release(val);
+        *val = ag_value_copy(v);
 }
 

--- a/test/list.c
+++ b/test/list.c
@@ -356,6 +356,25 @@ AG_TEST_INIT(refc_02,
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(len_01, "ag_list_len() returns 0 for an empty list")
+{
+        AG_AUTO(ag_list) *l = ag_list_new();
+        
+        AG_TEST_ASSERT (!ag_list_len(l));
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(len_02,
+    "ag_list_len() returns the number of values in a non empty list")
+{
+        AG_AUTO(ag_list) *l = sample_int_2();
+
+        AG_TEST_ASSERT (ag_list_len(l) == 7);
+}
+AG_TEST_EXIT();
+
+
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
@@ -384,6 +403,8 @@ extern ag_test_suite *test_suite_list(void)
                 sz_01, sz_02,
 
                 refc_01, refc_02,
+
+                len_01, len_02,
         };
 
         const char *desc[] = {
@@ -415,6 +436,8 @@ extern ag_test_suite *test_suite_list(void)
                 sz_01_desc, sz_02_desc,
 
                 refc_01_desc, refc_02_desc,
+
+                len_01_desc, len_02_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/list.c
+++ b/test/list.c
@@ -51,7 +51,7 @@ AG_TEST_EXIT();
 
 AG_TEST_INIT(copy_01, "ag_list_copy() creates a shallow copy of a sample list")
 {
-        AG_AUTO(ag_list) *l = sample_int();
+        AG_AUTO(ag_list) *l = sample_int_2();
         AG_AUTO(ag_list) *l2 = ag_list_copy(l);
         AG_TEST_ASSERT (l2 == l);
 }
@@ -67,17 +67,59 @@ AG_TEST_INIT(copy_02, "ag_list_copy() increases the reference count by 1")
 AG_TEST_EXIT();
 
 
+AG_TEST_INIT(release_01, "ag_list_release() performs a no-op if passed NULL")
+{
+        ag_list_release(NULL);
+        AG_TEST_ASSERT (true);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(release_02, 
+    "ag_list_release() performs a no-op if passed a handle to NULL")
+{
+        ag_list *l = NULL;
+        ag_list_release(&l);
+        AG_TEST_ASSERT (true);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(release_03,
+    "ag_list_reelease() disposes a single instance of a list")
+{
+        ag_list *l = sample_int();
+        ag_list_release(&l);
+        AG_TEST_ASSERT (!l);
+}
+AG_TEST_EXIT();
+
+
+AG_TEST_INIT(release_04, "ag_list_dispose() reduces the reference count by 1")
+{
+        ag_list *l = sample_int();
+        AG_AUTO(ag_list) *l2 = ag_list_copy(l);
+        AG_AUTO(ag_list) *l3 = ag_list_copy(l2);
+        ag_list_release(&l);
+
+        AG_TEST_ASSERT (!l && ag_list_refc(l2) == 2);
+}
+AG_TEST_EXIT();
+
+
 
 extern ag_test_suite *test_suite_list(void)
 {
         ag_test *test[] = {
                 new_01, new_02, copy_01,
-                copy_02,
+                copy_02, release_01, release_02,
+                release_03, release_04,
         };
 
         const char *desc[] = {
                 new_01_desc, new_02_desc, copy_01_desc,
-                copy_02_desc,
+                copy_02_desc, release_01_desc, release_02_desc,
+                release_03_desc, release_04_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_list interface");

--- a/test/log.c
+++ b/test/log.c
@@ -54,50 +54,50 @@
 
 AG_TEST_INIT(emerg_01, "ag_log_emerg() logs an emergency record") {
         ag_log_emerg("Testing ag_log_emerg()...");
-        AG_TEST_ASSERT (log_check("emerg"));
-} AG_TEST_EXIT();
+        AG_TEST (log_check("emerg"));
+}
 
 
 AG_TEST_INIT(alert_01, "ag_log_alert() logs an alert record") {
         ag_log_alert("Testing ag_log_alert()...");
-        AG_TEST_ASSERT (log_check("alert"));
-} AG_TEST_EXIT();
+        AG_TEST (log_check("alert"));
+}
 
 
 AG_TEST_INIT(crit_01, "ag_log_crit() logs a critical record") {
         ag_log_crit("Testing ag_log_crit()...");
-        AG_TEST_ASSERT (log_check("crit"));
-} AG_TEST_EXIT();
+        AG_TEST (log_check("crit"));
+}
 
 
 AG_TEST_INIT(err_01, "ag_log_err() logs an error record") {
         ag_log_err("Testing ag_log_err()...");
-        AG_TEST_ASSERT (log_check("err"));
-} AG_TEST_EXIT();
+        AG_TEST (log_check("err"));
+}
 
 
 AG_TEST_INIT(warning_01, "ag_log_warning() logs a warning record") {
         ag_log_warning("Testing ag_log_warning()...");
-        AG_TEST_ASSERT (log_check("warning"));
-} AG_TEST_EXIT();
+        AG_TEST (log_check("warning"));
+}
 
 
 AG_TEST_INIT(notice_01, "ag_log_notice() logs a notice record") {
         ag_log_notice("Testing ag_log_notice()...");
-        AG_TEST_ASSERT (log_check("notice"));
-} AG_TEST_EXIT();
+        AG_TEST (log_check("notice"));
+}
 
 
 AG_TEST_INIT(info_01, "ag_log_info() logs an information record") {
         ag_log_info("Testing ag_log_info()...");
-        AG_TEST_ASSERT (log_check("info"));
-} AG_TEST_EXIT();
+        AG_TEST (log_check("info"));
+}
 
 
 AG_TEST_INIT(debug_01, "ag_log_debug() logs a debug record") {
         ag_log_debug("Testing ag_log_debug()...");
-        AG_TEST_ASSERT (log_check("debug"));
-} AG_TEST_EXIT();
+        AG_TEST (log_check("debug"));
+}
 
 
 /*

--- a/test/log.c
+++ b/test/log.c
@@ -52,49 +52,49 @@
  */
 
 
-AG_TEST_INIT(emerg_01, "ag_log_emerg() logs an emergency record") {
+AG_TEST_CASE(emerg_01, "ag_log_emerg() logs an emergency record") {
         ag_log_emerg("Testing ag_log_emerg()...");
         AG_TEST (log_check("emerg"));
 }
 
 
-AG_TEST_INIT(alert_01, "ag_log_alert() logs an alert record") {
+AG_TEST_CASE(alert_01, "ag_log_alert() logs an alert record") {
         ag_log_alert("Testing ag_log_alert()...");
         AG_TEST (log_check("alert"));
 }
 
 
-AG_TEST_INIT(crit_01, "ag_log_crit() logs a critical record") {
+AG_TEST_CASE(crit_01, "ag_log_crit() logs a critical record") {
         ag_log_crit("Testing ag_log_crit()...");
         AG_TEST (log_check("crit"));
 }
 
 
-AG_TEST_INIT(err_01, "ag_log_err() logs an error record") {
+AG_TEST_CASE(err_01, "ag_log_err() logs an error record") {
         ag_log_err("Testing ag_log_err()...");
         AG_TEST (log_check("err"));
 }
 
 
-AG_TEST_INIT(warning_01, "ag_log_warning() logs a warning record") {
+AG_TEST_CASE(warning_01, "ag_log_warning() logs a warning record") {
         ag_log_warning("Testing ag_log_warning()...");
         AG_TEST (log_check("warning"));
 }
 
 
-AG_TEST_INIT(notice_01, "ag_log_notice() logs a notice record") {
+AG_TEST_CASE(notice_01, "ag_log_notice() logs a notice record") {
         ag_log_notice("Testing ag_log_notice()...");
         AG_TEST (log_check("notice"));
 }
 
 
-AG_TEST_INIT(info_01, "ag_log_info() logs an information record") {
+AG_TEST_CASE(info_01, "ag_log_info() logs an information record") {
         ag_log_info("Testing ag_log_info()...");
         AG_TEST (log_check("info"));
 }
 
 
-AG_TEST_INIT(debug_01, "ag_log_debug() logs a debug record") {
+AG_TEST_CASE(debug_01, "ag_log_debug() logs a debug record") {
         ag_log_debug("Testing ag_log_debug()...");
         AG_TEST (log_check("debug"));
 }

--- a/test/memblock.c
+++ b/test/memblock.c
@@ -3,32 +3,35 @@
 #include <string.h>
 
 struct test {
-        int *i;
-        int *j;
+        int     *i;
+        int     *j;
 };
+
 
 struct test2 {
-        int i;
-        int j;
+        int     i;
+        int     j;
 };
 
 
-AG_TEST_CASE(new_01, "ag_memblock_new() allocates memory on the heap for an"
-             " int") {
+AG_TEST_CASE(new_01,
+    "ag_memblock_new() allocates memory on the heap for an int")
+{
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
+
         AG_TEST (m);
 }
 
 
-AG_TEST_CASE(new_02, "ag_memblock_new() allocates memory on the heap for a test"
-             " struct")
+AG_TEST_CASE(new_02,
+    "ag_memblock_new() allocates memory on the heap for a test struct")
 {
         struct test *t = ag_memblock_new(sizeof *t);
         t->i = ag_memblock_new(sizeof *t->i);
         t->j = ag_memblock_new(sizeof *t->j);
 
         bool chk = (t && t->i && t->j);
-        
+
         ag_memblock_release((ag_memblock **)&t->i);
         ag_memblock_release((ag_memblock **)&t->j);
         ag_memblock_release((ag_memblock **)&t);
@@ -37,47 +40,52 @@ AG_TEST_CASE(new_02, "ag_memblock_new() allocates memory on the heap for a test"
 }
 
 
-AG_TEST_CASE(new_03, "ag_memblock_new() returns a block with a reference count"
-                " of 1")
+AG_TEST_CASE(new_03,
+    "ag_memblock_new() returns a block with a reference count of 1")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
+
         AG_TEST (ag_memblock_refc(m) == 1);
 }
 
 
-AG_TEST_CASE(new_04, "ag_memblock_new() returns a block with the requested data"
-                " size")
+AG_TEST_CASE(new_04,
+    "ag_memblock_new() returns a block with the requested data size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
+
         AG_TEST (ag_memblock_sz(m) == sizeof(int));
 }
 
 
-AG_TEST_CASE(new_05, "ag_memblock_new() returns a block with a total size >="
-                " requested data size")
+AG_TEST_CASE(new_05,
+    "ag_memblock_new() returns a block with a total size >= requested data"
+    " size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
+
         AG_TEST (ag_memblock_sz_total(m) >= sizeof(int));
 }
 
 
-AG_TEST_CASE(new_align_01, "ag_memblock_new_align() allocates memory on the heap"
-                " for an int")
+AG_TEST_CASE(new_align_01,
+    "ag_memblock_new_align() allocates memory on the heap for an int")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
+
         AG_TEST (m);
 }
 
 
-AG_TEST_CASE(new_align_02, "ag_memblock_new_align() allocates memory on the heap"
-                " for a test struct")
+AG_TEST_CASE(new_align_02,
+    "ag_memblock_new_align() allocates memory on the heap for a test struct")
 {
         struct test *t = ag_memblock_new_align(sizeof *t, 8);
         t->i = ag_memblock_new_align(sizeof *t->i, 32);
         t->j = ag_memblock_new_align(sizeof *t->j, 32);
 
         bool chk = (t && t->i && t->j);
-        
+
         ag_memblock_release((ag_memblock **)&t->i);
         ag_memblock_release((ag_memblock **)&t->j);
         ag_memblock_release((ag_memblock **)&t);
@@ -86,40 +94,45 @@ AG_TEST_CASE(new_align_02, "ag_memblock_new_align() allocates memory on the heap
 }
 
 
-AG_TEST_CASE(new_align_03, "ag_memblock_new_align() returns a block with a"
-                " reference count of 1")
+AG_TEST_CASE(new_align_03,
+    "ag_memblock_new_align() returns a block with a reference count of 1")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
+
         AG_TEST (ag_memblock_refc(m) == 1);
 }
 
 
-AG_TEST_CASE(new_align_04, "ag_memblock_new_align() returns a block with the"
-                " requested data size")
+AG_TEST_CASE(new_align_04,
+    "ag_memblock_new_align() returns a block with the requested data size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
+
         AG_TEST (ag_memblock_sz(m) == sizeof(int));
 }
 
 
-AG_TEST_CASE(new_align_05, "ag_memblock_new_align() returns a block with a total"
-                " size >= requested data size")
+AG_TEST_CASE(new_align_05,
+    "ag_memblock_new_align() returns a block with a total size >= requested"
+    " data size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
+
         AG_TEST (ag_memblock_sz_total(m) >= sizeof(int));
 }
 
 
-AG_TEST_CASE(new_align_06, "ag_memblock_new_align() returns a block with the"
-                " required alignment")
+AG_TEST_CASE(new_align_06,
+    "ag_memblock_new_align() returns a block with the required alignment")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 32);
+
         AG_TEST (ag_memblock_aligned(m, 32));
 }
 
 
-AG_TEST_CASE(clone_01, "ag_memblock_clone() makes a deep copy of an int in the"
-                " heap")
+AG_TEST_CASE(clone_01,
+    "ag_memblock_clone() makes a deep copy of an int in the heap")
 {
         int *i = ag_memblock_new(sizeof *i);
         *i = 555;
@@ -133,8 +146,8 @@ AG_TEST_CASE(clone_01, "ag_memblock_clone() makes a deep copy of an int in the"
         AG_TEST (chk);
 }
 
-AG_TEST_CASE(clone_02, "ag_memblock_clone() makes a deep copy of a test structure"
-                " in the heap")
+AG_TEST_CASE(clone_02,
+    "ag_memblock_clone() makes a deep copy of a test structure in the heap")
 {
         struct test *t = ag_memblock_new(sizeof *t);
         t->i = ag_memblock_new(sizeof *t->i);
@@ -155,35 +168,37 @@ AG_TEST_CASE(clone_02, "ag_memblock_clone() makes a deep copy of a test structur
 }
 
 
-AG_TEST_CASE(clone_03, "ag_memblock_clone() returns a copy with another address")
+AG_TEST_CASE(clone_03,
+    "ag_memblock_clone() returns a copy with another address")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
+
         AG_TEST (src != cp);
 }
 
 
-AG_TEST_CASE(clone_04, "ag_memblock_clone() sets the reference count of the copy"
-                " to 1")
+AG_TEST_CASE(clone_04,
+    "ag_memblock_clone() sets the reference count of the copy to 1")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
-        
+
         AG_TEST (ag_memblock_refc(cp) == 1);
 }
 
-AG_TEST_CASE(clone_05, "ag_memblock_clone() does not change the reference count"
-                       " of the source")
+AG_TEST_CASE(clone_05,
+    "ag_memblock_clone() does not change the reference count of the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
-        
+
         AG_TEST (ag_memblock_refc(src) == 1);
 }
 
 
-AG_TEST_CASE(clone_06, "ag_memblock_clone() preserves the data size of the"
-                       " source")
+AG_TEST_CASE(clone_06,
+    "ag_memblock_clone() preserves the data size of the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
@@ -192,8 +207,8 @@ AG_TEST_CASE(clone_06, "ag_memblock_clone() preserves the data size of the"
 }
 
 
-AG_TEST_CASE(clone_07, 
-             "ag_memblock_clone() maintains the total size of the source")
+AG_TEST_CASE(clone_07,
+    "ag_memblock_clone() maintains the total size of the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
@@ -201,8 +216,8 @@ AG_TEST_CASE(clone_07,
         AG_TEST (ag_memblock_sz(src) >= ag_memblock_sz(cp));
 }
 
-AG_TEST_CASE(clone_align_01, 
-             "ag_memblock_clone_align() makes a deep copy of an int")
+AG_TEST_CASE(clone_align_01,
+    "ag_memblock_clone_align() makes a deep copy of an int")
 {
         int *i = ag_memblock_new(sizeof *i);
         *i = 555;
@@ -217,8 +232,8 @@ AG_TEST_CASE(clone_align_01,
 }
 
 
-AG_TEST_CASE(clone_align_02, 
-             "ag_memblock_clone_align() makes a deep copy of a test structure")
+AG_TEST_CASE(clone_align_02,
+    "ag_memblock_clone_align() makes a deep copy of a test structure")
 {
         struct test *t = ag_memblock_new(sizeof *t);
         t->i = ag_memblock_new(sizeof *t->i);
@@ -239,38 +254,40 @@ AG_TEST_CASE(clone_align_02,
 }
 
 
-AG_TEST_CASE(clone_align_03, "ag_memblock_clone_align() returns a copy with another"
-                " address")
+AG_TEST_CASE(clone_align_03,
+    "ag_memblock_clone_align() returns a copy with another address")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone_align(src, 8);
+
         AG_TEST (src != cp);
 }
 
 
-AG_TEST_CASE(clone_align_04, "ag_memblock_clone_align() sets the reference count of"
-                " the copy to 1")
+AG_TEST_CASE(clone_align_04,
+    "ag_memblock_clone_align() sets the reference count of the copy to 1")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_copy(src);
         AG_AUTO(ag_memblock) *cp2 = ag_memblock_clone_align(cp, 8);
-        
+
         AG_TEST (ag_memblock_refc(cp2) == 1);
 }
 
-AG_TEST_CASE(clone_align_05, "ag_memblock_clone_align() does not change the"
-                " reference count of the source")
+AG_TEST_CASE(clone_align_05,
+    "ag_memblock_clone_align() does not change the reference count of the"
+    " source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_copy(src);
         AG_AUTO(ag_memblock) *cp2 = ag_memblock_clone_align(cp, 8);
-        
+
         AG_TEST (ag_memblock_refc(src) == 2 && ag_memblock_refc(cp) == 2);
 }
 
 
-AG_TEST_CASE(clone_align_06, "ag_memblock_clone_align() preserves the data size of"
-                " the source")
+AG_TEST_CASE(clone_align_06,
+    "ag_memblock_clone_align() preserves the data size of the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone_align(src, 8);
@@ -279,8 +296,8 @@ AG_TEST_CASE(clone_align_06, "ag_memblock_clone_align() preserves the data size 
 }
 
 
-AG_TEST_CASE(clone_align_07, "ag_memblock_clone_align() maintains the total size of"
-                " the source")
+AG_TEST_CASE(clone_align_07,
+    "ag_memblock_clone_align() maintains the total size of the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone_align(src, 8);
@@ -289,8 +306,8 @@ AG_TEST_CASE(clone_align_07, "ag_memblock_clone_align() maintains the total size
 }
 
 
-AG_TEST_CASE(clone_align_08, "ag_memblock_clone_align() honours its alignment"
-                " request")
+AG_TEST_CASE(clone_align_08,
+    "ag_memblock_clone_align() honours its alignment request")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone_align(src, 32);
@@ -299,9 +316,11 @@ AG_TEST_CASE(clone_align_08, "ag_memblock_clone_align() honours its alignment"
 }
 
 
-AG_TEST_CASE(release_01, "ag_memblock_release() performs a no-op if passed NULL")
+AG_TEST_CASE(release_01,
+    "ag_memblock_release() performs a no-op if passed NULL")
 {
         ag_memblock_release(NULL);
+
         AG_TEST (true);
 }
 
@@ -311,6 +330,7 @@ AG_TEST_CASE(release_02, "ag_memblock_release() performs a no-op if passed a"
 {
         ag_memblock *m = NULL;
         ag_memblock_release((ag_memblock **) &m);
+
         AG_TEST (true);
 }
 
@@ -319,21 +339,23 @@ AG_TEST_CASE(release_03, "ag_memblock_release() release an int on the heap")
 {
         int *i = ag_memblock_new(sizeof *i);
         ag_memblock_release((ag_memblock **)&i);
+
         AG_TEST (!i);
 }
 
 
-AG_TEST_CASE(release_04, "ag_memblock_release() releases a test struct on the"
-                " heap")
+AG_TEST_CASE(release_04,
+    "ag_memblock_release() releases a test struct on the heap")
 {
         struct test *t = ag_memblock_new(sizeof *t);
         ag_memblock_release((ag_memblock **)&t);
+
         AG_TEST (!t);
 }
 
 
-AG_TEST_CASE(release_05, "ag_memblock_release() reduces the reference count by 1"
-                "for lazy copies")
+AG_TEST_CASE(release_05,
+    "ag_memblock_release() reduces the reference count by 1 for lazy copies")
 {
         int *i = ag_memblock_new(sizeof *i);
         AG_AUTO(ag_memblock) *j = ag_memblock_copy(i);
@@ -343,21 +365,23 @@ AG_TEST_CASE(release_05, "ag_memblock_release() reduces the reference count by 1
 }
 
 
-AG_TEST_CASE(release_06, "ag_memblock_release() on a deep copy does not alter the"
-                " reference count of the source")
+AG_TEST_CASE(release_06,
+    "ag_memblock_release() on a deep copy does not alter the reference count of"
+    " the source")
 {
         AG_AUTO(ag_memblock) *i = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *j = ag_memblock_copy(i);
         ag_memblock *k = ag_memblock_clone(j);
         ag_memblock_release(&k);
-        
+
         AG_TEST (ag_memblock_refc(i) == 2);
 }
 
 
 
-AG_TEST_CASE(cmp_01, "ag_memblock_cmp() returns AG_CMP_EQ for two int memory"
-                " blocks with the same value")
+AG_TEST_CASE(cmp_01,
+    "ag_memblock_cmp() returns AG_CMP_EQ for two int memory blocks with the"
+    " same value")
 {
         int *i = ag_memblock_new(sizeof *i);
         *i = 555;
@@ -372,8 +396,9 @@ AG_TEST_CASE(cmp_01, "ag_memblock_cmp() returns AG_CMP_EQ for two int memory"
 }
 
 
-AG_TEST_CASE(cmp_02, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
-                " shallow copy of an int with its source")
+AG_TEST_CASE(cmp_02,
+    "ag_memblock_cmp() returns AG_CMP_EQ when comparing a shallow copy of an"
+    " int with its source")
 {
         int *i = ag_memblock_new(sizeof *i);
         *i = 555;
@@ -387,8 +412,9 @@ AG_TEST_CASE(cmp_02, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
 }
 
 
-AG_TEST_CASE(cmp_03, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
-                " copy of an int with its source")
+AG_TEST_CASE(cmp_03,
+    "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep copy of an int"
+    " with its source")
 {
         int *i = ag_memblock_new(sizeof *i);
         *i = 555;
@@ -402,8 +428,9 @@ AG_TEST_CASE(cmp_03, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
 }
 
 
-AG_TEST_CASE(cmp_04, "ag_memblock_cmp() returns AG_CMP_EQ for two memory blocks"
-                " with the same struct with scalar fields")
+AG_TEST_CASE(cmp_04,
+    "ag_memblock_cmp() returns AG_CMP_EQ for two memory blocks with the same"
+    " struct with scalar fields")
 {
         struct test2 *a = ag_memblock_new(sizeof *a);
         struct test2 *b = ag_memblock_new(sizeof *b);
@@ -420,8 +447,9 @@ AG_TEST_CASE(cmp_04, "ag_memblock_cmp() returns AG_CMP_EQ for two memory blocks"
 }
 
 
-AG_TEST_CASE(cmp_05, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
-                " shallow copy of a struct with scalar fields")
+AG_TEST_CASE(cmp_05,
+    "ag_memblock_cmp() returns AG_CMP_EQ when comparing a shallow copy of a"
+    " struct with scalar fields")
 {
         struct test2 *a = ag_memblock_new(sizeof *a);
         a->i = 555;
@@ -437,8 +465,9 @@ AG_TEST_CASE(cmp_05, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
 }
 
 
-AG_TEST_CASE(cmp_06, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
-                " copy of a struct with scalar fields")
+AG_TEST_CASE(cmp_06,
+    "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep copy of a struct"
+    " with scalar fields")
 {
         struct test2 *a = ag_memblock_new(sizeof *a);
         a->i = 555;
@@ -453,9 +482,9 @@ AG_TEST_CASE(cmp_06, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
 }
 
 
-AG_TEST_CASE(cmp_07, "ag_memblock_cmp() returns AG_CMP_LT when comparing an int"
-                " memory block to another whose first differing byte is"
-                " greater")
+AG_TEST_CASE(cmp_07,
+    "ag_memblock_cmp() returns AG_CMP_LT when comparing an int memory block to"
+    " another whose first differing byte is greater")
 {
         int *i = ag_memblock_new(sizeof *i);
         *i = 1;
@@ -470,8 +499,9 @@ AG_TEST_CASE(cmp_07, "ag_memblock_cmp() returns AG_CMP_LT when comparing an int"
 }
 
 
-AG_TEST_CASE(cmp_08, "ag_memblock_cmp() returns AG_CMP_GT when comparing an int"
-                " memory block to another whose first differing byte is lower")
+AG_TEST_CASE(cmp_08,
+    "ag_memblock_cmp() returns AG_CMP_GT when comparing an int memory block to"
+    " another whose first differing byte is lower")
 {
         int *i = ag_memblock_new(sizeof *i);
         *i = 2;
@@ -486,14 +516,15 @@ AG_TEST_CASE(cmp_08, "ag_memblock_cmp() returns AG_CMP_GT when comparing an int"
 }
 
 
-AG_TEST_CASE(cmp_09, "ag_memblock_cmp() returns AG_CMP_LT when comparing a memory"
-                " block holding a struct with scalar fields to another whose"
-                " first differing byte is greater")
+AG_TEST_CASE(cmp_09,
+    "ag_memblock_cmp() returns AG_CMP_LT when comparing a memory block holding"
+    " a struct with scalar fields to another whose first differing byte is"
+    " greater")
 {
         struct test2 *a = ag_memblock_new(sizeof *a);
         a->i = 1;
         a->j = 2;
-        
+
         struct test2 *b = ag_memblock_clone(a);
         b->i = 2;
         b->j = 2;
@@ -506,14 +537,15 @@ AG_TEST_CASE(cmp_09, "ag_memblock_cmp() returns AG_CMP_LT when comparing a memor
 }
 
 
-AG_TEST_CASE(cmp_10, "ag_memblock_cmp() returns AG_CMP_GT when comparing a memory"
-                " block holding a struct with scalar fields to another whose"
-                " first differing byte is lower")
+AG_TEST_CASE(cmp_10,
+    "ag_memblock_cmp() returns AG_CMP_GT when comparing a memory block holding"
+    " a struct with scalar fields to another whose first differing byte is"
+    " lower")
 {
         struct test2 *a = ag_memblock_new(sizeof *a);
         a->i = 2;
         a->j = 1;
-        
+
         struct test2 *b = ag_memblock_clone(a);
         b->i = 1;
         b->j = 1;
@@ -526,8 +558,9 @@ AG_TEST_CASE(cmp_10, "ag_memblock_cmp() returns AG_CMP_GT when comparing a memor
 }
 
 
-AG_TEST_CASE(lt_01, "ag_memblock_lt() returns true for an int memory block with"
-                " a value lower than another")
+AG_TEST_CASE(lt_01,
+    "ag_memblock_lt() returns true for an int memory block with a value lower"
+    " than another")
 {
         int *i = ag_memblock_new(sizeof *i);
         int *j = ag_memblock_new(sizeof *j);
@@ -537,13 +570,14 @@ AG_TEST_CASE(lt_01, "ag_memblock_lt() returns true for an int memory block with"
         bool chk = ag_memblock_lt(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
-        
+
         AG_TEST (chk);
 }
 
 
-AG_TEST_CASE(lt_02, "ag_memblock_lt() returns false for an int memory block with"
-                " the same value as another")
+AG_TEST_CASE(lt_02,
+    "ag_memblock_lt() returns false for an int memory block with the same value"
+    " as another")
 {
         int *i = ag_memblock_new(sizeof *i);
         int *j = ag_memblock_new(sizeof *j);
@@ -558,15 +592,16 @@ AG_TEST_CASE(lt_02, "ag_memblock_lt() returns false for an int memory block with
 }
 
 
-AG_TEST_CASE(lt_03, "ag_memblock_lt() returns false for an int memory block with"
-                " a greater value than another")
+AG_TEST_CASE(lt_03,
+    "ag_memblock_lt() returns false for an int memory block with a greater"
+    " value than another")
 {
         int *i = ag_memblock_new(sizeof *i);
         int *j = ag_memblock_new(sizeof *j);
         *i = 6;
         *j = 5;
 
-        bool chk = !ag_memblock_lt(i, j); 
+        bool chk = !ag_memblock_lt(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
 
@@ -574,8 +609,9 @@ AG_TEST_CASE(lt_03, "ag_memblock_lt() returns false for an int memory block with
 }
 
 
-AG_TEST_CASE(gt_01, "ag_memblock_gt() returns true for an int memory block with"
-                " a value greater than another")
+AG_TEST_CASE(gt_01,
+    "ag_memblock_gt() returns true for an int memory block with a value greater"
+    " than another")
 {
         int *i = ag_memblock_new(sizeof *i);
         int *j = ag_memblock_new(sizeof *j);
@@ -590,8 +626,9 @@ AG_TEST_CASE(gt_01, "ag_memblock_gt() returns true for an int memory block with"
 }
 
 
-AG_TEST_CASE(gt_02, "ag_memblock_gt() returns false for an int memory block with"
-                " the same value as another")
+AG_TEST_CASE(gt_02,
+    "ag_memblock_gt() returns false for an int memory block with the same value"
+    " as another")
 {
         int *i = ag_memblock_new(sizeof *i);
         int *j = ag_memblock_new(sizeof *j);
@@ -606,15 +643,16 @@ AG_TEST_CASE(gt_02, "ag_memblock_gt() returns false for an int memory block with
 }
 
 
-AG_TEST_CASE(gt_03, "ag_memblock_gt() returns false for an int memory block with"
-                " a lower value than another")
+AG_TEST_CASE(gt_03,
+    "ag_memblock_gt() returns false for an int memory block with a lower value"
+    " than another")
 {
         int *i = ag_memblock_new(sizeof *i);
         int *j = ag_memblock_new(sizeof *j);
         *i = 5;
         *j = 6;
 
-        bool chk = !ag_memblock_gt(i, j); 
+        bool chk = !ag_memblock_gt(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
 
@@ -622,8 +660,9 @@ AG_TEST_CASE(gt_03, "ag_memblock_gt() returns false for an int memory block with
 }
 
 
-AG_TEST_CASE(eq_01, "ag_memblock_eq() returns true for two int memory blocks with"
-                " the same value")
+AG_TEST_CASE(eq_01,
+    "ag_memblock_eq() returns true for two int memory blocks with the same"
+    " value")
 {
         int *i = ag_memblock_new(sizeof *i);
         int *j = ag_memblock_new(sizeof *j);
@@ -638,8 +677,9 @@ AG_TEST_CASE(eq_01, "ag_memblock_eq() returns true for two int memory blocks wit
 }
 
 
-AG_TEST_CASE(eq_02, "ag_memblock_eq() returns false for an int memory block with"
-                " a lower value than another")
+AG_TEST_CASE(eq_02,
+    "ag_memblock_eq() returns false for an int memory block with a lower value"
+    " than another")
 {
         int *i = ag_memblock_new(sizeof *i);
         int *j = ag_memblock_new(sizeof *j);
@@ -654,15 +694,16 @@ AG_TEST_CASE(eq_02, "ag_memblock_eq() returns false for an int memory block with
 }
 
 
-AG_TEST_CASE(eq_03, "ag_memblock_eq() returns false for an int memory block with"
-                " a greater value than another")
+AG_TEST_CASE(eq_03,
+    "ag_memblock_eq() returns false for an int memory block with a greater"
+    " value than another")
 {
         int *i = ag_memblock_new(sizeof *i);
         int *j = ag_memblock_new(sizeof *j);
         *i = 6;
         *j = 5;
 
-        bool chk = !ag_memblock_eq(i, j); 
+        bool chk = !ag_memblock_eq(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
 
@@ -682,8 +723,8 @@ AG_TEST_CASE(resize_01, "ag_memblock_resize() resizes an existing memory block")
 }
 
 
-AG_TEST_CASE(resize_02, "ag_memblock_resize() preserves data when resizing to a"
-                " larger size")
+AG_TEST_CASE(resize_02,
+    "ag_memblock_resize() preserves data when resizing to a larger size")
 {
         char *bfr = ag_memblock_new(6);
         strncpy(bfr, "Hello", 6);
@@ -697,8 +738,8 @@ AG_TEST_CASE(resize_02, "ag_memblock_resize() preserves data when resizing to a"
 }
 
 
-AG_TEST_CASE(resize_align_01, "ag_memblock_resize_align() resizes an existing"
-                " memory block")
+AG_TEST_CASE(resize_align_01,
+    "ag_memblock_resize_align() resizes an existing memory block")
 {
         char *bfr = ag_memblock_new(10);
         ag_memblock_resize_align((ag_memblock **)&bfr, 15, 8);
@@ -710,8 +751,8 @@ AG_TEST_CASE(resize_align_01, "ag_memblock_resize_align() resizes an existing"
 }
 
 
-AG_TEST_CASE(resize_align_02, "ag_memblock_resize_align() preserves data when"
-                " resizing to a larger size")
+AG_TEST_CASE(resize_align_02,
+    "ag_memblock_resize_align() preserves data when resizing to a larger size")
 {
         char *bfr = ag_memblock_new(6);
         strncpy(bfr, "Hello", 6);
@@ -725,8 +766,8 @@ AG_TEST_CASE(resize_align_02, "ag_memblock_resize_align() preserves data when"
 }
 
 
-AG_TEST_CASE(resize_align_03, "ag_memblock_resize_align() aligns to the requested"
-                " boundary")
+AG_TEST_CASE(resize_align_03,
+    "ag_memblock_resize_align() aligns to the requested boundary")
 {
         char *bfr = ag_memblock_new(6);
         strncpy(bfr, "Hello", 6);
@@ -740,8 +781,8 @@ AG_TEST_CASE(resize_align_03, "ag_memblock_resize_align() aligns to the requeste
 }
 
 
-AG_TEST_CASE(str_01, "ag_memblock_str() generates the string representation of a"
-                " memory block")
+AG_TEST_CASE(str_01,
+    "ag_memblock_str() generates the string representation of a memory block")
 {
         int *i = ag_memblock_new(sizeof *i);
         AG_AUTO(ag_string) *s = ag_memblock_str(i);
@@ -757,35 +798,63 @@ AG_TEST_CASE(str_01, "ag_memblock_str() generates the string representation of a
 
 extern ag_test_suite *test_suite_memblock(void)
 {
-        ag_test *test[] = { &new_01, &new_02, &new_03, &new_04, &new_05,
-                &new_align_01, &new_align_02, &new_align_03, &new_align_04,
-                &new_align_05, &new_align_06, &clone_01, &clone_02, &clone_03,
-                &clone_04, &clone_05, &clone_06, &clone_07, &clone_align_01,
-                &clone_align_02, &clone_align_03, &clone_align_04,
-                &clone_align_05, &clone_align_06, &clone_align_07,
-                &clone_align_08, &release_01, &release_02, &release_03,
-                &release_04, release_05, &release_06, &cmp_01, &cmp_02, &cmp_03,
-                &cmp_04, cmp_05, &cmp_06, &cmp_07, &cmp_08, &cmp_09, &cmp_10,
-                &lt_01, &lt_02, &lt_03, &gt_01, &gt_02, &gt_03, &eq_01, &eq_02,
-                &eq_03, &resize_01, &resize_02, &resize_align_01,
-                &resize_align_02, &resize_align_03, &str_01, };
+        ag_test *test[] = {
+                new_01,                 new_02,                 new_03,
+                new_04,                 new_05,
+                new_align_01,           new_align_02,           new_align_03,
+                new_align_04,           new_align_05,           new_align_06,
+                clone_01,               clone_02,               clone_03,
+                clone_04,               clone_05,               clone_06,
+                clone_07,
+                clone_align_01,         clone_align_02,         clone_align_03,
+                clone_align_04,         clone_align_05,         clone_align_06,
+                clone_align_07,         clone_align_08,
+                release_01,             release_02,             release_03,
+                release_04,             release_05,             release_06,
+                cmp_01,                 cmp_02,                 cmp_03,
+                cmp_04,                 cmp_05,                 cmp_06,
+                cmp_07,                 cmp_08,                 cmp_09,
+                cmp_10,
+                lt_01,                  lt_02,                  lt_03,
+                gt_01,                  gt_02,                  gt_03,
+                eq_01,                  eq_02,                  eq_03,
+                resize_01,              resize_02,
+                resize_align_01,        resize_align_02,        resize_align_03,
+                str_01, };
 
-        const char *desc[] = { new_01_desc, new_02_desc, new_03_desc,
-                new_04_desc, new_05_desc, new_align_01_desc, new_align_02_desc,
-                new_align_03_desc, new_align_04_desc, new_align_05_desc,
-                new_align_06_desc, clone_01_desc, clone_02_desc, clone_03_desc,
-                clone_04_desc, clone_05_desc, clone_06_desc, clone_07_desc,
-                clone_align_01_desc, clone_align_02_desc, clone_align_03_desc,
-                clone_align_04_desc, clone_align_05_desc, clone_align_06_desc,
-                clone_align_07_desc, clone_align_08_desc, release_01_desc,
-                release_02_desc, release_03_desc, release_04_desc,
-                release_05_desc, release_06_desc, cmp_01_desc, cmp_02_desc,
-                cmp_03_desc, cmp_04_desc, cmp_05_desc, cmp_06_desc, cmp_07_desc,
-                cmp_08_desc, cmp_09_desc, cmp_10_desc, lt_01_desc, lt_02_desc,
-                lt_03_desc, gt_01_desc, gt_02_desc, gt_03_desc, eq_01_desc,
-                eq_02_desc, eq_03_desc, resize_01_desc, resize_02_desc,
-                resize_align_01_desc, resize_align_02_desc,
-                resize_align_03_desc, str_01_desc, };
+        const char *desc[] = { 
+                new_01_desc,                    new_02_desc, 
+                new_03_desc,                    new_04_desc, 
+                new_05_desc, 
+                new_align_01_desc,              new_align_02_desc,
+                new_align_03_desc,              new_align_04_desc, 
+                new_align_05_desc,              new_align_06_desc, 
+                clone_01_desc,                  clone_02_desc, 
+                clone_03_desc,                  clone_04_desc, 
+                clone_05_desc,                  clone_06_desc, 
+                clone_07_desc,                  clone_align_01_desc, 
+                clone_align_02_desc,            clone_align_03_desc,
+                clone_align_04_desc,            clone_align_05_desc, 
+                clone_align_06_desc,            clone_align_07_desc, 
+                clone_align_08_desc,            release_01_desc,
+                release_02_desc,                release_03_desc, 
+                release_04_desc,                release_05_desc, 
+                release_06_desc, 
+                cmp_01_desc,            cmp_02_desc,
+                cmp_03_desc,            cmp_04_desc, 
+                cmp_05_desc,            cmp_06_desc, 
+                cmp_07_desc,            cmp_08_desc, 
+                cmp_09_desc,            cmp_10_desc, 
+                lt_01_desc,             lt_02_desc,
+                lt_03_desc, 
+                gt_01_desc,             gt_02_desc, 
+                gt_03_desc, 
+                eq_01_desc,             eq_02_desc, eq_03_desc, 
+                resize_01_desc,         resize_02_desc,
+                resize_align_01_desc,   resize_align_02_desc,
+                resize_align_03_desc, 
+                str_01_desc, 
+        };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_memblock interface");
         ag_test_suite_push_array(ctx, test, desc, sizeof test / sizeof *test);

--- a/test/memblock.c
+++ b/test/memblock.c
@@ -16,8 +16,8 @@ struct test2 {
 AG_TEST_INIT(new_01, "ag_memblock_new() allocates memory on the heap for an"
              " int") {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
-        AG_TEST_ASSERT (m);
-} AG_TEST_EXIT();
+        AG_TEST (m);
+}
 
 
 AG_TEST_INIT(new_02, "ag_memblock_new() allocates memory on the heap for a test"
@@ -27,50 +27,46 @@ AG_TEST_INIT(new_02, "ag_memblock_new() allocates memory on the heap for a test"
         t->i = ag_memblock_new(sizeof *t->i);
         t->j = ag_memblock_new(sizeof *t->j);
 
-        AG_TEST_ASSERT (t && t->i && t->j);
+        bool chk = (t && t->i && t->j);
         
         ag_memblock_release((ag_memblock **)&t->i);
         ag_memblock_release((ag_memblock **)&t->j);
         ag_memblock_release((ag_memblock **)&t);
 
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_03, "ag_memblock_new() returns a block with a reference count"
                 " of 1")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
-        AG_TEST_ASSERT (ag_memblock_refc(m) == 1);
+        AG_TEST (ag_memblock_refc(m) == 1);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_04, "ag_memblock_new() returns a block with the requested data"
                 " size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
-        AG_TEST_ASSERT (ag_memblock_sz(m) == sizeof(int));
+        AG_TEST (ag_memblock_sz(m) == sizeof(int));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_05, "ag_memblock_new() returns a block with a total size >="
                 " requested data size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
-        AG_TEST_ASSERT (ag_memblock_sz_total(m) >= sizeof(int));
+        AG_TEST (ag_memblock_sz_total(m) >= sizeof(int));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_align_01, "ag_memblock_new_align() allocates memory on the heap"
                 " for an int")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
-        AG_TEST_ASSERT (m);
+        AG_TEST (m);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_align_02, "ag_memblock_new_align() allocates memory on the heap"
@@ -80,49 +76,46 @@ AG_TEST_INIT(new_align_02, "ag_memblock_new_align() allocates memory on the heap
         t->i = ag_memblock_new_align(sizeof *t->i, 32);
         t->j = ag_memblock_new_align(sizeof *t->j, 32);
 
-        AG_TEST_ASSERT (t && t->i && t->j);
+        bool chk = (t && t->i && t->j);
         
         ag_memblock_release((ag_memblock **)&t->i);
         ag_memblock_release((ag_memblock **)&t->j);
         ag_memblock_release((ag_memblock **)&t);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_align_03, "ag_memblock_new_align() returns a block with a"
                 " reference count of 1")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
-        AG_TEST_ASSERT (ag_memblock_refc(m) == 1);
+        AG_TEST (ag_memblock_refc(m) == 1);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_align_04, "ag_memblock_new_align() returns a block with the"
                 " requested data size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
-        AG_TEST_ASSERT (ag_memblock_sz(m) == sizeof(int));
+        AG_TEST (ag_memblock_sz(m) == sizeof(int));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_align_05, "ag_memblock_new_align() returns a block with a total"
                 " size >= requested data size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
-        AG_TEST_ASSERT (ag_memblock_sz_total(m) >= sizeof(int));
+        AG_TEST (ag_memblock_sz_total(m) >= sizeof(int));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(new_align_06, "ag_memblock_new_align() returns a block with the"
                 " required alignment")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 32);
-        AG_TEST_ASSERT (ag_memblock_aligned(m, 32));
+        AG_TEST (ag_memblock_aligned(m, 32));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_01, "ag_memblock_clone() makes a deep copy of an int in the"
@@ -132,12 +125,13 @@ AG_TEST_INIT(clone_01, "ag_memblock_clone() makes a deep copy of an int in the"
         *i = 555;
 
         int *j = ag_memblock_clone(i);
-        AG_TEST_ASSERT (*j == 555);
+        bool chk = (*j == 555);
 
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 AG_TEST_INIT(clone_02, "ag_memblock_clone() makes a deep copy of a test structure"
                 " in the heap")
@@ -150,23 +144,23 @@ AG_TEST_INIT(clone_02, "ag_memblock_clone() makes a deep copy of a test structur
         *t->j = -666;
 
         struct test *cp = ag_memblock_clone(t);
-        AG_TEST_ASSERT (*cp->i == *t->i && *cp->j == *t->j);
+        bool chk = (*cp->i == *t->i && *cp->j == *t->j);
 
         ag_memblock_release((ag_memblock **)&t->i);
         ag_memblock_release((ag_memblock **)&t->j);
         ag_memblock_release((ag_memblock **)&t);
         ag_memblock_release((ag_memblock **)&cp);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_03, "ag_memblock_clone() returns a copy with another address")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
-        AG_TEST_ASSERT (src != cp);
+        AG_TEST (src != cp);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_04, "ag_memblock_clone() sets the reference count of the copy"
@@ -175,9 +169,8 @@ AG_TEST_INIT(clone_04, "ag_memblock_clone() sets the reference count of the copy
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
         
-        AG_TEST_ASSERT (ag_memblock_refc(cp) == 1);
+        AG_TEST (ag_memblock_refc(cp) == 1);
 }
-AG_TEST_EXIT();
 
 AG_TEST_INIT(clone_05, "ag_memblock_clone() does not change the reference count"
                        " of the source")
@@ -185,9 +178,8 @@ AG_TEST_INIT(clone_05, "ag_memblock_clone() does not change the reference count"
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
         
-        AG_TEST_ASSERT (ag_memblock_refc(src) == 1);
+        AG_TEST (ag_memblock_refc(src) == 1);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_06, "ag_memblock_clone() preserves the data size of the"
@@ -196,9 +188,8 @@ AG_TEST_INIT(clone_06, "ag_memblock_clone() preserves the data size of the"
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
 
-        AG_TEST_ASSERT (ag_memblock_sz(src) == ag_memblock_sz(cp));
+        AG_TEST (ag_memblock_sz(src) == ag_memblock_sz(cp));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_07, 
@@ -207,9 +198,8 @@ AG_TEST_INIT(clone_07,
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
 
-        AG_TEST_ASSERT (ag_memblock_sz(src) >= ag_memblock_sz(cp));
+        AG_TEST (ag_memblock_sz(src) >= ag_memblock_sz(cp));
 }
-AG_TEST_EXIT();
 
 AG_TEST_INIT(clone_align_01, 
              "ag_memblock_clone_align() makes a deep copy of an int")
@@ -218,12 +208,13 @@ AG_TEST_INIT(clone_align_01,
         *i = 555;
 
         int *j = ag_memblock_clone_align(i, 8);
-        AG_TEST_ASSERT (*j == 555);
+        bool chk = (*j == 555);
 
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_align_02, 
@@ -237,14 +228,15 @@ AG_TEST_INIT(clone_align_02,
         *t->j = -666;
 
         struct test *cp = ag_memblock_clone_align(t, 8);
-        AG_TEST_ASSERT (*cp->i == *t->i && *cp->j == *t->j);
+        bool chk = (*cp->i == *t->i && *cp->j == *t->j);
 
         ag_memblock_release((ag_memblock **)&t->i);
         ag_memblock_release((ag_memblock **)&t->j);
         ag_memblock_release((ag_memblock **)&t);
         ag_memblock_release((ag_memblock **)&cp);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_align_03, "ag_memblock_clone_align() returns a copy with another"
@@ -252,9 +244,8 @@ AG_TEST_INIT(clone_align_03, "ag_memblock_clone_align() returns a copy with anot
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone_align(src, 8);
-        AG_TEST_ASSERT (src != cp);
+        AG_TEST (src != cp);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_align_04, "ag_memblock_clone_align() sets the reference count of"
@@ -264,9 +255,8 @@ AG_TEST_INIT(clone_align_04, "ag_memblock_clone_align() sets the reference count
         AG_AUTO(ag_memblock) *cp = ag_memblock_copy(src);
         AG_AUTO(ag_memblock) *cp2 = ag_memblock_clone_align(cp, 8);
         
-        AG_TEST_ASSERT (ag_memblock_refc(cp2) == 1);
+        AG_TEST (ag_memblock_refc(cp2) == 1);
 }
-AG_TEST_EXIT();
 
 AG_TEST_INIT(clone_align_05, "ag_memblock_clone_align() does not change the"
                 " reference count of the source")
@@ -275,9 +265,8 @@ AG_TEST_INIT(clone_align_05, "ag_memblock_clone_align() does not change the"
         AG_AUTO(ag_memblock) *cp = ag_memblock_copy(src);
         AG_AUTO(ag_memblock) *cp2 = ag_memblock_clone_align(cp, 8);
         
-        AG_TEST_ASSERT (ag_memblock_refc(src) == 2 && ag_memblock_refc(cp) == 2);
+        AG_TEST (ag_memblock_refc(src) == 2 && ag_memblock_refc(cp) == 2);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_align_06, "ag_memblock_clone_align() preserves the data size of"
@@ -286,9 +275,8 @@ AG_TEST_INIT(clone_align_06, "ag_memblock_clone_align() preserves the data size 
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone_align(src, 8);
 
-        AG_TEST_ASSERT (ag_memblock_sz(src) == ag_memblock_sz(cp));
+        AG_TEST (ag_memblock_sz(src) == ag_memblock_sz(cp));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_align_07, "ag_memblock_clone_align() maintains the total size of"
@@ -297,9 +285,8 @@ AG_TEST_INIT(clone_align_07, "ag_memblock_clone_align() maintains the total size
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone_align(src, 8);
 
-        AG_TEST_ASSERT (ag_memblock_sz(src) >= ag_memblock_sz(cp));
+        AG_TEST (ag_memblock_sz(src) >= ag_memblock_sz(cp));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(clone_align_08, "ag_memblock_clone_align() honours its alignment"
@@ -308,17 +295,15 @@ AG_TEST_INIT(clone_align_08, "ag_memblock_clone_align() honours its alignment"
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone_align(src, 32);
 
-        AG_TEST_ASSERT (ag_memblock_aligned(cp, 32));
+        AG_TEST (ag_memblock_aligned(cp, 32));
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_01, "ag_memblock_release() performs a no-op if passed NULL")
 {
         ag_memblock_release(NULL);
-        AG_TEST_ASSERT (true);
+        AG_TEST (true);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_02, "ag_memblock_release() performs a no-op if passed a"
@@ -326,18 +311,16 @@ AG_TEST_INIT(release_02, "ag_memblock_release() performs a no-op if passed a"
 {
         ag_memblock *m = NULL;
         ag_memblock_release((ag_memblock **) &m);
-        AG_TEST_ASSERT (true);
+        AG_TEST (true);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_03, "ag_memblock_release() release an int on the heap")
 {
         int *i = ag_memblock_new(sizeof *i);
         ag_memblock_release((ag_memblock **)&i);
-        AG_TEST_ASSERT (!i);
+        AG_TEST (!i);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_04, "ag_memblock_release() releases a test struct on the"
@@ -345,9 +328,8 @@ AG_TEST_INIT(release_04, "ag_memblock_release() releases a test struct on the"
 {
         struct test *t = ag_memblock_new(sizeof *t);
         ag_memblock_release((ag_memblock **)&t);
-        AG_TEST_ASSERT (!t);
+        AG_TEST (!t);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_05, "ag_memblock_release() reduces the reference count by 1"
@@ -357,9 +339,8 @@ AG_TEST_INIT(release_05, "ag_memblock_release() reduces the reference count by 1
         AG_AUTO(ag_memblock) *j = ag_memblock_copy(i);
         ag_memblock_release((ag_memblock **)&i);
 
-        AG_TEST_ASSERT (ag_memblock_refc(j) == 1);
+        AG_TEST (ag_memblock_refc(j) == 1);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(release_06, "ag_memblock_release() on a deep copy does not alter the"
@@ -370,9 +351,8 @@ AG_TEST_INIT(release_06, "ag_memblock_release() on a deep copy does not alter th
         ag_memblock *k = ag_memblock_clone(j);
         ag_memblock_release(&k);
         
-        AG_TEST_ASSERT (ag_memblock_refc(i) == 2);
+        AG_TEST (ag_memblock_refc(i) == 2);
 }
-AG_TEST_EXIT();
 
 
 
@@ -384,12 +364,12 @@ AG_TEST_INIT(cmp_01, "ag_memblock_cmp() returns AG_CMP_EQ for two int memory"
         int *j = ag_memblock_new(sizeof *j);
         *j = 555;
 
-        AG_TEST_ASSERT(ag_memblock_cmp(i, j) == AG_CMP_EQ);
-
+        bool chk = (ag_memblock_cmp(i, j) == AG_CMP_EQ);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_02, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
@@ -399,12 +379,12 @@ AG_TEST_INIT(cmp_02, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
         *i = 555;
         int *j = ag_memblock_copy(i);
 
-        AG_TEST_ASSERT(ag_memblock_cmp(i, j) == AG_CMP_EQ);
-
+        bool chk = (ag_memblock_cmp(i, j) == AG_CMP_EQ);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_03, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
@@ -414,12 +394,12 @@ AG_TEST_INIT(cmp_03, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
         *i = 555;
         int *j = ag_memblock_clone(i);
 
-        AG_TEST_ASSERT(ag_memblock_cmp(i, j) == AG_CMP_EQ);
-
+        bool chk = (ag_memblock_cmp(i, j) == AG_CMP_EQ);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_04, "ag_memblock_cmp() returns AG_CMP_EQ for two memory blocks"
@@ -432,12 +412,12 @@ AG_TEST_INIT(cmp_04, "ag_memblock_cmp() returns AG_CMP_EQ for two memory blocks"
         b->i = 555;
         b->j = -666;
 
-        AG_TEST_ASSERT(ag_memblock_cmp(a, b) == AG_CMP_EQ);
-
+        bool chk = (ag_memblock_cmp(a, b) == AG_CMP_EQ);
         ag_memblock_release((ag_memblock **)&a);
         ag_memblock_release((ag_memblock **)&b);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_05, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
@@ -448,12 +428,13 @@ AG_TEST_INIT(cmp_05, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
         a->j = -666;
 
         struct test2 *b = ag_memblock_copy(a);
-        AG_TEST_ASSERT(ag_memblock_cmp(a, b) == AG_CMP_EQ);
+        bool chk = (ag_memblock_cmp(a, b) == AG_CMP_EQ);
 
         ag_memblock_release((ag_memblock **)&a);
         ag_memblock_release((ag_memblock **)&b);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_06, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
@@ -464,12 +445,12 @@ AG_TEST_INIT(cmp_06, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
         a->j = -666;
         struct test2 *b = ag_memblock_clone(a);
 
-        AG_TEST_ASSERT(ag_memblock_cmp(a, b) == AG_CMP_EQ);
-
+        bool chk = (ag_memblock_cmp(a, b) == AG_CMP_EQ);
         ag_memblock_release((ag_memblock **)&a);
         ag_memblock_release((ag_memblock **)&b);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_07, "ag_memblock_cmp() returns AG_CMP_LT when comparing an int"
@@ -481,12 +462,12 @@ AG_TEST_INIT(cmp_07, "ag_memblock_cmp() returns AG_CMP_LT when comparing an int"
         int *j = ag_memblock_new(sizeof *j);
         *j = 2;
 
-        AG_TEST_ASSERT(ag_memblock_cmp(i, j) == AG_CMP_LT);
-
+        bool chk = (ag_memblock_cmp(i, j) == AG_CMP_LT);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_08, "ag_memblock_cmp() returns AG_CMP_GT when comparing an int"
@@ -497,12 +478,12 @@ AG_TEST_INIT(cmp_08, "ag_memblock_cmp() returns AG_CMP_GT when comparing an int"
         int *j = ag_memblock_new(sizeof *j);
         *j = 1;
 
-        AG_TEST_ASSERT(ag_memblock_cmp(i, j) == AG_CMP_GT);
-
+        bool chk = (ag_memblock_cmp(i, j) == AG_CMP_GT);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_09, "ag_memblock_cmp() returns AG_CMP_LT when comparing a memory"
@@ -517,12 +498,12 @@ AG_TEST_INIT(cmp_09, "ag_memblock_cmp() returns AG_CMP_LT when comparing a memor
         b->i = 2;
         b->j = 2;
 
-        AG_TEST_ASSERT(ag_memblock_cmp(a, b) == AG_CMP_LT);
-
+        bool chk = (ag_memblock_cmp(a, b) == AG_CMP_LT);
         ag_memblock_release((ag_memblock **)&a);
         ag_memblock_release((ag_memblock **)&b);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(cmp_10, "ag_memblock_cmp() returns AG_CMP_GT when comparing a memory"
@@ -537,12 +518,12 @@ AG_TEST_INIT(cmp_10, "ag_memblock_cmp() returns AG_CMP_GT when comparing a memor
         b->i = 1;
         b->j = 1;
 
-        AG_TEST_ASSERT(ag_memblock_cmp(a, b) == AG_CMP_GT);
-
+        bool chk = ag_memblock_cmp(a, b) == AG_CMP_GT;
         ag_memblock_release((ag_memblock **)&a);
         ag_memblock_release((ag_memblock **)&b);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_01, "ag_memblock_lt() returns true for an int memory block with"
@@ -553,12 +534,12 @@ AG_TEST_INIT(lt_01, "ag_memblock_lt() returns true for an int memory block with"
         *i = 5;
         *j = 6;
 
-        AG_TEST_ASSERT (ag_memblock_lt(i, j));
-
+        bool chk = ag_memblock_lt(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+        
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_02, "ag_memblock_lt() returns false for an int memory block with"
@@ -569,12 +550,12 @@ AG_TEST_INIT(lt_02, "ag_memblock_lt() returns false for an int memory block with
         *i = 5;
         *j = 5;
 
-        AG_TEST_ASSERT (!ag_memblock_lt(i, j));
-
+        bool chk = !ag_memblock_lt(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(lt_03, "ag_memblock_lt() returns false for an int memory block with"
@@ -585,12 +566,12 @@ AG_TEST_INIT(lt_03, "ag_memblock_lt() returns false for an int memory block with
         *i = 6;
         *j = 5;
 
-        AG_TEST_ASSERT (!ag_memblock_lt(i, j));
-        
+        bool chk = !ag_memblock_lt(i, j); 
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_01, "ag_memblock_gt() returns true for an int memory block with"
@@ -601,12 +582,12 @@ AG_TEST_INIT(gt_01, "ag_memblock_gt() returns true for an int memory block with"
         *i = 6;
         *j = 5;
 
-        AG_TEST_ASSERT (ag_memblock_gt(i, j));
-
+        bool chk = ag_memblock_gt(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_02, "ag_memblock_gt() returns false for an int memory block with"
@@ -617,12 +598,12 @@ AG_TEST_INIT(gt_02, "ag_memblock_gt() returns false for an int memory block with
         *i = 5;
         *j = 5;
 
-        AG_TEST_ASSERT (!ag_memblock_gt(i, j));
-
+        bool chk = !ag_memblock_gt(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(gt_03, "ag_memblock_gt() returns false for an int memory block with"
@@ -633,12 +614,12 @@ AG_TEST_INIT(gt_03, "ag_memblock_gt() returns false for an int memory block with
         *i = 5;
         *j = 6;
 
-        AG_TEST_ASSERT (!ag_memblock_gt(i, j));
-        
+        bool chk = !ag_memblock_gt(i, j); 
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_01, "ag_memblock_eq() returns true for two int memory blocks with"
@@ -649,12 +630,12 @@ AG_TEST_INIT(eq_01, "ag_memblock_eq() returns true for two int memory blocks wit
         *i = 5;
         *j = 5;
 
-        AG_TEST_ASSERT (ag_memblock_eq(i, j));
-
+        bool chk = ag_memblock_eq(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_02, "ag_memblock_eq() returns false for an int memory block with"
@@ -665,12 +646,12 @@ AG_TEST_INIT(eq_02, "ag_memblock_eq() returns false for an int memory block with
         *i = 5;
         *j = 6;
 
-        AG_TEST_ASSERT (!ag_memblock_eq(i, j));
-
+        bool chk = !ag_memblock_eq(i, j);
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(eq_03, "ag_memblock_eq() returns false for an int memory block with"
@@ -681,23 +662,24 @@ AG_TEST_INIT(eq_03, "ag_memblock_eq() returns false for an int memory block with
         *i = 6;
         *j = 5;
 
-        AG_TEST_ASSERT (!ag_memblock_eq(i, j));
-        
+        bool chk = !ag_memblock_eq(i, j); 
         ag_memblock_release((ag_memblock **)&i);
         ag_memblock_release((ag_memblock **)&j);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
+
 
 AG_TEST_INIT(resize_01, "ag_memblock_resize() resizes an existing memory block")
 {
         char *bfr = ag_memblock_new(10);
         ag_memblock_resize((ag_memblock **)&bfr, 15);
 
-        AG_TEST_ASSERT (ag_memblock_sz(bfr) == 15);
-
+        bool chk = (ag_memblock_sz(bfr) == 15);
         ag_memblock_release((ag_memblock **)&bfr);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(resize_02, "ag_memblock_resize() preserves data when resizing to a"
@@ -708,11 +690,11 @@ AG_TEST_INIT(resize_02, "ag_memblock_resize() preserves data when resizing to a"
         bfr[5] = '\0';
         ag_memblock_resize((ag_memblock **)&bfr, 10);
 
-        AG_TEST_ASSERT (!strcmp(bfr, "Hello"));
-
+        bool chk = !strcmp(bfr, "Hello");
         ag_memblock_release((ag_memblock **)&bfr);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(resize_align_01, "ag_memblock_resize_align() resizes an existing"
@@ -721,11 +703,11 @@ AG_TEST_INIT(resize_align_01, "ag_memblock_resize_align() resizes an existing"
         char *bfr = ag_memblock_new(10);
         ag_memblock_resize_align((ag_memblock **)&bfr, 15, 8);
 
-        AG_TEST_ASSERT (ag_memblock_sz(bfr) == 15);
-
+        bool chk = (ag_memblock_sz(bfr) == 15);
         ag_memblock_release((ag_memblock **)&bfr);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(resize_align_02, "ag_memblock_resize_align() preserves data when"
@@ -736,11 +718,11 @@ AG_TEST_INIT(resize_align_02, "ag_memblock_resize_align() preserves data when"
         bfr[5] = '\0';
         ag_memblock_resize_align((ag_memblock **)&bfr, 10, 8);
 
-        AG_TEST_ASSERT (!strcmp(bfr, "Hello"));
-
+        bool chk = !strcmp(bfr, "Hello");
         ag_memblock_release((ag_memblock **)&bfr);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(resize_align_03, "ag_memblock_resize_align() aligns to the requested"
@@ -751,11 +733,11 @@ AG_TEST_INIT(resize_align_03, "ag_memblock_resize_align() aligns to the requeste
         bfr[5] = '\0';
         ag_memblock_resize_align((ag_memblock **)&bfr, 10, 32);
 
-        AG_TEST_ASSERT (ag_memblock_aligned(bfr, 32));
-
+        bool chk = ag_memblock_aligned(bfr, 32);
         ag_memblock_release((ag_memblock **)&bfr);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 AG_TEST_INIT(str_01, "ag_memblock_str() generates the string representation of a"
@@ -764,11 +746,11 @@ AG_TEST_INIT(str_01, "ag_memblock_str() generates the string representation of a
         int *i = ag_memblock_new(sizeof *i);
         AG_AUTO(ag_string) *s = ag_memblock_str(i);
 
-        AG_TEST_ASSERT (s && *s);
-
+        bool chk = s && *s;
         ag_memblock_release((ag_memblock **)&i);
+
+        AG_TEST (chk);
 }
-AG_TEST_EXIT();
 
 
 

--- a/test/memblock.c
+++ b/test/memblock.c
@@ -13,14 +13,14 @@ struct test2 {
 };
 
 
-AG_TEST_INIT(new_01, "ag_memblock_new() allocates memory on the heap for an"
+AG_TEST_CASE(new_01, "ag_memblock_new() allocates memory on the heap for an"
              " int") {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
         AG_TEST (m);
 }
 
 
-AG_TEST_INIT(new_02, "ag_memblock_new() allocates memory on the heap for a test"
+AG_TEST_CASE(new_02, "ag_memblock_new() allocates memory on the heap for a test"
              " struct")
 {
         struct test *t = ag_memblock_new(sizeof *t);
@@ -37,7 +37,7 @@ AG_TEST_INIT(new_02, "ag_memblock_new() allocates memory on the heap for a test"
 }
 
 
-AG_TEST_INIT(new_03, "ag_memblock_new() returns a block with a reference count"
+AG_TEST_CASE(new_03, "ag_memblock_new() returns a block with a reference count"
                 " of 1")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
@@ -45,7 +45,7 @@ AG_TEST_INIT(new_03, "ag_memblock_new() returns a block with a reference count"
 }
 
 
-AG_TEST_INIT(new_04, "ag_memblock_new() returns a block with the requested data"
+AG_TEST_CASE(new_04, "ag_memblock_new() returns a block with the requested data"
                 " size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
@@ -53,7 +53,7 @@ AG_TEST_INIT(new_04, "ag_memblock_new() returns a block with the requested data"
 }
 
 
-AG_TEST_INIT(new_05, "ag_memblock_new() returns a block with a total size >="
+AG_TEST_CASE(new_05, "ag_memblock_new() returns a block with a total size >="
                 " requested data size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new(sizeof(int));
@@ -61,7 +61,7 @@ AG_TEST_INIT(new_05, "ag_memblock_new() returns a block with a total size >="
 }
 
 
-AG_TEST_INIT(new_align_01, "ag_memblock_new_align() allocates memory on the heap"
+AG_TEST_CASE(new_align_01, "ag_memblock_new_align() allocates memory on the heap"
                 " for an int")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
@@ -69,7 +69,7 @@ AG_TEST_INIT(new_align_01, "ag_memblock_new_align() allocates memory on the heap
 }
 
 
-AG_TEST_INIT(new_align_02, "ag_memblock_new_align() allocates memory on the heap"
+AG_TEST_CASE(new_align_02, "ag_memblock_new_align() allocates memory on the heap"
                 " for a test struct")
 {
         struct test *t = ag_memblock_new_align(sizeof *t, 8);
@@ -86,7 +86,7 @@ AG_TEST_INIT(new_align_02, "ag_memblock_new_align() allocates memory on the heap
 }
 
 
-AG_TEST_INIT(new_align_03, "ag_memblock_new_align() returns a block with a"
+AG_TEST_CASE(new_align_03, "ag_memblock_new_align() returns a block with a"
                 " reference count of 1")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
@@ -94,7 +94,7 @@ AG_TEST_INIT(new_align_03, "ag_memblock_new_align() returns a block with a"
 }
 
 
-AG_TEST_INIT(new_align_04, "ag_memblock_new_align() returns a block with the"
+AG_TEST_CASE(new_align_04, "ag_memblock_new_align() returns a block with the"
                 " requested data size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
@@ -102,7 +102,7 @@ AG_TEST_INIT(new_align_04, "ag_memblock_new_align() returns a block with the"
 }
 
 
-AG_TEST_INIT(new_align_05, "ag_memblock_new_align() returns a block with a total"
+AG_TEST_CASE(new_align_05, "ag_memblock_new_align() returns a block with a total"
                 " size >= requested data size")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 8);
@@ -110,7 +110,7 @@ AG_TEST_INIT(new_align_05, "ag_memblock_new_align() returns a block with a total
 }
 
 
-AG_TEST_INIT(new_align_06, "ag_memblock_new_align() returns a block with the"
+AG_TEST_CASE(new_align_06, "ag_memblock_new_align() returns a block with the"
                 " required alignment")
 {
         AG_AUTO(ag_memblock) *m = ag_memblock_new_align(sizeof(int), 32);
@@ -118,7 +118,7 @@ AG_TEST_INIT(new_align_06, "ag_memblock_new_align() returns a block with the"
 }
 
 
-AG_TEST_INIT(clone_01, "ag_memblock_clone() makes a deep copy of an int in the"
+AG_TEST_CASE(clone_01, "ag_memblock_clone() makes a deep copy of an int in the"
                 " heap")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -133,7 +133,7 @@ AG_TEST_INIT(clone_01, "ag_memblock_clone() makes a deep copy of an int in the"
         AG_TEST (chk);
 }
 
-AG_TEST_INIT(clone_02, "ag_memblock_clone() makes a deep copy of a test structure"
+AG_TEST_CASE(clone_02, "ag_memblock_clone() makes a deep copy of a test structure"
                 " in the heap")
 {
         struct test *t = ag_memblock_new(sizeof *t);
@@ -155,7 +155,7 @@ AG_TEST_INIT(clone_02, "ag_memblock_clone() makes a deep copy of a test structur
 }
 
 
-AG_TEST_INIT(clone_03, "ag_memblock_clone() returns a copy with another address")
+AG_TEST_CASE(clone_03, "ag_memblock_clone() returns a copy with another address")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
         AG_AUTO(ag_memblock) *cp = ag_memblock_clone(src);
@@ -163,7 +163,7 @@ AG_TEST_INIT(clone_03, "ag_memblock_clone() returns a copy with another address"
 }
 
 
-AG_TEST_INIT(clone_04, "ag_memblock_clone() sets the reference count of the copy"
+AG_TEST_CASE(clone_04, "ag_memblock_clone() sets the reference count of the copy"
                 " to 1")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -172,7 +172,7 @@ AG_TEST_INIT(clone_04, "ag_memblock_clone() sets the reference count of the copy
         AG_TEST (ag_memblock_refc(cp) == 1);
 }
 
-AG_TEST_INIT(clone_05, "ag_memblock_clone() does not change the reference count"
+AG_TEST_CASE(clone_05, "ag_memblock_clone() does not change the reference count"
                        " of the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -182,7 +182,7 @@ AG_TEST_INIT(clone_05, "ag_memblock_clone() does not change the reference count"
 }
 
 
-AG_TEST_INIT(clone_06, "ag_memblock_clone() preserves the data size of the"
+AG_TEST_CASE(clone_06, "ag_memblock_clone() preserves the data size of the"
                        " source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -192,7 +192,7 @@ AG_TEST_INIT(clone_06, "ag_memblock_clone() preserves the data size of the"
 }
 
 
-AG_TEST_INIT(clone_07, 
+AG_TEST_CASE(clone_07, 
              "ag_memblock_clone() maintains the total size of the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -201,7 +201,7 @@ AG_TEST_INIT(clone_07,
         AG_TEST (ag_memblock_sz(src) >= ag_memblock_sz(cp));
 }
 
-AG_TEST_INIT(clone_align_01, 
+AG_TEST_CASE(clone_align_01, 
              "ag_memblock_clone_align() makes a deep copy of an int")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -217,7 +217,7 @@ AG_TEST_INIT(clone_align_01,
 }
 
 
-AG_TEST_INIT(clone_align_02, 
+AG_TEST_CASE(clone_align_02, 
              "ag_memblock_clone_align() makes a deep copy of a test structure")
 {
         struct test *t = ag_memblock_new(sizeof *t);
@@ -239,7 +239,7 @@ AG_TEST_INIT(clone_align_02,
 }
 
 
-AG_TEST_INIT(clone_align_03, "ag_memblock_clone_align() returns a copy with another"
+AG_TEST_CASE(clone_align_03, "ag_memblock_clone_align() returns a copy with another"
                 " address")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -248,7 +248,7 @@ AG_TEST_INIT(clone_align_03, "ag_memblock_clone_align() returns a copy with anot
 }
 
 
-AG_TEST_INIT(clone_align_04, "ag_memblock_clone_align() sets the reference count of"
+AG_TEST_CASE(clone_align_04, "ag_memblock_clone_align() sets the reference count of"
                 " the copy to 1")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -258,7 +258,7 @@ AG_TEST_INIT(clone_align_04, "ag_memblock_clone_align() sets the reference count
         AG_TEST (ag_memblock_refc(cp2) == 1);
 }
 
-AG_TEST_INIT(clone_align_05, "ag_memblock_clone_align() does not change the"
+AG_TEST_CASE(clone_align_05, "ag_memblock_clone_align() does not change the"
                 " reference count of the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -269,7 +269,7 @@ AG_TEST_INIT(clone_align_05, "ag_memblock_clone_align() does not change the"
 }
 
 
-AG_TEST_INIT(clone_align_06, "ag_memblock_clone_align() preserves the data size of"
+AG_TEST_CASE(clone_align_06, "ag_memblock_clone_align() preserves the data size of"
                 " the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -279,7 +279,7 @@ AG_TEST_INIT(clone_align_06, "ag_memblock_clone_align() preserves the data size 
 }
 
 
-AG_TEST_INIT(clone_align_07, "ag_memblock_clone_align() maintains the total size of"
+AG_TEST_CASE(clone_align_07, "ag_memblock_clone_align() maintains the total size of"
                 " the source")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -289,7 +289,7 @@ AG_TEST_INIT(clone_align_07, "ag_memblock_clone_align() maintains the total size
 }
 
 
-AG_TEST_INIT(clone_align_08, "ag_memblock_clone_align() honours its alignment"
+AG_TEST_CASE(clone_align_08, "ag_memblock_clone_align() honours its alignment"
                 " request")
 {
         AG_AUTO(ag_memblock) *src = ag_memblock_new(sizeof(int));
@@ -299,14 +299,14 @@ AG_TEST_INIT(clone_align_08, "ag_memblock_clone_align() honours its alignment"
 }
 
 
-AG_TEST_INIT(release_01, "ag_memblock_release() performs a no-op if passed NULL")
+AG_TEST_CASE(release_01, "ag_memblock_release() performs a no-op if passed NULL")
 {
         ag_memblock_release(NULL);
         AG_TEST (true);
 }
 
 
-AG_TEST_INIT(release_02, "ag_memblock_release() performs a no-op if passed a"
+AG_TEST_CASE(release_02, "ag_memblock_release() performs a no-op if passed a"
                 " handle to a null pointer")
 {
         ag_memblock *m = NULL;
@@ -315,7 +315,7 @@ AG_TEST_INIT(release_02, "ag_memblock_release() performs a no-op if passed a"
 }
 
 
-AG_TEST_INIT(release_03, "ag_memblock_release() release an int on the heap")
+AG_TEST_CASE(release_03, "ag_memblock_release() release an int on the heap")
 {
         int *i = ag_memblock_new(sizeof *i);
         ag_memblock_release((ag_memblock **)&i);
@@ -323,7 +323,7 @@ AG_TEST_INIT(release_03, "ag_memblock_release() release an int on the heap")
 }
 
 
-AG_TEST_INIT(release_04, "ag_memblock_release() releases a test struct on the"
+AG_TEST_CASE(release_04, "ag_memblock_release() releases a test struct on the"
                 " heap")
 {
         struct test *t = ag_memblock_new(sizeof *t);
@@ -332,7 +332,7 @@ AG_TEST_INIT(release_04, "ag_memblock_release() releases a test struct on the"
 }
 
 
-AG_TEST_INIT(release_05, "ag_memblock_release() reduces the reference count by 1"
+AG_TEST_CASE(release_05, "ag_memblock_release() reduces the reference count by 1"
                 "for lazy copies")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -343,7 +343,7 @@ AG_TEST_INIT(release_05, "ag_memblock_release() reduces the reference count by 1
 }
 
 
-AG_TEST_INIT(release_06, "ag_memblock_release() on a deep copy does not alter the"
+AG_TEST_CASE(release_06, "ag_memblock_release() on a deep copy does not alter the"
                 " reference count of the source")
 {
         AG_AUTO(ag_memblock) *i = ag_memblock_new(sizeof(int));
@@ -356,7 +356,7 @@ AG_TEST_INIT(release_06, "ag_memblock_release() on a deep copy does not alter th
 
 
 
-AG_TEST_INIT(cmp_01, "ag_memblock_cmp() returns AG_CMP_EQ for two int memory"
+AG_TEST_CASE(cmp_01, "ag_memblock_cmp() returns AG_CMP_EQ for two int memory"
                 " blocks with the same value")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -372,7 +372,7 @@ AG_TEST_INIT(cmp_01, "ag_memblock_cmp() returns AG_CMP_EQ for two int memory"
 }
 
 
-AG_TEST_INIT(cmp_02, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
+AG_TEST_CASE(cmp_02, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
                 " shallow copy of an int with its source")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -387,7 +387,7 @@ AG_TEST_INIT(cmp_02, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
 }
 
 
-AG_TEST_INIT(cmp_03, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
+AG_TEST_CASE(cmp_03, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
                 " copy of an int with its source")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -402,7 +402,7 @@ AG_TEST_INIT(cmp_03, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
 }
 
 
-AG_TEST_INIT(cmp_04, "ag_memblock_cmp() returns AG_CMP_EQ for two memory blocks"
+AG_TEST_CASE(cmp_04, "ag_memblock_cmp() returns AG_CMP_EQ for two memory blocks"
                 " with the same struct with scalar fields")
 {
         struct test2 *a = ag_memblock_new(sizeof *a);
@@ -420,7 +420,7 @@ AG_TEST_INIT(cmp_04, "ag_memblock_cmp() returns AG_CMP_EQ for two memory blocks"
 }
 
 
-AG_TEST_INIT(cmp_05, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
+AG_TEST_CASE(cmp_05, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
                 " shallow copy of a struct with scalar fields")
 {
         struct test2 *a = ag_memblock_new(sizeof *a);
@@ -437,7 +437,7 @@ AG_TEST_INIT(cmp_05, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a"
 }
 
 
-AG_TEST_INIT(cmp_06, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
+AG_TEST_CASE(cmp_06, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
                 " copy of a struct with scalar fields")
 {
         struct test2 *a = ag_memblock_new(sizeof *a);
@@ -453,7 +453,7 @@ AG_TEST_INIT(cmp_06, "ag_memblock_cmp() returns AG_CMP_EQ when comparing a deep"
 }
 
 
-AG_TEST_INIT(cmp_07, "ag_memblock_cmp() returns AG_CMP_LT when comparing an int"
+AG_TEST_CASE(cmp_07, "ag_memblock_cmp() returns AG_CMP_LT when comparing an int"
                 " memory block to another whose first differing byte is"
                 " greater")
 {
@@ -470,7 +470,7 @@ AG_TEST_INIT(cmp_07, "ag_memblock_cmp() returns AG_CMP_LT when comparing an int"
 }
 
 
-AG_TEST_INIT(cmp_08, "ag_memblock_cmp() returns AG_CMP_GT when comparing an int"
+AG_TEST_CASE(cmp_08, "ag_memblock_cmp() returns AG_CMP_GT when comparing an int"
                 " memory block to another whose first differing byte is lower")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -486,7 +486,7 @@ AG_TEST_INIT(cmp_08, "ag_memblock_cmp() returns AG_CMP_GT when comparing an int"
 }
 
 
-AG_TEST_INIT(cmp_09, "ag_memblock_cmp() returns AG_CMP_LT when comparing a memory"
+AG_TEST_CASE(cmp_09, "ag_memblock_cmp() returns AG_CMP_LT when comparing a memory"
                 " block holding a struct with scalar fields to another whose"
                 " first differing byte is greater")
 {
@@ -506,7 +506,7 @@ AG_TEST_INIT(cmp_09, "ag_memblock_cmp() returns AG_CMP_LT when comparing a memor
 }
 
 
-AG_TEST_INIT(cmp_10, "ag_memblock_cmp() returns AG_CMP_GT when comparing a memory"
+AG_TEST_CASE(cmp_10, "ag_memblock_cmp() returns AG_CMP_GT when comparing a memory"
                 " block holding a struct with scalar fields to another whose"
                 " first differing byte is lower")
 {
@@ -526,7 +526,7 @@ AG_TEST_INIT(cmp_10, "ag_memblock_cmp() returns AG_CMP_GT when comparing a memor
 }
 
 
-AG_TEST_INIT(lt_01, "ag_memblock_lt() returns true for an int memory block with"
+AG_TEST_CASE(lt_01, "ag_memblock_lt() returns true for an int memory block with"
                 " a value lower than another")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -542,7 +542,7 @@ AG_TEST_INIT(lt_01, "ag_memblock_lt() returns true for an int memory block with"
 }
 
 
-AG_TEST_INIT(lt_02, "ag_memblock_lt() returns false for an int memory block with"
+AG_TEST_CASE(lt_02, "ag_memblock_lt() returns false for an int memory block with"
                 " the same value as another")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -558,7 +558,7 @@ AG_TEST_INIT(lt_02, "ag_memblock_lt() returns false for an int memory block with
 }
 
 
-AG_TEST_INIT(lt_03, "ag_memblock_lt() returns false for an int memory block with"
+AG_TEST_CASE(lt_03, "ag_memblock_lt() returns false for an int memory block with"
                 " a greater value than another")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -574,7 +574,7 @@ AG_TEST_INIT(lt_03, "ag_memblock_lt() returns false for an int memory block with
 }
 
 
-AG_TEST_INIT(gt_01, "ag_memblock_gt() returns true for an int memory block with"
+AG_TEST_CASE(gt_01, "ag_memblock_gt() returns true for an int memory block with"
                 " a value greater than another")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -590,7 +590,7 @@ AG_TEST_INIT(gt_01, "ag_memblock_gt() returns true for an int memory block with"
 }
 
 
-AG_TEST_INIT(gt_02, "ag_memblock_gt() returns false for an int memory block with"
+AG_TEST_CASE(gt_02, "ag_memblock_gt() returns false for an int memory block with"
                 " the same value as another")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -606,7 +606,7 @@ AG_TEST_INIT(gt_02, "ag_memblock_gt() returns false for an int memory block with
 }
 
 
-AG_TEST_INIT(gt_03, "ag_memblock_gt() returns false for an int memory block with"
+AG_TEST_CASE(gt_03, "ag_memblock_gt() returns false for an int memory block with"
                 " a lower value than another")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -622,7 +622,7 @@ AG_TEST_INIT(gt_03, "ag_memblock_gt() returns false for an int memory block with
 }
 
 
-AG_TEST_INIT(eq_01, "ag_memblock_eq() returns true for two int memory blocks with"
+AG_TEST_CASE(eq_01, "ag_memblock_eq() returns true for two int memory blocks with"
                 " the same value")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -638,7 +638,7 @@ AG_TEST_INIT(eq_01, "ag_memblock_eq() returns true for two int memory blocks wit
 }
 
 
-AG_TEST_INIT(eq_02, "ag_memblock_eq() returns false for an int memory block with"
+AG_TEST_CASE(eq_02, "ag_memblock_eq() returns false for an int memory block with"
                 " a lower value than another")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -654,7 +654,7 @@ AG_TEST_INIT(eq_02, "ag_memblock_eq() returns false for an int memory block with
 }
 
 
-AG_TEST_INIT(eq_03, "ag_memblock_eq() returns false for an int memory block with"
+AG_TEST_CASE(eq_03, "ag_memblock_eq() returns false for an int memory block with"
                 " a greater value than another")
 {
         int *i = ag_memblock_new(sizeof *i);
@@ -670,7 +670,7 @@ AG_TEST_INIT(eq_03, "ag_memblock_eq() returns false for an int memory block with
 }
 
 
-AG_TEST_INIT(resize_01, "ag_memblock_resize() resizes an existing memory block")
+AG_TEST_CASE(resize_01, "ag_memblock_resize() resizes an existing memory block")
 {
         char *bfr = ag_memblock_new(10);
         ag_memblock_resize((ag_memblock **)&bfr, 15);
@@ -682,7 +682,7 @@ AG_TEST_INIT(resize_01, "ag_memblock_resize() resizes an existing memory block")
 }
 
 
-AG_TEST_INIT(resize_02, "ag_memblock_resize() preserves data when resizing to a"
+AG_TEST_CASE(resize_02, "ag_memblock_resize() preserves data when resizing to a"
                 " larger size")
 {
         char *bfr = ag_memblock_new(6);
@@ -697,7 +697,7 @@ AG_TEST_INIT(resize_02, "ag_memblock_resize() preserves data when resizing to a"
 }
 
 
-AG_TEST_INIT(resize_align_01, "ag_memblock_resize_align() resizes an existing"
+AG_TEST_CASE(resize_align_01, "ag_memblock_resize_align() resizes an existing"
                 " memory block")
 {
         char *bfr = ag_memblock_new(10);
@@ -710,7 +710,7 @@ AG_TEST_INIT(resize_align_01, "ag_memblock_resize_align() resizes an existing"
 }
 
 
-AG_TEST_INIT(resize_align_02, "ag_memblock_resize_align() preserves data when"
+AG_TEST_CASE(resize_align_02, "ag_memblock_resize_align() preserves data when"
                 " resizing to a larger size")
 {
         char *bfr = ag_memblock_new(6);
@@ -725,7 +725,7 @@ AG_TEST_INIT(resize_align_02, "ag_memblock_resize_align() preserves data when"
 }
 
 
-AG_TEST_INIT(resize_align_03, "ag_memblock_resize_align() aligns to the requested"
+AG_TEST_CASE(resize_align_03, "ag_memblock_resize_align() aligns to the requested"
                 " boundary")
 {
         char *bfr = ag_memblock_new(6);
@@ -740,7 +740,7 @@ AG_TEST_INIT(resize_align_03, "ag_memblock_resize_align() aligns to the requeste
 }
 
 
-AG_TEST_INIT(str_01, "ag_memblock_str() generates the string representation of a"
+AG_TEST_CASE(str_01, "ag_memblock_str() generates the string representation of a"
                 " memory block")
 {
         int *i = ag_memblock_new(sizeof *i);

--- a/test/object.c
+++ b/test/object.c
@@ -134,26 +134,26 @@ static void register_derived(void)
 }
 
 
-AG_TEST_INIT(new_01, "ag_object_new() creates a new base object") {
+AG_TEST_CASE(new_01, "ag_object_new() creates a new base object") {
         AG_AUTO(ag_object) *o = sample_base();
         AG_TEST (o);
 }
 
 
-AG_TEST_INIT(new_02, "ag_object_new() creates a new derived object") {
+AG_TEST_CASE(new_02, "ag_object_new() creates a new derived object") {
         AG_AUTO(ag_object) *o = sample_derived();
         AG_TEST (o);
 }
 
 
-AG_TEST_INIT(copy_01, "ag_object_copy() makes a shallow copy of a base object") {
+AG_TEST_CASE(copy_01, "ag_object_copy() makes a shallow copy of a base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
         AG_TEST (o == o2);
 }
 
 
-AG_TEST_INIT(copy_02, "ag_object_copy() makes a shallow copy of a derived"
+AG_TEST_CASE(copy_02, "ag_object_copy() makes a shallow copy of a derived"
                       " object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -161,7 +161,7 @@ AG_TEST_INIT(copy_02, "ag_object_copy() makes a shallow copy of a derived"
 }
 
 
-AG_TEST_INIT(copy_03, "ag_object_copy() updates the reference count of a shallow"
+AG_TEST_CASE(copy_03, "ag_object_copy() updates the reference count of a shallow"
                       " copy of a base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -169,7 +169,7 @@ AG_TEST_INIT(copy_03, "ag_object_copy() updates the reference count of a shallow
 }
 
 
-AG_TEST_INIT(copy_04, "ag_object_copy() updates the reference count of a shallow"
+AG_TEST_CASE(copy_04, "ag_object_copy() updates the reference count of a shallow"
                       " copy of a derived object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -177,7 +177,7 @@ AG_TEST_INIT(copy_04, "ag_object_copy() updates the reference count of a shallow
 }
 
 
-AG_TEST_INIT(copy_05, "ag_object_copy() preserves the data of the shallow copy of"
+AG_TEST_CASE(copy_05, "ag_object_copy() preserves the data of the shallow copy of"
                       " a base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -189,7 +189,7 @@ AG_TEST_INIT(copy_05, "ag_object_copy() preserves the data of the shallow copy o
 }
 
 
-AG_TEST_INIT(copy_06, "ag_object_copy() preserves the data of the shallow copy of"
+AG_TEST_CASE(copy_06, "ag_object_copy() preserves the data of the shallow copy of"
                       " a derived object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -201,21 +201,21 @@ AG_TEST_INIT(copy_06, "ag_object_copy() preserves the data of the shallow copy o
 }
 
 
-AG_TEST_INIT(clone_01, "ag_object_clone() makes a deep copy of a base object") {
+AG_TEST_CASE(clone_01, "ag_object_clone() makes a deep copy of a base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
         AG_TEST (o != o2);
 }
 
 
-AG_TEST_INIT(clone_02, "ag_object_clone() makes a deep copy of a derived object") {
+AG_TEST_CASE(clone_02, "ag_object_clone() makes a deep copy of a derived object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
         AG_TEST (o != o2);
 }
 
 
-AG_TEST_INIT(clone_03, "ag_object_clone() does not affect the reference count of"
+AG_TEST_CASE(clone_03, "ag_object_clone() does not affect the reference count of"
                        " the original base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
@@ -223,7 +223,7 @@ AG_TEST_INIT(clone_03, "ag_object_clone() does not affect the reference count of
 }
 
 
-AG_TEST_INIT(clone_04, "ag_object_clone() does not affect the reference count of"
+AG_TEST_CASE(clone_04, "ag_object_clone() does not affect the reference count of"
                        " the original derived object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
@@ -231,7 +231,7 @@ AG_TEST_INIT(clone_04, "ag_object_clone() does not affect the reference count of
 }
 
 
-AG_TEST_INIT(clone_05, "ag_object_clone() preserves the data of the deep copy of a"
+AG_TEST_CASE(clone_05, "ag_object_clone() preserves the data of the deep copy of a"
                        " base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
@@ -243,7 +243,7 @@ AG_TEST_INIT(clone_05, "ag_object_clone() preserves the data of the deep copy of
 }
 
 
-AG_TEST_INIT(clone_06, "ag_object_copy() preserves the data of the deep copy of a"
+AG_TEST_CASE(clone_06, "ag_object_copy() preserves the data of the deep copy of a"
                        " a derived object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
@@ -255,13 +255,13 @@ AG_TEST_INIT(clone_06, "ag_object_copy() preserves the data of the deep copy of 
 }
 
 
-AG_TEST_INIT(release_01, "ag_object_release() performs a no-op if passed NULL") {
+AG_TEST_CASE(release_01, "ag_object_release() performs a no-op if passed NULL") {
         ag_object_release(NULL);
         AG_TEST (true);
 }
 
 
-AG_TEST_INIT(release_02, "ag_object_release() performs a no-op if passed a handle"
+AG_TEST_CASE(release_02, "ag_object_release() performs a no-op if passed a handle"
                          " to a null pointer") {
         ag_object *o = NULL;
         ag_object_release(&o);
@@ -269,20 +269,20 @@ AG_TEST_INIT(release_02, "ag_object_release() performs a no-op if passed a handl
 }
 
 
-AG_TEST_INIT(release_03, "ag_object_release() releases a base object") {
+AG_TEST_CASE(release_03, "ag_object_release() releases a base object") {
         ag_object *o = sample_base();
         ag_object_release(&o);
         AG_TEST (!o);
 }
 
-AG_TEST_INIT(release_04, "ag_object_release() releases a derived object") {
+AG_TEST_CASE(release_04, "ag_object_release() releases a derived object") {
         ag_object *o = sample_derived();
         ag_object_release(&o);
         AG_TEST (!o);
 }
 
 
-AG_TEST_INIT(release_05, "ag_object_release() reduces the reference count by 1 for"
+AG_TEST_CASE(release_05, "ag_object_release() reduces the reference count by 1 for"
                          " a base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -293,7 +293,7 @@ AG_TEST_INIT(release_05, "ag_object_release() reduces the reference count by 1 f
 }
 
 
-AG_TEST_INIT(release_06, "ag_object_release() reduces the reference count by 1 for"
+AG_TEST_CASE(release_06, "ag_object_release() reduces the reference count by 1 for"
                          " a derived object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -304,7 +304,7 @@ AG_TEST_INIT(release_06, "ag_object_release() reduces the reference count by 1 f
 }
 
 
-AG_TEST_INIT(cmp_01, "ag_object_cmp() returns AG_CMP_EQ when comparing the same"
+AG_TEST_CASE(cmp_01, "ag_object_cmp() returns AG_CMP_EQ when comparing the same"
                      " base objects") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -312,7 +312,7 @@ AG_TEST_INIT(cmp_01, "ag_object_cmp() returns AG_CMP_EQ when comparing the same"
 }
 
 
-AG_TEST_INIT(cmp_02, "ag_object_cmp() return AG_CMP_EQ when comparing the same"
+AG_TEST_CASE(cmp_02, "ag_object_cmp() return AG_CMP_EQ when comparing the same"
                      " derived objects") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -320,7 +320,7 @@ AG_TEST_INIT(cmp_02, "ag_object_cmp() return AG_CMP_EQ when comparing the same"
 }
 
 
-AG_TEST_INIT(lt_01, "ag_object_lt() returns false when comparing the same base"
+AG_TEST_CASE(lt_01, "ag_object_lt() returns false when comparing the same base"
                     " objects") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -328,7 +328,7 @@ AG_TEST_INIT(lt_01, "ag_object_lt() returns false when comparing the same base"
 }
 
 
-AG_TEST_INIT(lt_02, "ag_object_lt() returns false when comparing the same derived"
+AG_TEST_CASE(lt_02, "ag_object_lt() returns false when comparing the same derived"
                     " objects") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -336,7 +336,7 @@ AG_TEST_INIT(lt_02, "ag_object_lt() returns false when comparing the same derive
 }
 
 
-AG_TEST_INIT(gt_01, "ag_object_gt() returns false when comparing the same base"
+AG_TEST_CASE(gt_01, "ag_object_gt() returns false when comparing the same base"
                     " objects") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
@@ -344,7 +344,7 @@ AG_TEST_INIT(gt_01, "ag_object_gt() returns false when comparing the same base"
 }
 
 
-AG_TEST_INIT(gt_02,
+AG_TEST_CASE(gt_02,
     "ag_object_gt() returns false when comparing the same derived objects")
 {
         AG_AUTO(ag_object) *o = sample_derived();
@@ -354,7 +354,7 @@ AG_TEST_INIT(gt_02,
 }
 
 
-AG_TEST_INIT(typeid_01,
+AG_TEST_CASE(typeid_01,
     "ag_object_typeid() returns the type ID of a base object")
 {
         AG_AUTO(ag_object) *o = sample_base();
@@ -363,7 +363,7 @@ AG_TEST_INIT(typeid_01,
 }
 
 
-AG_TEST_INIT(typeid_02, 
+AG_TEST_CASE(typeid_02, 
     "ag_object_typeid() returns the type ID of a derived object")
 {
         AG_AUTO(ag_object) *o = sample_derived();
@@ -372,7 +372,7 @@ AG_TEST_INIT(typeid_02,
 }
 
 
-AG_TEST_INIT(uuid_01, "ag_object_uuid() returns the UUID of a base object")
+AG_TEST_CASE(uuid_01, "ag_object_uuid() returns the UUID of a base object")
 {
         AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_uuid) *u = ag_object_uuid(o);
@@ -381,7 +381,7 @@ AG_TEST_INIT(uuid_01, "ag_object_uuid() returns the UUID of a base object")
 }
 
 
-AG_TEST_INIT(uuid_02, "ag_object_uuid() returns the UUID of a derived object")
+AG_TEST_CASE(uuid_02, "ag_object_uuid() returns the UUID of a derived object")
 {
         AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_uuid) *u = ag_object_uuid(o);
@@ -390,7 +390,7 @@ AG_TEST_INIT(uuid_02, "ag_object_uuid() returns the UUID of a derived object")
 }
 
 
-AG_TEST_INIT(sz_01, "ag_object_sz() returns the size of a base object")
+AG_TEST_CASE(sz_01, "ag_object_sz() returns the size of a base object")
 {
         AG_AUTO(ag_object) *o = sample_base();
 
@@ -398,7 +398,7 @@ AG_TEST_INIT(sz_01, "ag_object_sz() returns the size of a base object")
 }
 
 
-AG_TEST_INIT(sz_02, "ag_object_sz() returns the size of a derived object")
+AG_TEST_CASE(sz_02, "ag_object_sz() returns the size of a derived object")
 {
         AG_AUTO(ag_object) *o = sample_derived();
 
@@ -406,7 +406,7 @@ AG_TEST_INIT(sz_02, "ag_object_sz() returns the size of a derived object")
 }
 
 
-AG_TEST_INIT(sz_03,
+AG_TEST_CASE(sz_03,
     "ag_object_sz() returns a greater size for a derived object than that of a"
     " base object")
 {
@@ -417,7 +417,7 @@ AG_TEST_INIT(sz_03,
 }
 
 
-AG_TEST_INIT(refc_01,
+AG_TEST_CASE(refc_01,
     "ag_object_refc() returns the reference count of a base object")
 {
         AG_AUTO(ag_object) *o = sample_base();
@@ -427,7 +427,7 @@ AG_TEST_INIT(refc_01,
 }
 
 
-AG_TEST_INIT(refc_02,
+AG_TEST_CASE(refc_02,
     "ag_object_refc() returns the reference count of a derived object")
 {
         AG_AUTO(ag_object) *o = sample_derived();
@@ -437,7 +437,7 @@ AG_TEST_INIT(refc_02,
 }
 
 
-AG_TEST_INIT(len_01, "ag_object_len() returns 1 for a base object")
+AG_TEST_CASE(len_01, "ag_object_len() returns 1 for a base object")
 {
         AG_AUTO(ag_object) *o = sample_base();
 
@@ -445,7 +445,7 @@ AG_TEST_INIT(len_01, "ag_object_len() returns 1 for a base object")
 }
 
 
-AG_TEST_INIT(len_02, "ag_object_len() returns 0 for a derived object")
+AG_TEST_CASE(len_02, "ag_object_len() returns 0 for a derived object")
 {
         AG_AUTO(ag_object) *o = sample_derived();
 
@@ -453,7 +453,7 @@ AG_TEST_INIT(len_02, "ag_object_len() returns 0 for a derived object")
 }
 
 
-AG_TEST_INIT(valid_01,
+AG_TEST_CASE(valid_01,
     "ag_object_valid() executes its default callback if not overridden")
 {
         AG_AUTO(ag_object) *o = sample_base();
@@ -462,7 +462,7 @@ AG_TEST_INIT(valid_01,
 }
 
 
-AG_TEST_INIT(valid_02,
+AG_TEST_CASE(valid_02,
     "ag_object_valid() executes its provided callback if overridden")
 {
         AG_AUTO(ag_object) *o = sample_derived();
@@ -471,7 +471,7 @@ AG_TEST_INIT(valid_02,
 }
 
 
-AG_TEST_INIT(hash_01,
+AG_TEST_CASE(hash_01,
     "ag_object_hash() executes its default callback if not overridden")
 {
         AG_AUTO(ag_object) *o = sample_base();
@@ -481,7 +481,7 @@ AG_TEST_INIT(hash_01,
 }
 
 
-AG_TEST_INIT(hash_02,
+AG_TEST_CASE(hash_02,
     "ag_object_hash() executes its provided callback if overridden")
 {
         AG_AUTO(ag_object) *o = sample_derived();
@@ -491,7 +491,7 @@ AG_TEST_INIT(hash_02,
 }
 
 
-AG_TEST_INIT(str_01,
+AG_TEST_CASE(str_01,
     "ag_object_str() executes its default callback if not overridden")
 {
         AG_AUTO(ag_object) *o = sample_base();
@@ -501,7 +501,7 @@ AG_TEST_INIT(str_01,
 }
 
 
-AG_TEST_INIT(str_02,
+AG_TEST_CASE(str_02,
     "ag_object_str() executes its provided callback if overridden")
 {
         AG_AUTO(ag_object) *o = sample_derived();
@@ -511,7 +511,7 @@ AG_TEST_INIT(str_02,
 }
 
 
-AG_TEST_INIT(empty_01,
+AG_TEST_CASE(empty_01,
     "ag_object_empty() returns false if the object length is greater than zero")
 {
         AG_AUTO(ag_object) *o = sample_base();
@@ -520,7 +520,7 @@ AG_TEST_INIT(empty_01,
 }
 
 
-AG_TEST_INIT(empty_02,
+AG_TEST_CASE(empty_02,
     "ag_object_empty() returns true if the object length is zero")
 {
         AG_AUTO(ag_object) *o = sample_derived();
@@ -529,7 +529,7 @@ AG_TEST_INIT(empty_02,
 }
 
 
-AG_TEST_INIT(payload_01,
+AG_TEST_CASE(payload_01,
     "ag_object_payload() gets a handle to the object payload")
 {
         AG_AUTO(ag_object) *o = sample_base();
@@ -539,7 +539,7 @@ AG_TEST_INIT(payload_01,
 }
 
 
-AG_TEST_INIT(payload_mutable_01,
+AG_TEST_CASE(payload_mutable_01,
     "ag_object_payload_mutable() gets a handle to the object payload")
 {
         AG_AUTO(ag_object) *o = sample_derived();
@@ -549,7 +549,7 @@ AG_TEST_INIT(payload_mutable_01,
 }
 
 
-AG_TEST_INIT(payload_mutable_02,
+AG_TEST_CASE(payload_mutable_02,
     "ag_object_payload_mutable() does not create a clone of the object if its"
     " refc is 1")
 {
@@ -561,7 +561,7 @@ AG_TEST_INIT(payload_mutable_02,
 }
 
 
-AG_TEST_INIT(payload_mutable_03,
+AG_TEST_CASE(payload_mutable_03,
     "ag_object_payload_mutable() creates a clone of  the object if its"
     " refc > 1")
 {
@@ -573,7 +573,7 @@ AG_TEST_INIT(payload_mutable_03,
 }
 
 
-AG_TEST_INIT(payload_mutable_04, 
+AG_TEST_CASE(payload_mutable_04, 
     "ag_object_payload_mutable() reduces the refc of the original object by 1"
     " if it creates a clone")
 {

--- a/test/object.c
+++ b/test/object.c
@@ -6,18 +6,19 @@
 
 
 struct payload_base {
-        int x;
-        int y;
+        int     x;
+        int     y;
 };
 
 
 struct payload_derived {
-        int *x;
-        int *y;
+        int     *x;
+        int     *y;
 };
 
 
-static ag_object *sample_base(void)
+static ag_object *
+sample_base(void)
 {
         struct payload_base *p = ag_memblock_new(sizeof *p);
         p->x = 555;
@@ -27,7 +28,8 @@ static ag_object *sample_base(void)
 }
 
 
-static ag_object *sample_derived(void)
+static ag_object *
+sample_derived(void)
 {
         struct payload_derived *p = ag_memblock_new(sizeof *p);
 
@@ -41,30 +43,33 @@ static ag_object *sample_derived(void)
 }
 
 
-static ag_memblock *virt_clone(const ag_memblock *payload)
+static ag_memblock *
+virt_clone(const ag_memblock *payload)
 {
-    const struct payload_derived *p = (const struct payload_derived *)payload;
-    struct payload_derived *cp = ag_memblock_new(sizeof *p);
+        const struct payload_derived *p = payload;
+        struct payload_derived *cp = ag_memblock_new(sizeof *p);
 
-    cp->x = ag_memblock_new(sizeof *cp->x);
-    cp->y = ag_memblock_new(sizeof *cp->y);
+        cp->x = ag_memblock_new(sizeof *cp->x);
+        cp->y = ag_memblock_new(sizeof *cp->y);
 
-    *cp->x = *p->x;
-    *cp->y = *p->y;
+        *cp->x = *p->x;
+        *cp->y = *p->y;
 
-    return cp;
+        return cp;
 }
 
 
-static void virt_release(ag_memblock *payload)
+static void
+virt_release(ag_memblock *payload)
 {
-    struct payload_derived *p = (struct payload_derived *)payload;
-    ag_memblock_release((void **) &p->x);
-    ag_memblock_release((void **) &p->y);
+        struct payload_derived *p = (struct payload_derived *)payload;
+        ag_memblock_release((void **) &p->x);
+        ag_memblock_release((void **) &p->y);
 }
 
 
-static enum ag_cmp virt_cmp(const ag_object *ctx, const ag_object *cmp)
+static enum ag_cmp
+virt_cmp(const ag_object *ctx, const ag_object *cmp)
 {
         AG_AUTO(ag_uuid) *u1 = ag_object_uuid(ctx);
         AG_AUTO(ag_uuid) *u2 = ag_object_uuid(cmp);
@@ -73,14 +78,16 @@ static enum ag_cmp virt_cmp(const ag_object *ctx, const ag_object *cmp)
 }
 
 
-static bool virt_valid(const ag_object *ctx)
+static bool
+virt_valid(const ag_object *ctx)
 {
         const struct payload_derived *p = ag_object_payload(ctx);
         return *p->x == 555 && *p->y == -666;
 }
 
 
-static size_t virt_sz(const ag_object *ctx)
+static size_t
+virt_sz(const ag_object *ctx)
 {
         const struct payload_derived *p = ag_object_payload(ctx);
 
@@ -89,28 +96,32 @@ static size_t virt_sz(const ag_object *ctx)
 }
 
 
-static size_t virt_len(const ag_object *ctx)
+static size_t
+virt_len(const ag_object *ctx)
 {
         (void)ctx;
         return 0;
 }
 
 
-static ag_hash virt_hash(const ag_object *ctx)
+static ag_hash
+virt_hash(const ag_object *ctx)
 {
         const struct payload_derived *p = ag_object_payload(ctx);
         return ag_hash_new(*p->x);
 }
 
 
-static ag_string *virt_str(const ag_object *ctx)
+static ag_string *
+virt_str(const ag_object *ctx)
 {
         (void)ctx;
         return ag_string_new("This is a sample derived object");
 }
 
 
-static void register_base(void)
+static void
+register_base(void)
 {
         struct ag_object_vtable vt = {
                 .clone = NULL, .release = NULL, .cmp = NULL,
@@ -122,7 +133,8 @@ static void register_base(void)
 }
 
 
-static void register_derived(void)
+static void
+register_derived(void)
 {
         struct ag_object_vtable vt = {
                 .clone = virt_clone, .release = virt_release, .cmp = virt_cmp,
@@ -134,212 +146,261 @@ static void register_derived(void)
 }
 
 
-AG_TEST_CASE(new_01, "ag_object_new() creates a new base object") {
+AG_TEST_CASE(new_01, "ag_object_new() creates a new base object")
+{
         AG_AUTO(ag_object) *o = sample_base();
+
         AG_TEST (o);
 }
 
 
-AG_TEST_CASE(new_02, "ag_object_new() creates a new derived object") {
+AG_TEST_CASE(new_02, "ag_object_new() creates a new derived object")
+{
         AG_AUTO(ag_object) *o = sample_derived();
+
         AG_TEST (o);
 }
 
 
-AG_TEST_CASE(copy_01, "ag_object_copy() makes a shallow copy of a base object") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_CASE(copy_01, "ag_object_copy() makes a shallow copy of a base object")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
         AG_TEST (o == o2);
 }
 
 
 AG_TEST_CASE(copy_02, "ag_object_copy() makes a shallow copy of a derived"
-                      " object") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+                      " object")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
         AG_TEST (o == o2);
 }
 
 
-AG_TEST_CASE(copy_03, "ag_object_copy() updates the reference count of a shallow"
-                      " copy of a base object") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_CASE(copy_03,
+    "ag_object_copy() updates the reference count of a shallow copy of a base"
+    " object")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
         AG_TEST (ag_object_refc(o) == 2);
 }
 
 
-AG_TEST_CASE(copy_04, "ag_object_copy() updates the reference count of a shallow"
-                      " copy of a derived object") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+AG_TEST_CASE(copy_04,
+    "ag_object_copy() updates the reference count of a shallow copy of a"
+    " derived object")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
         AG_TEST (ag_object_refc(o) == 2);
 }
 
 
-AG_TEST_CASE(copy_05, "ag_object_copy() preserves the data of the shallow copy of"
-                      " a base object") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_CASE(copy_05,
+    "ag_object_copy() preserves the data of the shallow copy of a base object")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
 
-        const struct payload_base *p  = ag_object_payload(o);
+        const struct payload_base *p = ag_object_payload(o);
         const struct payload_base *p2 = ag_object_payload(o2);
 
         AG_TEST (p->x == p2->x && p->y == p2->y);
 }
 
 
-AG_TEST_CASE(copy_06, "ag_object_copy() preserves the data of the shallow copy of"
-                      " a derived object") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+AG_TEST_CASE(copy_06,
+    "ag_object_copy() preserves the data of the shallow copy of a derived"
+    " object")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
 
-        const struct payload_derived *p  = ag_object_payload(o);
+        const struct payload_derived *p = ag_object_payload(o);
         const struct payload_derived *p2 = ag_object_payload(o2);
 
         AG_TEST (*p->x == *p2->x && *p->y == *p2->y);
 }
 
 
-AG_TEST_CASE(clone_01, "ag_object_clone() makes a deep copy of a base object") {
+AG_TEST_CASE(clone_01, "ag_object_clone() makes a deep copy of a base object")
+{
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
         AG_TEST (o != o2);
 }
 
 
-AG_TEST_CASE(clone_02, "ag_object_clone() makes a deep copy of a derived object") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+AG_TEST_CASE(clone_02,
+    "ag_object_clone() makes a deep copy of a derived object")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
+
         AG_TEST (o != o2);
 }
 
 
-AG_TEST_CASE(clone_03, "ag_object_clone() does not affect the reference count of"
-                       " the original base object") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_CASE(clone_03,
+    "ag_object_clone() does not affect the reference count of the original base"
+    " object")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
+
         AG_TEST (ag_object_refc(o) == 1);
 }
 
 
-AG_TEST_CASE(clone_04, "ag_object_clone() does not affect the reference count of"
-                       " the original derived object") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+AG_TEST_CASE(clone_04,
+    "ag_object_clone() does not affect the reference count of the original"
+    " derived object")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
+
         AG_TEST (ag_object_refc(o) == 1);
 }
 
 
-AG_TEST_CASE(clone_05, "ag_object_clone() preserves the data of the deep copy of a"
-                       " base object") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_CASE(clone_05,
+    "ag_object_clone() preserves the data of the deep copy of a base object")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
 
-        const struct payload_base *p  = ag_object_payload(o);
+        const struct payload_base *p = ag_object_payload(o);
         const struct payload_base *p2 = ag_object_payload(o2);
 
         AG_TEST (p->x == p2->x && p->y == p2->y);
 }
 
 
-AG_TEST_CASE(clone_06, "ag_object_copy() preserves the data of the deep copy of a"
-                       " a derived object") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+AG_TEST_CASE(clone_06,
+    "ag_object_copy() preserves the data of the deep copy of a a derived"
+    " object")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
 
-        const struct payload_derived *p  = ag_object_payload(o);
+        const struct payload_derived *p = ag_object_payload(o);
         const struct payload_derived *p2 = ag_object_payload(o2);
 
         AG_TEST (*p->x == *p2->x && *p->y == *p2->y);
 }
 
 
-AG_TEST_CASE(release_01, "ag_object_release() performs a no-op if passed NULL") {
+AG_TEST_CASE(release_01, "ag_object_release() performs a no-op if passed NULL")
+{
         ag_object_release(NULL);
         AG_TEST (true);
 }
 
 
-AG_TEST_CASE(release_02, "ag_object_release() performs a no-op if passed a handle"
-                         " to a null pointer") {
+AG_TEST_CASE(release_02,
+    "ag_object_release() performs a no-op if passed a handle to a null pointer")
+{
         ag_object *o = NULL;
         ag_object_release(&o);
+
         AG_TEST (true);
 }
 
 
-AG_TEST_CASE(release_03, "ag_object_release() releases a base object") {
+AG_TEST_CASE(release_03, "ag_object_release() releases a base object")
+{
         ag_object *o = sample_base();
         ag_object_release(&o);
+
         AG_TEST (!o);
 }
 
-AG_TEST_CASE(release_04, "ag_object_release() releases a derived object") {
+AG_TEST_CASE(release_04, "ag_object_release() releases a derived object")
+{
         ag_object *o = sample_derived();
         ag_object_release(&o);
+
         AG_TEST (!o);
 }
 
 
-AG_TEST_CASE(release_05, "ag_object_release() reduces the reference count by 1 for"
-                         " a base object") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_CASE(release_05,
+    "ag_object_release() reduces the reference count by 1 for a base object")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        ag_object          *o3 = ag_object_copy(o);
-
+        ag_object *o3 = ag_object_copy(o);
         ag_object_release(&o3);
+
         AG_TEST (ag_object_refc(o) == 2);
 }
 
 
-AG_TEST_CASE(release_06, "ag_object_release() reduces the reference count by 1 for"
-                         " a derived object") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+AG_TEST_CASE(release_06,
+"ag_object_release() reduces the reference count by 1 for a derived object")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        ag_object          *o3 = ag_object_copy(o);
-
+        ag_object *o3 = ag_object_copy(o);
         ag_object_release(&o3);
+
         AG_TEST (ag_object_refc(o) == 2);
 }
 
 
-AG_TEST_CASE(cmp_01, "ag_object_cmp() returns AG_CMP_EQ when comparing the same"
-                     " base objects") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_CASE(cmp_01,
+    "ag_object_cmp() returns AG_CMP_EQ when comparing the same base objects")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
         AG_TEST (ag_object_cmp(o, o2) == AG_CMP_EQ);
 }
 
 
-AG_TEST_CASE(cmp_02, "ag_object_cmp() return AG_CMP_EQ when comparing the same"
-                     " derived objects") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+AG_TEST_CASE(cmp_02,
+    "ag_object_cmp() return AG_CMP_EQ when comparing the same derived objects")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
         AG_TEST (ag_object_cmp(o, o2) == AG_CMP_EQ);
 }
 
 
-AG_TEST_CASE(lt_01, "ag_object_lt() returns false when comparing the same base"
-                    " objects") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_CASE(lt_01,
+    "ag_object_lt() returns false when comparing the same base objects")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
         AG_TEST (!ag_object_lt(o, o2));
 }
 
 
-AG_TEST_CASE(lt_02, "ag_object_lt() returns false when comparing the same derived"
-                    " objects") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+AG_TEST_CASE(lt_02,
+    "ag_object_lt() returns false when comparing the same derived objects")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
         AG_TEST (!ag_object_lt(o, o2));
 }
 
 
-AG_TEST_CASE(gt_01, "ag_object_gt() returns false when comparing the same base"
-                    " objects") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_CASE(gt_01,
+    "ag_object_gt() returns false when comparing the same base objects")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
         AG_TEST (!ag_object_gt(o, o2));
 }
 
@@ -363,7 +424,7 @@ AG_TEST_CASE(typeid_01,
 }
 
 
-AG_TEST_CASE(typeid_02, 
+AG_TEST_CASE(typeid_02,
     "ag_object_typeid() returns the type ID of a derived object")
 {
         AG_AUTO(ag_object) *o = sample_derived();
@@ -496,7 +557,7 @@ AG_TEST_CASE(str_01,
 {
         AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_string) *s = ag_object_str(o);
-        
+
         AG_TEST (ag_string_has(s, "uuid"));
 }
 
@@ -568,12 +629,12 @@ AG_TEST_CASE(payload_mutable_03,
         AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
         (void)ag_object_payload_mutable(&o);
-        
+
         AG_TEST (o != o2);
 }
 
 
-AG_TEST_CASE(payload_mutable_04, 
+AG_TEST_CASE(payload_mutable_04,
     "ag_object_payload_mutable() reduces the refc of the original object by 1"
     " if it creates a clone")
 {
@@ -581,7 +642,7 @@ AG_TEST_CASE(payload_mutable_04,
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
         AG_AUTO(ag_object) *o3 = ag_object_copy(o);
         (void)ag_object_payload_mutable(&o);
-        
+
         AG_TEST (ag_object_refc(o3) == 2);
 }
 
@@ -612,29 +673,29 @@ extern ag_test_suite *test_suite_object(void)
         };
 
         const char *desc[] = {
-                new_01_desc,             new_02_desc,     
-                copy_01_desc,            copy_02_desc,    
+                new_01_desc,             new_02_desc,
+                copy_01_desc,            copy_02_desc,
                 copy_03_desc,            copy_04_desc,
-                copy_05_desc,            copy_06_desc,    
-                clone_01_desc,           clone_02_desc,   
+                copy_05_desc,            copy_06_desc,
+                clone_01_desc,           clone_02_desc,
                 clone_03_desc,           clone_04_desc,
-                clone_05_desc,           clone_06_desc,   
-                release_01_desc,         release_02_desc, 
+                clone_05_desc,           clone_06_desc,
+                release_01_desc,         release_02_desc,
                 release_03_desc,         release_04_desc,
-                release_05_desc,         release_06_desc, 
-                cmp_01_desc,             cmp_02_desc,     
+                release_05_desc,         release_06_desc,
+                cmp_01_desc,             cmp_02_desc,
                 lt_01_desc,              lt_02_desc,
-                gt_01_desc,              gt_02_desc,      
-                typeid_01_desc,          typeid_02_desc,  
+                gt_01_desc,              gt_02_desc,
+                typeid_01_desc,          typeid_02_desc,
                 uuid_01_desc,            uuid_02_desc,
-                sz_01_desc,              sz_02_desc,      
-                sz_03_desc,              refc_01_desc,    
+                sz_01_desc,              sz_02_desc,
+                sz_03_desc,              refc_01_desc,
                 refc_02_desc,            len_01_desc,
-                len_02_desc,             valid_01_desc,   
-                valid_02_desc,           hash_01_desc,    
+                len_02_desc,             valid_01_desc,
+                valid_02_desc,           hash_01_desc,
                 hash_02_desc,            str_01_desc,
-                str_02_desc,             empty_01_desc,   
-                empty_02_desc,           payload_01_desc, 
+                str_02_desc,             empty_01_desc,
+                empty_02_desc,           payload_01_desc,
                 payload_mutable_01_desc, payload_mutable_02_desc,
                 payload_mutable_03_desc, payload_mutable_04_desc,
         };

--- a/test/object.c
+++ b/test/object.c
@@ -136,45 +136,45 @@ static void register_derived(void)
 
 AG_TEST_INIT(new_01, "ag_object_new() creates a new base object") {
         AG_AUTO(ag_object) *o = sample_base();
-        AG_TEST_ASSERT (o);
-} AG_TEST_EXIT();
+        AG_TEST (o);
+}
 
 
 AG_TEST_INIT(new_02, "ag_object_new() creates a new derived object") {
         AG_AUTO(ag_object) *o = sample_derived();
-        AG_TEST_ASSERT (o);
-} AG_TEST_EXIT();
+        AG_TEST (o);
+}
 
 
 AG_TEST_INIT(copy_01, "ag_object_copy() makes a shallow copy of a base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (o == o2);
-} AG_TEST_EXIT();
+        AG_TEST (o == o2);
+}
 
 
 AG_TEST_INIT(copy_02, "ag_object_copy() makes a shallow copy of a derived"
                       " object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (o == o2);
-} AG_TEST_EXIT();
+        AG_TEST (o == o2);
+}
 
 
 AG_TEST_INIT(copy_03, "ag_object_copy() updates the reference count of a shallow"
                       " copy of a base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (ag_object_refc(o) == 2);
-} AG_TEST_EXIT();
+        AG_TEST (ag_object_refc(o) == 2);
+}
 
 
 AG_TEST_INIT(copy_04, "ag_object_copy() updates the reference count of a shallow"
                       " copy of a derived object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (ag_object_refc(o) == 2);
-} AG_TEST_EXIT();
+        AG_TEST (ag_object_refc(o) == 2);
+}
 
 
 AG_TEST_INIT(copy_05, "ag_object_copy() preserves the data of the shallow copy of"
@@ -185,8 +185,8 @@ AG_TEST_INIT(copy_05, "ag_object_copy() preserves the data of the shallow copy o
         const struct payload_base *p  = ag_object_payload(o);
         const struct payload_base *p2 = ag_object_payload(o2);
 
-        AG_TEST_ASSERT (p->x == p2->x && p->y == p2->y);
-} AG_TEST_EXIT();
+        AG_TEST (p->x == p2->x && p->y == p2->y);
+}
 
 
 AG_TEST_INIT(copy_06, "ag_object_copy() preserves the data of the shallow copy of"
@@ -197,38 +197,38 @@ AG_TEST_INIT(copy_06, "ag_object_copy() preserves the data of the shallow copy o
         const struct payload_derived *p  = ag_object_payload(o);
         const struct payload_derived *p2 = ag_object_payload(o2);
 
-        AG_TEST_ASSERT (*p->x == *p2->x && *p->y == *p2->y);
-} AG_TEST_EXIT();
+        AG_TEST (*p->x == *p2->x && *p->y == *p2->y);
+}
 
 
 AG_TEST_INIT(clone_01, "ag_object_clone() makes a deep copy of a base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
-        AG_TEST_ASSERT (o != o2);
-} AG_TEST_EXIT();
+        AG_TEST (o != o2);
+}
 
 
 AG_TEST_INIT(clone_02, "ag_object_clone() makes a deep copy of a derived object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
-        AG_TEST_ASSERT (o != o2);
-} AG_TEST_EXIT();
+        AG_TEST (o != o2);
+}
 
 
 AG_TEST_INIT(clone_03, "ag_object_clone() does not affect the reference count of"
                        " the original base object") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
-        AG_TEST_ASSERT (ag_object_refc(o) == 1);
-} AG_TEST_EXIT();
+        AG_TEST (ag_object_refc(o) == 1);
+}
 
 
 AG_TEST_INIT(clone_04, "ag_object_clone() does not affect the reference count of"
                        " the original derived object") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_clone(o);
-        AG_TEST_ASSERT (ag_object_refc(o) == 1);
-} AG_TEST_EXIT();
+        AG_TEST (ag_object_refc(o) == 1);
+}
 
 
 AG_TEST_INIT(clone_05, "ag_object_clone() preserves the data of the deep copy of a"
@@ -239,8 +239,8 @@ AG_TEST_INIT(clone_05, "ag_object_clone() preserves the data of the deep copy of
         const struct payload_base *p  = ag_object_payload(o);
         const struct payload_base *p2 = ag_object_payload(o2);
 
-        AG_TEST_ASSERT (p->x == p2->x && p->y == p2->y);
-} AG_TEST_EXIT();
+        AG_TEST (p->x == p2->x && p->y == p2->y);
+}
 
 
 AG_TEST_INIT(clone_06, "ag_object_copy() preserves the data of the deep copy of a"
@@ -251,35 +251,35 @@ AG_TEST_INIT(clone_06, "ag_object_copy() preserves the data of the deep copy of 
         const struct payload_derived *p  = ag_object_payload(o);
         const struct payload_derived *p2 = ag_object_payload(o2);
 
-        AG_TEST_ASSERT (*p->x == *p2->x && *p->y == *p2->y);
-} AG_TEST_EXIT();
+        AG_TEST (*p->x == *p2->x && *p->y == *p2->y);
+}
 
 
 AG_TEST_INIT(release_01, "ag_object_release() performs a no-op if passed NULL") {
         ag_object_release(NULL);
-        AG_TEST_ASSERT (true);
-} AG_TEST_EXIT();
+        AG_TEST (true);
+}
 
 
 AG_TEST_INIT(release_02, "ag_object_release() performs a no-op if passed a handle"
                          " to a null pointer") {
         ag_object *o = NULL;
         ag_object_release(&o);
-        AG_TEST_ASSERT (true);
-} AG_TEST_EXIT();
+        AG_TEST (true);
+}
 
 
 AG_TEST_INIT(release_03, "ag_object_release() releases a base object") {
         ag_object *o = sample_base();
         ag_object_release(&o);
-        AG_TEST_ASSERT (!o);
-} AG_TEST_EXIT();
+        AG_TEST (!o);
+}
 
 AG_TEST_INIT(release_04, "ag_object_release() releases a derived object") {
         ag_object *o = sample_derived();
         ag_object_release(&o);
-        AG_TEST_ASSERT (!o);
-} AG_TEST_EXIT();
+        AG_TEST (!o);
+}
 
 
 AG_TEST_INIT(release_05, "ag_object_release() reduces the reference count by 1 for"
@@ -289,8 +289,8 @@ AG_TEST_INIT(release_05, "ag_object_release() reduces the reference count by 1 f
         ag_object          *o3 = ag_object_copy(o);
 
         ag_object_release(&o3);
-        AG_TEST_ASSERT (ag_object_refc(o) == 2);
-} AG_TEST_EXIT();
+        AG_TEST (ag_object_refc(o) == 2);
+}
 
 
 AG_TEST_INIT(release_06, "ag_object_release() reduces the reference count by 1 for"
@@ -300,237 +300,290 @@ AG_TEST_INIT(release_06, "ag_object_release() reduces the reference count by 1 f
         ag_object          *o3 = ag_object_copy(o);
 
         ag_object_release(&o3);
-        AG_TEST_ASSERT (ag_object_refc(o) == 2);
-} AG_TEST_EXIT();
+        AG_TEST (ag_object_refc(o) == 2);
+}
 
 
 AG_TEST_INIT(cmp_01, "ag_object_cmp() returns AG_CMP_EQ when comparing the same"
                      " base objects") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (ag_object_cmp(o, o2) == AG_CMP_EQ);
-} AG_TEST_EXIT();
+        AG_TEST (ag_object_cmp(o, o2) == AG_CMP_EQ);
+}
 
 
 AG_TEST_INIT(cmp_02, "ag_object_cmp() return AG_CMP_EQ when comparing the same"
                      " derived objects") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (ag_object_cmp(o, o2) == AG_CMP_EQ);
-} AG_TEST_EXIT();
+        AG_TEST (ag_object_cmp(o, o2) == AG_CMP_EQ);
+}
 
 
 AG_TEST_INIT(lt_01, "ag_object_lt() returns false when comparing the same base"
                     " objects") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (!ag_object_lt(o, o2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_object_lt(o, o2));
+}
 
 
 AG_TEST_INIT(lt_02, "ag_object_lt() returns false when comparing the same derived"
                     " objects") {
         AG_AUTO(ag_object) *o  = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (!ag_object_lt(o, o2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_object_lt(o, o2));
+}
 
 
 AG_TEST_INIT(gt_01, "ag_object_gt() returns false when comparing the same base"
                     " objects") {
         AG_AUTO(ag_object) *o  = sample_base();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (!ag_object_gt(o, o2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_object_gt(o, o2));
+}
 
 
-AG_TEST_INIT(gt_02, "ag_object_gt() returns false when comparing the same derived"
-                    " objects") {
-        AG_AUTO(ag_object) *o  = sample_derived();
+AG_TEST_INIT(gt_02,
+    "ag_object_gt() returns false when comparing the same derived objects")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (!ag_object_gt(o, o2));
-} AG_TEST_EXIT();
+
+        AG_TEST (!ag_object_gt(o, o2));
+}
 
 
-AG_TEST_INIT(typeid_01, "ag_object_typeid() returns the type ID of a base"
-                        " object") {
-        AG_AUTO(ag_object) *o  = sample_base();
-        AG_TEST_ASSERT (ag_object_typeid(o) == TYPEID_BASE);
-} AG_TEST_EXIT();
+AG_TEST_INIT(typeid_01,
+    "ag_object_typeid() returns the type ID of a base object")
+{
+        AG_AUTO(ag_object) *o = sample_base();
+
+        AG_TEST (ag_object_typeid(o) == TYPEID_BASE);
+}
 
 
-AG_TEST_INIT(typeid_02, "ag_object_typeid() returns the type ID of a derived"
-                        " object") {
-        AG_AUTO(ag_object) *o  = sample_derived();
-        AG_TEST_ASSERT (ag_object_typeid(o) == TYPEID_DERIVED);
-} AG_TEST_EXIT();
+AG_TEST_INIT(typeid_02, 
+    "ag_object_typeid() returns the type ID of a derived object")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
+
+        AG_TEST (ag_object_typeid(o) == TYPEID_DERIVED);
+}
 
 
-AG_TEST_INIT(uuid_01, "ag_object_uuid() returns the UUID of a base object") {
+AG_TEST_INIT(uuid_01, "ag_object_uuid() returns the UUID of a base object")
+{
         AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_uuid) *u = ag_object_uuid(o);
-        AG_TEST_ASSERT (!ag_uuid_empty(u));
-} AG_TEST_EXIT();
+
+        AG_TEST (!ag_uuid_empty(u));
+}
 
 
-AG_TEST_INIT(uuid_02, "ag_object_uuid() returns the UUID of a derived object") {
+AG_TEST_INIT(uuid_02, "ag_object_uuid() returns the UUID of a derived object")
+{
         AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_uuid) *u = ag_object_uuid(o);
-        AG_TEST_ASSERT (!ag_uuid_empty(u));
-} AG_TEST_EXIT();
+
+        AG_TEST (!ag_uuid_empty(u));
+}
 
 
-AG_TEST_INIT(sz_01, "ag_object_sz() returns the size of a base object") {
+AG_TEST_INIT(sz_01, "ag_object_sz() returns the size of a base object")
+{
         AG_AUTO(ag_object) *o = sample_base();
-        AG_TEST_ASSERT (ag_object_sz(o));
-} AG_TEST_EXIT();
+
+        AG_TEST (ag_object_sz(o));
+}
 
 
-AG_TEST_INIT(sz_02, "ag_object_sz() returns the size of a derived object") {
+AG_TEST_INIT(sz_02, "ag_object_sz() returns the size of a derived object")
+{
         AG_AUTO(ag_object) *o = sample_derived();
-        AG_TEST_ASSERT (ag_object_sz(o));
-} AG_TEST_EXIT();
+
+        AG_TEST (ag_object_sz(o));
+}
 
 
-AG_TEST_INIT(sz_03, "ag_object_sz() returns a greater size for a derived object"
-                    " than that of a base object") {
-        AG_AUTO(ag_object) *o  = sample_base();
+AG_TEST_INIT(sz_03,
+    "ag_object_sz() returns a greater size for a derived object than that of a"
+    " base object")
+{
+        AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_object) *o2 = sample_derived();
-        AG_TEST_ASSERT (ag_object_sz(o2) > ag_object_sz(o));
-} AG_TEST_EXIT();
+
+        AG_TEST (ag_object_sz(o2) > ag_object_sz(o));
+}
 
 
-AG_TEST_INIT(refc_01, "ag_object_refc() returns the reference count of a base"
-                      " object") {
-        AG_AUTO(ag_object) *o  = sample_base();
-        AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (ag_object_refc(o) == 2);
-} AG_TEST_EXIT();
-
-
-AG_TEST_INIT(refc_02, "ag_object_refc() returns the reference count of a derived"
-                      " object") {
-        AG_AUTO(ag_object) *o  = sample_derived();
-        AG_AUTO(ag_object) *o2 = ag_object_copy(o);
-        AG_TEST_ASSERT (ag_object_refc(o) == 2);
-} AG_TEST_EXIT();
-
-
-AG_TEST_INIT(len_01, "ag_object_len() returns 1 for a base object") {
+AG_TEST_INIT(refc_01,
+    "ag_object_refc() returns the reference count of a base object")
+{
         AG_AUTO(ag_object) *o = sample_base();
-        AG_TEST_ASSERT (ag_object_len(o) == 1);
-} AG_TEST_EXIT();
+        AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
+        AG_TEST (ag_object_refc(o) == 2);
+}
 
 
-AG_TEST_INIT(len_02, "ag_object_len() returns 0 for a derived object") {
+AG_TEST_INIT(refc_02,
+    "ag_object_refc() returns the reference count of a derived object")
+{
         AG_AUTO(ag_object) *o = sample_derived();
-        AG_TEST_ASSERT (ag_object_len(o) == 0);
-} AG_TEST_EXIT();
+        AG_AUTO(ag_object) *o2 = ag_object_copy(o);
+
+        AG_TEST (ag_object_refc(o) == 2);
+}
 
 
-AG_TEST_INIT(valid_01, "ag_object_valid() executes its default callback if not"
-                       " overridden") {
+AG_TEST_INIT(len_01, "ag_object_len() returns 1 for a base object")
+{
         AG_AUTO(ag_object) *o = sample_base();
-        AG_TEST_ASSERT (ag_object_valid(o));
-} AG_TEST_EXIT();
+
+        AG_TEST (ag_object_len(o) == 1);
+}
 
 
-AG_TEST_INIT(valid_02, "ag_object_valid() executes its provided callback if"
-                       " overridden") {
+AG_TEST_INIT(len_02, "ag_object_len() returns 0 for a derived object")
+{
         AG_AUTO(ag_object) *o = sample_derived();
-        AG_TEST_ASSERT (ag_object_valid(o));
-} AG_TEST_EXIT();
+
+        AG_TEST (ag_object_len(o) == 0);
+}
 
 
-AG_TEST_INIT(hash_01, "ag_object_hash() executes its default callback if not"
-                      " overridden") {
+AG_TEST_INIT(valid_01,
+    "ag_object_valid() executes its default callback if not overridden")
+{
+        AG_AUTO(ag_object) *o = sample_base();
+
+        AG_TEST (ag_object_valid(o));
+}
+
+
+AG_TEST_INIT(valid_02,
+    "ag_object_valid() executes its provided callback if overridden")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
+
+        AG_TEST (ag_object_valid(o));
+}
+
+
+AG_TEST_INIT(hash_01,
+    "ag_object_hash() executes its default callback if not overridden")
+{
         AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_uuid) *u = ag_object_uuid(o);
-        AG_TEST_ASSERT (ag_object_hash(o) == ag_uuid_hash(u));
-} AG_TEST_EXIT();
+
+        AG_TEST (ag_object_hash(o) == ag_uuid_hash(u));
+}
 
 
-AG_TEST_INIT(hash_02, "ag_object_hash() executes its provided callback if"
-                      " overridden") {
+AG_TEST_INIT(hash_02,
+    "ag_object_hash() executes its provided callback if overridden")
+{
         AG_AUTO(ag_object) *o = sample_derived();
         const struct payload_derived *p = ag_object_payload(o);
-        AG_TEST_ASSERT (ag_object_hash(o) == ag_hash_new(*p->x));
-} AG_TEST_EXIT();
+
+        AG_TEST (ag_object_hash(o) == ag_hash_new(*p->x));
+}
 
 
-AG_TEST_INIT(str_01, "ag_object_str() executes its default callback if not"
-                     " overridden") {
+AG_TEST_INIT(str_01,
+    "ag_object_str() executes its default callback if not overridden")
+{
         AG_AUTO(ag_object) *o = sample_base();
         AG_AUTO(ag_string) *s = ag_object_str(o);
-        AG_TEST_ASSERT (ag_string_has(s, "uuid"));
-} AG_TEST_EXIT();
+        
+        AG_TEST (ag_string_has(s, "uuid"));
+}
 
 
-AG_TEST_INIT(str_02, "ag_object_str() executes its provided callback if"
-                     " overridden") {
+AG_TEST_INIT(str_02,
+    "ag_object_str() executes its provided callback if overridden")
+{
         AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_string) *s = ag_object_str(o);
-        AG_TEST_ASSERT (ag_string_eq(s, "This is a sample derived object"));
-} AG_TEST_EXIT();
+
+        AG_TEST (ag_string_eq(s, "This is a sample derived object"));
+}
 
 
-AG_TEST_INIT(empty_01, "ag_object_empty() returns false if the object length"
-                       " is greater than zero") {
+AG_TEST_INIT(empty_01,
+    "ag_object_empty() returns false if the object length is greater than zero")
+{
         AG_AUTO(ag_object) *o = sample_base();
-        AG_TEST_ASSERT (!ag_object_empty(o));
-} AG_TEST_EXIT();
+
+        AG_TEST (!ag_object_empty(o));
+}
 
 
-AG_TEST_INIT(empty_02, "ag_object_empty() returns true if the object length is"
-                       " zero") {
+AG_TEST_INIT(empty_02,
+    "ag_object_empty() returns true if the object length is zero")
+{
         AG_AUTO(ag_object) *o = sample_derived();
-        AG_TEST_ASSERT (ag_object_empty(o));
-} AG_TEST_EXIT();
+
+        AG_TEST (ag_object_empty(o));
+}
 
 
-AG_TEST_INIT(payload_01, "ag_object_payload() gets a handle to the object"
-                         " payload") {
+AG_TEST_INIT(payload_01,
+    "ag_object_payload() gets a handle to the object payload")
+{
         AG_AUTO(ag_object) *o = sample_base();
         const struct payload_base *p = ag_object_payload(o);
-        AG_TEST_ASSERT (p->x == 555 && p->y == -666);
-} AG_TEST_EXIT();
+
+        AG_TEST (p->x == 555 && p->y == -666);
+}
 
 
-AG_TEST_INIT(payload_mutable_01, "ag_object_payload_mutable() gets a handle to"
-                                 " the object payload") {
+AG_TEST_INIT(payload_mutable_01,
+    "ag_object_payload_mutable() gets a handle to the object payload")
+{
         AG_AUTO(ag_object) *o = sample_derived();
         struct payload_derived *p = ag_object_payload_mutable(&o);
-        AG_TEST_ASSERT (*p->x == 555 && *p->y == -666);
-} AG_TEST_EXIT();
+
+        AG_TEST (*p->x == 555 && *p->y == -666);
+}
 
 
-AG_TEST_INIT(payload_mutable_02, "ag_object_payload_mutable() does not create a"
-                                 " clone of the object if its refc is 1") {
-        AG_AUTO(ag_object) *o  = sample_derived();
-        ag_object          *o2 = o;
+AG_TEST_INIT(payload_mutable_02,
+    "ag_object_payload_mutable() does not create a clone of the object if its"
+    " refc is 1")
+{
+        AG_AUTO(ag_object) *o = sample_derived();
+        ag_object *o2 = o;
         (void)ag_object_payload_mutable(&o);
-        AG_TEST_ASSERT (o == o2);
-} AG_TEST_EXIT();
+
+        AG_TEST (o == o2);
+}
 
 
-AG_TEST_INIT(payload_mutable_03, "ag_object_payload_mutable() creates a clone of"
-                                 " the object if its refc > 1") {
+AG_TEST_INIT(payload_mutable_03,
+    "ag_object_payload_mutable() creates a clone of  the object if its"
+    " refc > 1")
+{
         AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
         (void)ag_object_payload_mutable(&o);
-        AG_TEST_ASSERT (o != o2);
-} AG_TEST_EXIT();
+        
+        AG_TEST (o != o2);
+}
 
 
-AG_TEST_INIT(payload_mutable_04, "ag_object_payload_mutable() reduces the refc of"
-                                 " the original object by 1 if it creates a"
-                                 " clone") {
+AG_TEST_INIT(payload_mutable_04, 
+    "ag_object_payload_mutable() reduces the refc of the original object by 1"
+    " if it creates a clone")
+{
         AG_AUTO(ag_object) *o = sample_derived();
         AG_AUTO(ag_object) *o2 = ag_object_copy(o);
         AG_AUTO(ag_object) *o3 = ag_object_copy(o);
         (void)ag_object_payload_mutable(&o);
-        AG_TEST_ASSERT (ag_object_refc(o3) == 2);
-} AG_TEST_EXIT();
+        
+        AG_TEST (ag_object_refc(o3) == 2);
+}
 
 
 extern ag_test_suite *test_suite_object(void)

--- a/test/runner.c
+++ b/test/runner.c
@@ -7,8 +7,8 @@
 
 int main(int argc, char **argv)
 {
-    (void) argc;
-    (void) argv;
+        (void) argc;
+        (void) argv;
 
         ag_init();
 
@@ -19,18 +19,21 @@ int main(int argc, char **argv)
         ag_test_suite *str = test_suite_string();
         ag_test_suite *obj = test_suite_object();
         ag_test_suite *val = test_suite_value();
+        ag_test_suite *lst = test_suite_list();
 
         ag_test_harness_push(th, log);
         ag_test_harness_push(th, mblock);
         ag_test_harness_push(th, str);
         ag_test_harness_push(th, obj);
         ag_test_harness_push(th, val);
+        ag_test_harness_push(th, lst);
 
         ag_test_suite_release(&log);
         ag_test_suite_release(&mblock);
         ag_test_suite_release(&str);
         ag_test_suite_release(&obj);
         ag_test_suite_release(&val);
+        ag_test_suite_release(&lst);
 
         ag_test_harness_exec(th);
         ag_test_harness_log(th, stdout);

--- a/test/string.c
+++ b/test/string.c
@@ -18,6 +18,7 @@ AG_TEST_CASE(new_01, "ag_string_new() can create an empty string")
 AG_TEST_CASE(new_02, "ag_string_new() can create an ASCII string") 
 {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
+
         AG_TEST (s && *s && ag_string_eq(s, "Hello, world!"));
 }
 
@@ -25,6 +26,7 @@ AG_TEST_CASE(new_02, "ag_string_new() can create an ASCII string")
 AG_TEST_CASE(new_03, "ag_string_new() can create a Unicode string")
 {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
+
         AG_TEST (s && *s && ag_string_eq(s, "नमस्ते दुनिया!"));
 }
 
@@ -33,6 +35,7 @@ AG_TEST_CASE(new_03, "ag_string_new() can create a Unicode string")
 AG_TEST_CASE(new_empty_01, "ag_string_new_empty() creates an empty string")
 {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
+
         AG_TEST (s && !*s);
 }
 

--- a/test/string.c
+++ b/test/string.c
@@ -7,26 +7,31 @@
  */
 
 
-AG_TEST_INIT(new_01, "ag_string_new() can create an empty string") {
+AG_TEST_CASE(new_01, "ag_string_new() can create an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("");
+
         AG_TEST (s && !*s);
 }
 
 
-AG_TEST_INIT(new_02, "ag_string_new() can create an ASCII string") {
+AG_TEST_CASE(new_02, "ag_string_new() can create an ASCII string") 
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_TEST (s && *s && ag_string_eq(s, "Hello, world!"));
 }
 
 
-AG_TEST_INIT(new_03, "ag_string_new() can create a Unicode string") {
+AG_TEST_CASE(new_03, "ag_string_new() can create a Unicode string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_TEST (s && *s && ag_string_eq(s, "नमस्ते दुनिया!"));
 }
 
 
 /* This unit test checks whether ag_string_new_empty() behaves as expected. */
-AG_TEST_INIT(new_empty_01, "ag_string_new_empty() creates an empty string") {
+AG_TEST_CASE(new_empty_01, "ag_string_new_empty() creates an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_TEST (s && !*s);
 }
@@ -39,22 +44,28 @@ AG_TEST_INIT(new_empty_01, "ag_string_new_empty() creates an empty string") {
  */
 
 
-AG_TEST_INIT(new_fmt_01, "ag_string_new_fmt() can create an empty string") {
+AG_TEST_CASE(new_fmt_01, "ag_string_new_fmt() can create an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_fmt("%s", "");
         AG_TEST (s && !*s);
 }
 
 
-AG_TEST_INIT(new_fmt_02, "ag_string_new_fmt() can create a formatted ASCII"
-                " string") {
-        AG_AUTO(ag_string) *s = ag_string_new_fmt("%d. %s", 111, "Hello, world!");
+AG_TEST_CASE(new_fmt_02,
+    "ag_string_new_fmt() can create a formatted ASCII string")
+{
+        AG_AUTO(ag_string) *s = ag_string_new_fmt("%d. %s", 111,
+            "Hello, world!");
+
         AG_TEST (s && *s && ag_string_eq(s, "111. Hello, world!"));
 }
 
 
-AG_TEST_INIT(new_fmt_03, "ag_string_new_fmt() can create a formatted Unicode"
-                " string") {
+AG_TEST_CASE(new_fmt_03,
+    "ag_string_new_fmt() can create a formatted Unicode string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_fmt("%d. %s", -12, "नमस्ते दुनिया!");
+
         AG_TEST (s && *s && ag_string_eq(s, "-12. नमस्ते दुनिया!"));
 }
 
@@ -65,30 +76,38 @@ AG_TEST_INIT(new_fmt_03, "ag_string_new_fmt() can create a formatted Unicode"
  */
 
 
-AG_TEST_INIT(copy_01, "ag_string_copy() can create a copy of an empty string") {
+AG_TEST_CASE(copy_01, "ag_string_copy() can create a copy of an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (s2 && !*s2);
 }
 
 
-AG_TEST_INIT(copy_02, "ag_string_copy() can create a copy of an ASCII string") {
+AG_TEST_CASE(copy_02, "ag_string_copy() can create a copy of an ASCII string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (s2 && *s2 && ag_string_eq(s, s2));
 }
 
 
-AG_TEST_INIT(copy_03, "ag_string_copy() can create a copy of a Unicode string") {
+AG_TEST_CASE(copy_03, "ag_string_copy() can create a copy of a Unicode string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (s2 && *s2 && ag_string_eq(s, s2));
 }
 
 
-AG_TEST_INIT(copy_04, "ag_string_copy() increases the reference count by 1") {
+AG_TEST_CASE(copy_04, "ag_string_copy() increases the reference count by 1")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (ag_string_refc(s) == 2);
 }
 
@@ -99,33 +118,40 @@ AG_TEST_INIT(copy_04, "ag_string_copy() increases the reference count by 1") {
  */
 
 
-AG_TEST_INIT(release_01, "ag_string_release() performs a no-op if passed NULL") {
+AG_TEST_CASE(release_01, "ag_string_release() performs a no-op if passed NULL")
+{
         ag_string_release(NULL);
+
         AG_TEST (true);
 }
 
 
-AG_TEST_INIT(release_02, "ag_string_release() performs a no-op if passed a handle"
-                " to NULL") {
+AG_TEST_CASE(release_02,
+    "ag_string_release() performs a no-op if passed a handle to NULL")
+{
         ag_string *s = NULL;
         ag_string_release(&s);
+
         AG_TEST (true);
 }
 
 
-AG_TEST_INIT(release_03, "ag_string_release() disposes a single instance of a"
+AG_TEST_CASE(release_03, "ag_string_release() disposes a single instance of a"
                 " string") {
         ag_string *s = ag_string_new("Hello, world!");
         ag_string_release(&s);
+
         AG_TEST (!s);
 }
 
 
-AG_TEST_INIT(release_04, "ag_string_release() reduces the reference count by 1") {
+AG_TEST_CASE(release_04, "ag_string_release() reduces the reference count by 1")
+{
         ag_string *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
         AG_AUTO(ag_string) *s3 = ag_string_copy(s2);
         ag_string_release(&s);
+
         AG_TEST (!s && ag_string_refc(s2) == 2);
 }
 
@@ -136,74 +162,99 @@ AG_TEST_INIT(release_04, "ag_string_release() reduces the reference count by 1")
  */
 
 
-AG_TEST_INIT(cmp_01, "ag_string_cmp() returns AG_CMP_EQ when comparing two empty"
-                " strings") {
+AG_TEST_CASE(cmp_01,
+    "ag_string_cmp() returns AG_CMP_EQ when comparing two empty strings")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new_empty();
+
         AG_TEST (ag_string_cmp(s, s2) == AG_CMP_EQ);
 }
 
 
-AG_TEST_INIT(cmp_02, "ag_string_cmp() return AG_CMP_LT when comparing an empty"
-                " string with another string") {
+AG_TEST_CASE(cmp_02,
+    "ag_string_cmp() return AG_CMP_LT when comparing an empty string with"
+    " another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_cmp(s, s2) == AG_CMP_LT);
 }
 
 
-AG_TEST_INIT(cmp_03, "ag_string_cmp() return AG_CMP_EQ when comparing two equal"
-                " ASCII strings") {
+AG_TEST_CASE(cmp_03,
+    "ag_string_cmp() return AG_CMP_EQ when comparing two equal ASCII strings")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (ag_string_cmp(s, s2) == AG_CMP_EQ);
 }
 
 
-AG_TEST_INIT(cmp_04, "ag_string_cmp() returns AG_CMP_LT when comparing an ASCII"
-                " string that is lexicographically less than another") {
+AG_TEST_CASE(cmp_04,
+    "ag_string_cmp() returns AG_CMP_LT when comparing an ASCII string that is"
+    " lexicographically less than another")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_cmp(s, s2) == AG_CMP_LT);
 }
 
 
-AG_TEST_INIT(cmp_05, "ag_string_cmp() returns AG_CMP_GT when comparing an ASCII"
-                " string that is lexicographically greater than another") {
+AG_TEST_CASE(cmp_05,
+    "ag_string_cmp() returns AG_CMP_GT when comparing an ASCII string that is"
+    " lexicographically greater than another")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_cmp(s2, s) == AG_CMP_GT);
 }
 
 
-AG_TEST_INIT(cmp_06, "ag_string_cmp() returns AG_CMP_GT when comparing an ASCII"
-                " string to an empty string") {
+AG_TEST_CASE(cmp_06,
+    "ag_string_cmp() returns AG_CMP_GT when comparing an ASCII string to an"
+    " empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_cmp(s2, s) == AG_CMP_GT);
 }
 
 
-AG_TEST_INIT(cmp_07, "ag_string_cmp() returns AG_CMP_EQ when comparing two equal"
-                " Unicode strings") {
+AG_TEST_CASE(cmp_07,
+    "ag_string_cmp() returns AG_CMP_EQ when comparing two equal Unicode"
+    "strings")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (ag_string_cmp(s, s2) == AG_CMP_EQ);
 }
 
 
-AG_TEST_INIT(cmp_08, "ag_string_cmp() returns AG_CMP_LT when comparing a Unicode"
-                " string that is lexicographically less than another") {
+AG_TEST_CASE(cmp_08,
+    "ag_string_cmp() returns AG_CMP_LT when comparing a Unicode string that is"
+    " lexicographically less than another")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
+
         AG_TEST (ag_string_cmp(s2, s) == AG_CMP_LT);
 }
 
 
-AG_TEST_INIT(cmp_09, "ag_string_cmp() returns AG_CMP_GT when comparing a Unicode"
-                " string that is lexicographically greater than another") {
+AG_TEST_CASE(cmp_09,
+    "ag_string_cmp() returns AG_CMP_GT when comparing a Unicode string that is"
+    " lexicographically greater than another")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
+
         AG_TEST (ag_string_cmp(s, s2) == AG_CMP_GT);
 }
 
@@ -214,74 +265,99 @@ AG_TEST_INIT(cmp_09, "ag_string_cmp() returns AG_CMP_GT when comparing a Unicode
  */
 
 
-AG_TEST_INIT(lt_01, "ag_string_lt() returns false when comparing two empty"
-                " strings") {
+AG_TEST_CASE(lt_01, 
+    "ag_string_lt() returns false when comparing two empty strings")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new_empty();
+
         AG_TEST (!ag_string_lt(s, s2));
 }
 
 
-AG_TEST_INIT(lt_02, "ag_string_lt() returns true when comparing an empty string"
-                " with a non-empty string") {
+AG_TEST_CASE(lt_02,
+    "ag_string_lt() returns true when comparing an empty string with a"
+    " non-empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_lt(s, s2));
 }
 
 
-AG_TEST_INIT(lt_03, "ag_string_lt() returns false when comparing a string with an"
-                " empty string") {
+AG_TEST_CASE(lt_03,
+    "ag_string_lt() returns false when comparing a string with an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (!ag_string_lt(s2, s));
 }
 
 
-AG_TEST_INIT(lt_04, "ag_string_lt() returns true when comparing an ASCII string"
-                " that is lexicographically less than another string") {
+AG_TEST_CASE(lt_04,
+    "ag_string_lt() returns true when comparing an ASCII string that is"
+    " lexicographically less than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_lt(s, s2));
 }
 
 
-AG_TEST_INIT(lt_05, "ag_string_lt() returns false when comparing an ASCII string"
-                " that is lexicographically equal to another string") {
+AG_TEST_CASE(lt_05,
+    "ag_string_lt() returns false when comparing an ASCII string that is"
+    " lexicographically equal to another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (!ag_string_lt(s, s2));
 }
 
 
-AG_TEST_INIT(lt_06, "ag_string_lt() returns false when comparing an ASCII string"
-                " that is lexicographically greater than another string") {
+AG_TEST_CASE(lt_06,
+    "ag_string_lt() returns false when comparing an ASCII string that is"
+    " lexicographically greater than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (!ag_string_lt(s2, s));
 }
 
 
-AG_TEST_INIT(lt_07, "ag_string_lt() returns true when comparing a Unicode string"
-                " that is lexicographically less than another string") {
+AG_TEST_CASE(lt_07,
+    "ag_string_lt() returns true when comparing a Unicode string that is"
+    " lexicographically less than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
+
         AG_TEST (ag_string_lt(s2, s));
 }
 
 
-AG_TEST_INIT(lt_08, "ag_string_lt() returns false when comparing a Unicode string"
-                " that is lexicographically equal to another string") {
+AG_TEST_CASE(lt_08, 
+    "ag_string_lt() returns false when comparing a Unicode string that is"
+    " lexicographically equal to another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (!ag_string_lt(s2, s));
 }
 
 
-AG_TEST_INIT(lt_09, "ag_string_lt() returns false when comparing a Unicode string"
-                " that is lexicographically greater than another string") {
+AG_TEST_CASE(lt_09,
+    "ag_string_lt() returns false when comparing a Unicode string that is"
+    " lexicographically greater than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
+
         AG_TEST (!ag_string_lt(s, s2));
 }
 
@@ -292,74 +368,98 @@ AG_TEST_INIT(lt_09, "ag_string_lt() returns false when comparing a Unicode strin
  */
 
 
-AG_TEST_INIT(eq_01, "ag_string_eq() returns true when comparing two empty"
-                " strings") {
+AG_TEST_CASE(eq_01,
+    "ag_string_eq() returns true when comparing two empty strings")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new_empty();
         AG_TEST (ag_string_eq(s, s2));
 }
 
 
-AG_TEST_INIT(eq_02, "ag_string_eq() returns false when comparing an empty string"
-                " with a non-empty string") {
+AG_TEST_CASE(eq_02,
+    "ag_string_eq() returns false when comparing an empty string with a"
+    " non-empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (!ag_string_eq(s, s2));
 }
 
 
-AG_TEST_INIT(eq_03, "ag_string_eq() returns false when comparing a string with an"
-                " empty string") {
+AG_TEST_CASE(eq_03,
+    "ag_string_eq() returns false when comparing a string with an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (!ag_string_eq(s2, s));
 }
 
 
-AG_TEST_INIT(eq_04, "ag_string_eq() returns false when comparing an ASCII string"
-                " that is lexicographically less than another string") {
+AG_TEST_CASE(eq_04,
+    "ag_string_eq() returns false when comparing an ASCII string that is"
+    " lexicographically less than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+        
         AG_TEST (!ag_string_eq(s, s2));
 }
 
 
-AG_TEST_INIT(eq_05, "ag_string_eq() returns true when comparing an ASCII string"
-                " that is lexicographically equal to another string") {
+AG_TEST_CASE(eq_05,
+    "ag_string_eq() returns true when comparing an ASCII string that is"
+    " lexicographically equal to another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+        
         AG_TEST (ag_string_eq(s, s2));
 }
 
 
-AG_TEST_INIT(eq_06, "ag_string_eq() returns false when comparing an ASCII string"
-                " that is lexicographically greater than another string") {
+AG_TEST_CASE(eq_06,
+    "ag_string_eq() returns false when comparing an ASCII string that is"
+    " lexicographically greater than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+        
         AG_TEST (!ag_string_eq(s2, s));
 }
 
 
-AG_TEST_INIT(eq_07, "ag_string_eq() returns false when comparing a Unicode string"
-                " that is lexicographically less than another string") {
+AG_TEST_CASE(eq_07,
+    "ag_string_eq() returns false when comparing a Unicode string that is"
+    " lexicographically less than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
+        
         AG_TEST (!ag_string_eq(s2, s));
 }
 
 
-AG_TEST_INIT(eq_08, "ag_string_eq() returns true when comparing a Unicode string"
-                " that is lexicographically equal to another string") {
+AG_TEST_CASE(eq_08,
+    "ag_string_eq() returns true when comparing a Unicode string that is"
+    " lexicographically equal to another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+        
         AG_TEST (ag_string_eq(s2, s));
 }
 
 
-AG_TEST_INIT(eq_09, "ag_string_eq() returns false when comparing a Unicode string"
-                " that is lexicographically greater than another string") {
+AG_TEST_CASE(eq_09,
+    "ag_string_eq() returns false when comparing a Unicode string that is"
+    " lexicographically greater than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
+        
         AG_TEST (!ag_string_eq(s, s2));
 }
 
@@ -370,23 +470,28 @@ AG_TEST_INIT(eq_09, "ag_string_eq() returns false when comparing a Unicode strin
  */
 
 
-AG_TEST_INIT(gt_01, "ag_string_gt() returns false when comparing two empty"
-                " strings") {
+AG_TEST_CASE(gt_01,
+    "ag_string_gt() returns false when comparing two empty strings")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new_empty();
+
         AG_TEST (!ag_string_gt(s, s2));
 }
 
 
-AG_TEST_INIT(gt_02, "ag_string_gt() returns false when comparing an empty string"
-                " with a non-empty string") {
+AG_TEST_CASE(gt_02,
+    "ag_string_gt() returns false when comparing an empty string  with a"
+    " non-empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+        
         AG_TEST (!ag_string_gt(s, s2));
 }
 
 
-AG_TEST_INIT(gt_03, "ag_string_gt() returns true when comparing a string with an"
+AG_TEST_CASE(gt_03, "ag_string_gt() returns true when comparing a string with an"
                 " empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
@@ -394,7 +499,7 @@ AG_TEST_INIT(gt_03, "ag_string_gt() returns true when comparing a string with an
 }
 
 
-AG_TEST_INIT(gt_04, "ag_string_gt() returns false when comparing an ASCII string"
+AG_TEST_CASE(gt_04, "ag_string_gt() returns false when comparing an ASCII string"
                 " that is lexicographically less than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
@@ -402,7 +507,7 @@ AG_TEST_INIT(gt_04, "ag_string_gt() returns false when comparing an ASCII string
 }
 
 
-AG_TEST_INIT(gt_05, "ag_string_gt() returns false when comparing an ASCII string"
+AG_TEST_CASE(gt_05, "ag_string_gt() returns false when comparing an ASCII string"
                 " that is lexicographically equal to another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
@@ -410,7 +515,7 @@ AG_TEST_INIT(gt_05, "ag_string_gt() returns false when comparing an ASCII string
 }
 
 
-AG_TEST_INIT(gt_06, "ag_string_gt() returns true when comparing an ASCII string"
+AG_TEST_CASE(gt_06, "ag_string_gt() returns true when comparing an ASCII string"
                 " that is lexicographically greater than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
@@ -418,7 +523,7 @@ AG_TEST_INIT(gt_06, "ag_string_gt() returns true when comparing an ASCII string"
 }
 
 
-AG_TEST_INIT(gt_07, "ag_string_gt() returns false when comparing a Unicode string"
+AG_TEST_CASE(gt_07, "ag_string_gt() returns false when comparing a Unicode string"
                 " that is lexicographically less than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
@@ -426,7 +531,7 @@ AG_TEST_INIT(gt_07, "ag_string_gt() returns false when comparing a Unicode strin
 }
 
 
-AG_TEST_INIT(gt_08, "ag_string_gt() returns false when comparing a Unicode string"
+AG_TEST_CASE(gt_08, "ag_string_gt() returns false when comparing a Unicode string"
                 " that is lexicographically equal to another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
@@ -434,7 +539,7 @@ AG_TEST_INIT(gt_08, "ag_string_gt() returns false when comparing a Unicode strin
 }
 
 
-AG_TEST_INIT(gt_09, "ag_string_gt() returns true when comparing a Unicode string"
+AG_TEST_CASE(gt_09, "ag_string_gt() returns true when comparing a Unicode string"
                 " that is lexicographically greater than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
@@ -448,19 +553,19 @@ AG_TEST_INIT(gt_09, "ag_string_gt() returns true when comparing a Unicode string
  */
 
 
-AG_TEST_INIT(empty_01, "ag_string_empty() returns true for an empty string") {
+AG_TEST_CASE(empty_01, "ag_string_empty() returns true for an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_TEST (ag_string_empty(s));
 }
 
 
-AG_TEST_INIT(empty_02, "ag_string_empty() returns false for an ASCII string") {
+AG_TEST_CASE(empty_02, "ag_string_empty() returns false for an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_TEST (!ag_string_empty(s));
 }
 
 
-AG_TEST_INIT(empty_03, "ag_string_empty() returns false for a Unicode string") {
+AG_TEST_CASE(empty_03, "ag_string_empty() returns false for a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_TEST (!ag_string_empty(s));
 }
@@ -476,19 +581,19 @@ AG_TEST_INIT(empty_03, "ag_string_empty() returns false for a Unicode string") {
  */
 
 
-AG_TEST_INIT(len_01, "ag_string_len() returns 0 for an empty string") {
+AG_TEST_CASE(len_01, "ag_string_len() returns 0 for an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_TEST (!ag_string_len(s));
 }
 
 
-AG_TEST_INIT(len_02, "ag_string_len() returns the length of an ASCII string") {
+AG_TEST_CASE(len_02, "ag_string_len() returns the length of an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_TEST (ag_string_len(s) == 13);
 }
 
 
-AG_TEST_INIT(len_03, "ag_string_len() returns the length of a Unicode string") {
+AG_TEST_CASE(len_03, "ag_string_len() returns the length of a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_TEST (ag_string_len(s) == 14);
 }
@@ -500,19 +605,19 @@ AG_TEST_INIT(len_03, "ag_string_len() returns the length of a Unicode string") {
  */
 
 
-AG_TEST_INIT(sz_01, "ag_string_sz() returns 1 for an empty string") {
+AG_TEST_CASE(sz_01, "ag_string_sz() returns 1 for an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_TEST (ag_string_sz(s) == 1);
 }
 
 
-AG_TEST_INIT(sz_02, "ag_string_sz() determines the size of an ASCII string") {
+AG_TEST_CASE(sz_02, "ag_string_sz() determines the size of an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_TEST (ag_string_sz(s) == 14);
 }
 
 
-AG_TEST_INIT(sz_03, "ag_string_sz() determines the size of Unicode string") {
+AG_TEST_CASE(sz_03, "ag_string_sz() determines the size of Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_TEST (ag_string_sz(s) == 39);
 }
@@ -524,13 +629,13 @@ AG_TEST_INIT(sz_03, "ag_string_sz() determines the size of Unicode string") {
  */
 
 
-AG_TEST_INIT(refc_01, "ag_string_refc() returns 1 for a single instance") {
+AG_TEST_CASE(refc_01, "ag_string_refc() returns 1 for a single instance") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_TEST (ag_string_refc(s) == 1);
 }
 
 
-AG_TEST_INIT(refc_02, "ag_string_refc() detects incremented reference counts") {
+AG_TEST_CASE(refc_02, "ag_string_refc() detects incremented reference counts") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
         AG_AUTO(ag_string) *s3 = ag_string_copy(s2);
@@ -538,7 +643,7 @@ AG_TEST_INIT(refc_02, "ag_string_refc() detects incremented reference counts") {
 }
 
 
-AG_TEST_INIT(refc_03, "ag_string_refc() detects decremented reference counts") {
+AG_TEST_CASE(refc_03, "ag_string_refc() detects decremented reference counts") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         ag_string *s2 = ag_string_copy(s);
         ag_string_release(&s2);
@@ -553,14 +658,14 @@ AG_TEST_INIT(refc_03, "ag_string_refc() detects decremented reference counts") {
  */
 
 
-AG_TEST_INIT(has_01, "ag_string_has() returns true when both needle and haystack"
+AG_TEST_CASE(has_01, "ag_string_has() returns true when both needle and haystack"
                 " are empty strings") {
         AG_AUTO(ag_string) *h = ag_string_new_empty(), *n = ag_string_new_empty();
         AG_TEST (ag_string_has(h, n));
 }
 
 
-AG_TEST_INIT(has_02, "ag_string_has() returns false when haystack is empty and"
+AG_TEST_CASE(has_02, "ag_string_has() returns false when haystack is empty and"
                 " needle is not") {
         AG_AUTO(ag_string) *h = ag_string_new_empty(),
                         *n = ag_string_new("Hello, world!");
@@ -568,7 +673,7 @@ AG_TEST_INIT(has_02, "ag_string_has() returns false when haystack is empty and"
 }
 
 
-AG_TEST_INIT(has_03, "ag_string_has() returns false when haystack is not empty and"
+AG_TEST_CASE(has_03, "ag_string_has() returns false when haystack is not empty and"
                 " needle is") {
         AG_AUTO(ag_string) *h = ag_string_new("Hello, world!"), 
                         *n = ag_string_new_empty();
@@ -576,7 +681,7 @@ AG_TEST_INIT(has_03, "ag_string_has() returns false when haystack is not empty a
 }
 
 
-AG_TEST_INIT(has_04, "ag_string_has() returns true if it finds an ASCII needle in"
+AG_TEST_CASE(has_04, "ag_string_has() returns true if it finds an ASCII needle in"
                 " an ASCII haystack") {
         AG_AUTO(ag_string) *h = ag_string_new("Hello, world!"),
                         *n = ag_string_new("o, wo");
@@ -584,7 +689,7 @@ AG_TEST_INIT(has_04, "ag_string_has() returns true if it finds an ASCII needle i
 }
 
 
-AG_TEST_INIT(has_05, "ag_string_has() returns false if it doesn't find an ASCII"
+AG_TEST_CASE(has_05, "ag_string_has() returns false if it doesn't find an ASCII"
                 " needle in an ASCII haystack") {
         AG_AUTO(ag_string) *h = ag_string_new("Hello, world!"), 
                         *n = ag_string_new("o, w!");
@@ -592,7 +697,7 @@ AG_TEST_INIT(has_05, "ag_string_has() returns false if it doesn't find an ASCII"
 }
 
 
-AG_TEST_INIT(has_06, "ag_string_has() returns true if it finds a Unicode needle in"
+AG_TEST_CASE(has_06, "ag_string_has() returns true if it finds a Unicode needle in"
                 " a Unicode haystack") {
         AG_AUTO(ag_string) *h = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *n = ag_string_new("ते दुनि");
@@ -600,7 +705,7 @@ AG_TEST_INIT(has_06, "ag_string_has() returns true if it finds a Unicode needle 
 }
 
 
-AG_TEST_INIT(has_07, "ag_string_has() returns false if it doesn't find a Unicode"
+AG_TEST_CASE(has_07, "ag_string_has() returns false if it doesn't find a Unicode"
                 " needle in a Unicode haystack") {
         AG_AUTO(ag_string) *h = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *n = ag_string_new("तेदुनि");
@@ -618,42 +723,42 @@ AG_TEST_INIT(has_07, "ag_string_has() returns false if it doesn't find a Unicode
  */
 
 
-AG_TEST_INIT(lower_01, "ag_string_lower() has no effect on an empty string") {
+AG_TEST_CASE(lower_01, "ag_string_lower() has no effect on an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_lower(s);
         AG_TEST (ag_string_eq(s, s2));
 }
 
 
-AG_TEST_INIT(lower_02, "ag_string_lower() converts an ASCII string to lowercase") {
+AG_TEST_CASE(lower_02, "ag_string_lower() converts an ASCII string to lowercase") {
         AG_AUTO(ag_string) *s = ag_string_new("HElLo, WOrlD!");
         AG_AUTO(ag_string) *s2 = ag_string_lower(s);
         AG_TEST (ag_string_eq(s2, "hello, world!"));
 }
 
 
-AG_TEST_INIT(upper_01, "ag_string_upper() has no effect on an empty string") {
+AG_TEST_CASE(upper_01, "ag_string_upper() has no effect on an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_upper(s);
         AG_TEST (ag_string_eq(s, s2));
 }
 
 
-AG_TEST_INIT(upper_02, "ag_string_upper() converts an ASCII string to uppercase") {
+AG_TEST_CASE(upper_02, "ag_string_upper() converts an ASCII string to uppercase") {
         AG_AUTO(ag_string) *s = ag_string_new("heLlO, woRLd!");
         AG_AUTO(ag_string) *s2 = ag_string_upper(s);
         AG_TEST (ag_string_eq(s2, "HELLO, WORLD!"));
 }
 
 
-AG_TEST_INIT(proper_01, "ag_string_proper() has no effect on an empty string") {
+AG_TEST_CASE(proper_01, "ag_string_proper() has no effect on an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_proper(s);
         AG_TEST (ag_string_eq(s, s2));
 }
 
 
-AG_TEST_INIT(proper_02, "ag_string_proper() converts an ASCII string to proper"
+AG_TEST_CASE(proper_02, "ag_string_proper() converts an ASCII string to proper"
                 " case") {
         AG_AUTO(ag_string) *s = ag_string_new("tHIS isN'T.iN pRopER cASe.");
         AG_AUTO(ag_string) *s2 = ag_string_proper(s);
@@ -667,7 +772,7 @@ AG_TEST_INIT(proper_02, "ag_string_proper() converts an ASCII string to proper"
  */
 
 
-AG_TEST_INIT(split_01, "ag_string_split() returns an empty string if applied on an"
+AG_TEST_CASE(split_01, "ag_string_split() returns an empty string if applied on an"
                 " empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split(s, " wo");
@@ -675,14 +780,14 @@ AG_TEST_INIT(split_01, "ag_string_split() returns an empty string if applied on 
 }
 
 
-AG_TEST_INIT(split_02, "ag_string_split() returns the original string if the pivot"
+AG_TEST_CASE(split_02, "ag_string_split() returns the original string if the pivot"
                 " is an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "");
         AG_TEST (ag_string_eq(s, s2));
 }
 
-AG_TEST_INIT(split_03, "ag_string_split() returns an empty string if both the"
+AG_TEST_CASE(split_03, "ag_string_split() returns an empty string if both the"
                 " string and the pivot are empty") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "");
@@ -690,7 +795,7 @@ AG_TEST_INIT(split_03, "ag_string_split() returns an empty string if both the"
 }
 
 
-AG_TEST_INIT(split_04, "ag_string_split() returns an empty string if the pivot is"
+AG_TEST_CASE(split_04, "ag_string_split() returns an empty string if the pivot is"
                 " not found") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "xyz");
@@ -698,7 +803,7 @@ AG_TEST_INIT(split_04, "ag_string_split() returns an empty string if the pivot i
 }
 
 
-AG_TEST_INIT(split_05, "ag_string_split() returns an empty string if both the"
+AG_TEST_CASE(split_05, "ag_string_split() returns an empty string if both the"
                 " string and pivot are the same") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, s);
@@ -706,7 +811,7 @@ AG_TEST_INIT(split_05, "ag_string_split() returns an empty string if both the"
 }
 
 
-AG_TEST_INIT(split_06, "ag_string_split() returns the left side of the pivot if it"
+AG_TEST_CASE(split_06, "ag_string_split() returns the left side of the pivot if it"
                 " exists in an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, " wo");
@@ -714,7 +819,7 @@ AG_TEST_INIT(split_06, "ag_string_split() returns the left side of the pivot if 
 }
 
 
-AG_TEST_INIT(split_07, "ag_string_split() returns the left side of the pivot if it"
+AG_TEST_CASE(split_07, "ag_string_split() returns the left side of the pivot if it"
                 " exists in a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "या");
@@ -728,7 +833,7 @@ AG_TEST_INIT(split_07, "ag_string_split() returns the left side of the pivot if 
  */
 
 
-AG_TEST_INIT(split_right_01, "ag_string_split_right() returns an empty string if"
+AG_TEST_CASE(split_right_01, "ag_string_split_right() returns an empty string if"
                 " applied on an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, " wo");
@@ -736,7 +841,7 @@ AG_TEST_INIT(split_right_01, "ag_string_split_right() returns an empty string if
 }
 
 
-AG_TEST_INIT(split_right_02, "ag_string_split_right() returns the original string"
+AG_TEST_CASE(split_right_02, "ag_string_split_right() returns the original string"
                 " if the pivot is an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, "");
@@ -744,7 +849,7 @@ AG_TEST_INIT(split_right_02, "ag_string_split_right() returns the original strin
 }
 
 
-AG_TEST_INIT(split_right_03, "ag_string_split_right() returns an empty string if"
+AG_TEST_CASE(split_right_03, "ag_string_split_right() returns an empty string if"
                 " both the string and the pivot are empty") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "");
@@ -752,7 +857,7 @@ AG_TEST_INIT(split_right_03, "ag_string_split_right() returns an empty string if
 }
 
 
-AG_TEST_INIT(split_right_04, "ag_string_split_right() returns an empty string if"
+AG_TEST_CASE(split_right_04, "ag_string_split_right() returns an empty string if"
                 " the pivot is not found") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, "xyz");
@@ -760,7 +865,7 @@ AG_TEST_INIT(split_right_04, "ag_string_split_right() returns an empty string if
 }
 
 
-AG_TEST_INIT(split_right_05, "ag_string_split_right() returns an empty string if"
+AG_TEST_CASE(split_right_05, "ag_string_split_right() returns an empty string if"
                 " both the string and pivot are the same") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, s);
@@ -768,7 +873,7 @@ AG_TEST_INIT(split_right_05, "ag_string_split_right() returns an empty string if
 }
 
 
-AG_TEST_INIT(split_right_06, "ag_string_split_right() returns the right side of"
+AG_TEST_CASE(split_right_06, "ag_string_split_right() returns the right side of"
                 " the pivot if it exists in an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, " w");
@@ -776,7 +881,7 @@ AG_TEST_INIT(split_right_06, "ag_string_split_right() returns the right side of"
 }
 
 
-AG_TEST_INIT(split_right_07, "ag_string_split() returns the right side of the"
+AG_TEST_CASE(split_right_07, "ag_string_split() returns the right side of the"
                 " pivot if it exists in a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, "स्ते");

--- a/test/string.c
+++ b/test/string.c
@@ -9,27 +9,27 @@
 
 AG_TEST_INIT(new_01, "ag_string_new() can create an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new("");
-        AG_TEST_ASSERT (s && !*s);
-} AG_TEST_EXIT();
+        AG_TEST (s && !*s);
+}
 
 
 AG_TEST_INIT(new_02, "ag_string_new() can create an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (s && *s && ag_string_eq(s, "Hello, world!"));
-} AG_TEST_EXIT();
+        AG_TEST (s && *s && ag_string_eq(s, "Hello, world!"));
+}
 
 
 AG_TEST_INIT(new_03, "ag_string_new() can create a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
-        AG_TEST_ASSERT (s && *s && ag_string_eq(s, "नमस्ते दुनिया!"));
-} AG_TEST_EXIT();
+        AG_TEST (s && *s && ag_string_eq(s, "नमस्ते दुनिया!"));
+}
 
 
 /* This unit test checks whether ag_string_new_empty() behaves as expected. */
 AG_TEST_INIT(new_empty_01, "ag_string_new_empty() creates an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
-        AG_TEST_ASSERT (s && !*s);
-} AG_TEST_EXIT();
+        AG_TEST (s && !*s);
+}
 
 
 /* 
@@ -41,22 +41,22 @@ AG_TEST_INIT(new_empty_01, "ag_string_new_empty() creates an empty string") {
 
 AG_TEST_INIT(new_fmt_01, "ag_string_new_fmt() can create an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_fmt("%s", "");
-        AG_TEST_ASSERT (s && !*s);
-} AG_TEST_EXIT();
+        AG_TEST (s && !*s);
+}
 
 
 AG_TEST_INIT(new_fmt_02, "ag_string_new_fmt() can create a formatted ASCII"
                 " string") {
         AG_AUTO(ag_string) *s = ag_string_new_fmt("%d. %s", 111, "Hello, world!");
-        AG_TEST_ASSERT (s && *s && ag_string_eq(s, "111. Hello, world!"));
-} AG_TEST_EXIT();
+        AG_TEST (s && *s && ag_string_eq(s, "111. Hello, world!"));
+}
 
 
 AG_TEST_INIT(new_fmt_03, "ag_string_new_fmt() can create a formatted Unicode"
                 " string") {
         AG_AUTO(ag_string) *s = ag_string_new_fmt("%d. %s", -12, "नमस्ते दुनिया!");
-        AG_TEST_ASSERT (s && *s && ag_string_eq(s, "-12. नमस्ते दुनिया!"));
-} AG_TEST_EXIT();
+        AG_TEST (s && *s && ag_string_eq(s, "-12. नमस्ते दुनिया!"));
+}
 
 
 /*
@@ -68,29 +68,29 @@ AG_TEST_INIT(new_fmt_03, "ag_string_new_fmt() can create a formatted Unicode"
 AG_TEST_INIT(copy_01, "ag_string_copy() can create a copy of an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (s2 && !*s2);
-} AG_TEST_EXIT();
+        AG_TEST (s2 && !*s2);
+}
 
 
 AG_TEST_INIT(copy_02, "ag_string_copy() can create a copy of an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (s2 && *s2 && ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (s2 && *s2 && ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(copy_03, "ag_string_copy() can create a copy of a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (s2 && *s2 && ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (s2 && *s2 && ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(copy_04, "ag_string_copy() increases the reference count by 1") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (ag_string_refc(s) == 2);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_refc(s) == 2);
+}
 
 
 /*
@@ -101,24 +101,24 @@ AG_TEST_INIT(copy_04, "ag_string_copy() increases the reference count by 1") {
 
 AG_TEST_INIT(release_01, "ag_string_release() performs a no-op if passed NULL") {
         ag_string_release(NULL);
-        AG_TEST_ASSERT (true);
-} AG_TEST_EXIT();
+        AG_TEST (true);
+}
 
 
 AG_TEST_INIT(release_02, "ag_string_release() performs a no-op if passed a handle"
                 " to NULL") {
         ag_string *s = NULL;
         ag_string_release(&s);
-        AG_TEST_ASSERT (true);
-} AG_TEST_EXIT();
+        AG_TEST (true);
+}
 
 
 AG_TEST_INIT(release_03, "ag_string_release() disposes a single instance of a"
                 " string") {
         ag_string *s = ag_string_new("Hello, world!");
         ag_string_release(&s);
-        AG_TEST_ASSERT (!s);
-} AG_TEST_EXIT();
+        AG_TEST (!s);
+}
 
 
 AG_TEST_INIT(release_04, "ag_string_release() reduces the reference count by 1") {
@@ -126,8 +126,8 @@ AG_TEST_INIT(release_04, "ag_string_release() reduces the reference count by 1")
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
         AG_AUTO(ag_string) *s3 = ag_string_copy(s2);
         ag_string_release(&s);
-        AG_TEST_ASSERT (!s && ag_string_refc(s2) == 2);
-} AG_TEST_EXIT();
+        AG_TEST (!s && ag_string_refc(s2) == 2);
+}
 
 
 /*
@@ -140,72 +140,72 @@ AG_TEST_INIT(cmp_01, "ag_string_cmp() returns AG_CMP_EQ when comparing two empty
                 " strings") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new_empty();
-        AG_TEST_ASSERT (ag_string_cmp(s, s2) == AG_CMP_EQ);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_cmp(s, s2) == AG_CMP_EQ);
+}
 
 
 AG_TEST_INIT(cmp_02, "ag_string_cmp() return AG_CMP_LT when comparing an empty"
                 " string with another string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_cmp(s, s2) == AG_CMP_LT);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_cmp(s, s2) == AG_CMP_LT);
+}
 
 
 AG_TEST_INIT(cmp_03, "ag_string_cmp() return AG_CMP_EQ when comparing two equal"
                 " ASCII strings") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (ag_string_cmp(s, s2) == AG_CMP_EQ);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_cmp(s, s2) == AG_CMP_EQ);
+}
 
 
 AG_TEST_INIT(cmp_04, "ag_string_cmp() returns AG_CMP_LT when comparing an ASCII"
                 " string that is lexicographically less than another") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_cmp(s, s2) == AG_CMP_LT);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_cmp(s, s2) == AG_CMP_LT);
+}
 
 
 AG_TEST_INIT(cmp_05, "ag_string_cmp() returns AG_CMP_GT when comparing an ASCII"
                 " string that is lexicographically greater than another") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_cmp(s2, s) == AG_CMP_GT);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_cmp(s2, s) == AG_CMP_GT);
+}
 
 
 AG_TEST_INIT(cmp_06, "ag_string_cmp() returns AG_CMP_GT when comparing an ASCII"
                 " string to an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_cmp(s2, s) == AG_CMP_GT);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_cmp(s2, s) == AG_CMP_GT);
+}
 
 
 AG_TEST_INIT(cmp_07, "ag_string_cmp() returns AG_CMP_EQ when comparing two equal"
                 " Unicode strings") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (ag_string_cmp(s, s2) == AG_CMP_EQ);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_cmp(s, s2) == AG_CMP_EQ);
+}
 
 
 AG_TEST_INIT(cmp_08, "ag_string_cmp() returns AG_CMP_LT when comparing a Unicode"
                 " string that is lexicographically less than another") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
-        AG_TEST_ASSERT (ag_string_cmp(s2, s) == AG_CMP_LT);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_cmp(s2, s) == AG_CMP_LT);
+}
 
 
 AG_TEST_INIT(cmp_09, "ag_string_cmp() returns AG_CMP_GT when comparing a Unicode"
                 " string that is lexicographically greater than another") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
-        AG_TEST_ASSERT (ag_string_cmp(s, s2) == AG_CMP_GT);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_cmp(s, s2) == AG_CMP_GT);
+}
 
 
 /*
@@ -218,72 +218,72 @@ AG_TEST_INIT(lt_01, "ag_string_lt() returns false when comparing two empty"
                 " strings") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new_empty();
-        AG_TEST_ASSERT (!ag_string_lt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_lt(s, s2));
+}
 
 
 AG_TEST_INIT(lt_02, "ag_string_lt() returns true when comparing an empty string"
                 " with a non-empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_lt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_lt(s, s2));
+}
 
 
 AG_TEST_INIT(lt_03, "ag_string_lt() returns false when comparing a string with an"
                 " empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_lt(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_lt(s2, s));
+}
 
 
 AG_TEST_INIT(lt_04, "ag_string_lt() returns true when comparing an ASCII string"
                 " that is lexicographically less than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_lt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_lt(s, s2));
+}
 
 
 AG_TEST_INIT(lt_05, "ag_string_lt() returns false when comparing an ASCII string"
                 " that is lexicographically equal to another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (!ag_string_lt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_lt(s, s2));
+}
 
 
 AG_TEST_INIT(lt_06, "ag_string_lt() returns false when comparing an ASCII string"
                 " that is lexicographically greater than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_lt(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_lt(s2, s));
+}
 
 
 AG_TEST_INIT(lt_07, "ag_string_lt() returns true when comparing a Unicode string"
                 " that is lexicographically less than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
-        AG_TEST_ASSERT (ag_string_lt(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_lt(s2, s));
+}
 
 
 AG_TEST_INIT(lt_08, "ag_string_lt() returns false when comparing a Unicode string"
                 " that is lexicographically equal to another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (!ag_string_lt(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_lt(s2, s));
+}
 
 
 AG_TEST_INIT(lt_09, "ag_string_lt() returns false when comparing a Unicode string"
                 " that is lexicographically greater than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
-        AG_TEST_ASSERT (!ag_string_lt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_lt(s, s2));
+}
 
 
 /*
@@ -296,72 +296,72 @@ AG_TEST_INIT(eq_01, "ag_string_eq() returns true when comparing two empty"
                 " strings") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new_empty();
-        AG_TEST_ASSERT (ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(eq_02, "ag_string_eq() returns false when comparing an empty string"
                 " with a non-empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(eq_03, "ag_string_eq() returns false when comparing a string with an"
                 " empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_eq(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_eq(s2, s));
+}
 
 
 AG_TEST_INIT(eq_04, "ag_string_eq() returns false when comparing an ASCII string"
                 " that is lexicographically less than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(eq_05, "ag_string_eq() returns true when comparing an ASCII string"
                 " that is lexicographically equal to another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(eq_06, "ag_string_eq() returns false when comparing an ASCII string"
                 " that is lexicographically greater than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_eq(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_eq(s2, s));
+}
 
 
 AG_TEST_INIT(eq_07, "ag_string_eq() returns false when comparing a Unicode string"
                 " that is lexicographically less than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
-        AG_TEST_ASSERT (!ag_string_eq(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_eq(s2, s));
+}
 
 
 AG_TEST_INIT(eq_08, "ag_string_eq() returns true when comparing a Unicode string"
                 " that is lexicographically equal to another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (ag_string_eq(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, s));
+}
 
 
 AG_TEST_INIT(eq_09, "ag_string_eq() returns false when comparing a Unicode string"
                 " that is lexicographically greater than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
-        AG_TEST_ASSERT (!ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_eq(s, s2));
+}
 
 
 /*
@@ -374,72 +374,72 @@ AG_TEST_INIT(gt_01, "ag_string_gt() returns false when comparing two empty"
                 " strings") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new_empty();
-        AG_TEST_ASSERT (!ag_string_gt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_gt(s, s2));
+}
 
 
 AG_TEST_INIT(gt_02, "ag_string_gt() returns false when comparing an empty string"
                 " with a non-empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_gt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_gt(s, s2));
+}
 
 
 AG_TEST_INIT(gt_03, "ag_string_gt() returns true when comparing a string with an"
                 " empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_gt(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_gt(s2, s));
+}
 
 
 AG_TEST_INIT(gt_04, "ag_string_gt() returns false when comparing an ASCII string"
                 " that is lexicographically less than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_gt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_gt(s, s2));
+}
 
 
 AG_TEST_INIT(gt_05, "ag_string_gt() returns false when comparing an ASCII string"
                 " that is lexicographically equal to another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (!ag_string_gt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_gt(s, s2));
+}
 
 
 AG_TEST_INIT(gt_06, "ag_string_gt() returns true when comparing an ASCII string"
                 " that is lexicographically greater than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_gt(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_gt(s2, s));
+}
 
 
 AG_TEST_INIT(gt_07, "ag_string_gt() returns false when comparing a Unicode string"
                 " that is lexicographically less than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
-        AG_TEST_ASSERT (!ag_string_gt(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_gt(s2, s));
+}
 
 
 AG_TEST_INIT(gt_08, "ag_string_gt() returns false when comparing a Unicode string"
                 " that is lexicographically equal to another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
-        AG_TEST_ASSERT (!ag_string_gt(s2, s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_gt(s2, s));
+}
 
 
 AG_TEST_INIT(gt_09, "ag_string_gt() returns true when comparing a Unicode string"
                 " that is lexicographically greater than another string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
-        AG_TEST_ASSERT (ag_string_gt(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_gt(s, s2));
+}
 
 
 /*
@@ -450,20 +450,20 @@ AG_TEST_INIT(gt_09, "ag_string_gt() returns true when comparing a Unicode string
 
 AG_TEST_INIT(empty_01, "ag_string_empty() returns true for an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
-        AG_TEST_ASSERT (ag_string_empty(s));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_empty(s));
+}
 
 
 AG_TEST_INIT(empty_02, "ag_string_empty() returns false for an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_empty(s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_empty(s));
+}
 
 
 AG_TEST_INIT(empty_03, "ag_string_empty() returns false for a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
-        AG_TEST_ASSERT (!ag_string_empty(s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_empty(s));
+}
 
 
 /*
@@ -478,20 +478,20 @@ AG_TEST_INIT(empty_03, "ag_string_empty() returns false for a Unicode string") {
 
 AG_TEST_INIT(len_01, "ag_string_len() returns 0 for an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
-        AG_TEST_ASSERT (!ag_string_len(s));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_len(s));
+}
 
 
 AG_TEST_INIT(len_02, "ag_string_len() returns the length of an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_len(s) == 13);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_len(s) == 13);
+}
 
 
 AG_TEST_INIT(len_03, "ag_string_len() returns the length of a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
-        AG_TEST_ASSERT (ag_string_len(s) == 14);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_len(s) == 14);
+}
 
 
 /*
@@ -502,20 +502,20 @@ AG_TEST_INIT(len_03, "ag_string_len() returns the length of a Unicode string") {
 
 AG_TEST_INIT(sz_01, "ag_string_sz() returns 1 for an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
-        AG_TEST_ASSERT (ag_string_sz(s) == 1);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_sz(s) == 1);
+}
 
 
 AG_TEST_INIT(sz_02, "ag_string_sz() determines the size of an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_sz(s) == 14);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_sz(s) == 14);
+}
 
 
 AG_TEST_INIT(sz_03, "ag_string_sz() determines the size of Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
-        AG_TEST_ASSERT (ag_string_sz(s) == 39);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_sz(s) == 39);
+}
 
 
 /*
@@ -526,16 +526,16 @@ AG_TEST_INIT(sz_03, "ag_string_sz() determines the size of Unicode string") {
 
 AG_TEST_INIT(refc_01, "ag_string_refc() returns 1 for a single instance") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (ag_string_refc(s) == 1);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_refc(s) == 1);
+}
 
 
 AG_TEST_INIT(refc_02, "ag_string_refc() detects incremented reference counts") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
         AG_AUTO(ag_string) *s3 = ag_string_copy(s2);
-        AG_TEST_ASSERT (ag_string_refc(s) == 3);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_refc(s) == 3);
+}
 
 
 AG_TEST_INIT(refc_03, "ag_string_refc() detects decremented reference counts") {
@@ -543,8 +543,8 @@ AG_TEST_INIT(refc_03, "ag_string_refc() detects decremented reference counts") {
         ag_string *s2 = ag_string_copy(s);
         ag_string_release(&s2);
         AG_AUTO(ag_string) *s3 = ag_string_copy(s);
-        AG_TEST_ASSERT (ag_string_refc(s) == 2);
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_refc(s) == 2);
+}
 
 
 /*
@@ -556,56 +556,56 @@ AG_TEST_INIT(refc_03, "ag_string_refc() detects decremented reference counts") {
 AG_TEST_INIT(has_01, "ag_string_has() returns true when both needle and haystack"
                 " are empty strings") {
         AG_AUTO(ag_string) *h = ag_string_new_empty(), *n = ag_string_new_empty();
-        AG_TEST_ASSERT (ag_string_has(h, n));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_has(h, n));
+}
 
 
 AG_TEST_INIT(has_02, "ag_string_has() returns false when haystack is empty and"
                 " needle is not") {
         AG_AUTO(ag_string) *h = ag_string_new_empty(),
                         *n = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (!ag_string_has(h, n));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_has(h, n));
+}
 
 
 AG_TEST_INIT(has_03, "ag_string_has() returns false when haystack is not empty and"
                 " needle is") {
         AG_AUTO(ag_string) *h = ag_string_new("Hello, world!"), 
                         *n = ag_string_new_empty();
-        AG_TEST_ASSERT (!ag_string_has(h, n));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_has(h, n));
+}
 
 
 AG_TEST_INIT(has_04, "ag_string_has() returns true if it finds an ASCII needle in"
                 " an ASCII haystack") {
         AG_AUTO(ag_string) *h = ag_string_new("Hello, world!"),
                         *n = ag_string_new("o, wo");
-        AG_TEST_ASSERT (ag_string_has(h, n));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_has(h, n));
+}
 
 
 AG_TEST_INIT(has_05, "ag_string_has() returns false if it doesn't find an ASCII"
                 " needle in an ASCII haystack") {
         AG_AUTO(ag_string) *h = ag_string_new("Hello, world!"), 
                         *n = ag_string_new("o, w!");
-        AG_TEST_ASSERT (!ag_string_has(h, n));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_has(h, n));
+}
 
 
 AG_TEST_INIT(has_06, "ag_string_has() returns true if it finds a Unicode needle in"
                 " a Unicode haystack") {
         AG_AUTO(ag_string) *h = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *n = ag_string_new("ते दुनि");
-        AG_TEST_ASSERT (ag_string_has(h, n));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_has(h, n));
+}
 
 
 AG_TEST_INIT(has_07, "ag_string_has() returns false if it doesn't find a Unicode"
                 " needle in a Unicode haystack") {
         AG_AUTO(ag_string) *h = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *n = ag_string_new("तेदुनि");
-        AG_TEST_ASSERT (!ag_string_has(h, n));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_string_has(h, n));
+}
 
 
 /*
@@ -621,44 +621,44 @@ AG_TEST_INIT(has_07, "ag_string_has() returns false if it doesn't find a Unicode
 AG_TEST_INIT(lower_01, "ag_string_lower() has no effect on an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_lower(s);
-        AG_TEST_ASSERT (ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(lower_02, "ag_string_lower() converts an ASCII string to lowercase") {
         AG_AUTO(ag_string) *s = ag_string_new("HElLo, WOrlD!");
         AG_AUTO(ag_string) *s2 = ag_string_lower(s);
-        AG_TEST_ASSERT (ag_string_eq(s2, "hello, world!"));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, "hello, world!"));
+}
 
 
 AG_TEST_INIT(upper_01, "ag_string_upper() has no effect on an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_upper(s);
-        AG_TEST_ASSERT (ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(upper_02, "ag_string_upper() converts an ASCII string to uppercase") {
         AG_AUTO(ag_string) *s = ag_string_new("heLlO, woRLd!");
         AG_AUTO(ag_string) *s2 = ag_string_upper(s);
-        AG_TEST_ASSERT (ag_string_eq(s2, "HELLO, WORLD!"));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, "HELLO, WORLD!"));
+}
 
 
 AG_TEST_INIT(proper_01, "ag_string_proper() has no effect on an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_proper(s);
-        AG_TEST_ASSERT (ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(proper_02, "ag_string_proper() converts an ASCII string to proper"
                 " case") {
         AG_AUTO(ag_string) *s = ag_string_new("tHIS isN'T.iN pRopER cASe.");
         AG_AUTO(ag_string) *s2 = ag_string_proper(s);
-        AG_TEST_ASSERT (ag_string_eq(s2, "This Isn't.In Proper Case."));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, "This Isn't.In Proper Case."));
+}
 
 
 /*
@@ -671,55 +671,55 @@ AG_TEST_INIT(split_01, "ag_string_split() returns an empty string if applied on 
                 " empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split(s, " wo");
-        AG_TEST_ASSERT (ag_string_empty(s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_empty(s2));
+}
 
 
 AG_TEST_INIT(split_02, "ag_string_split() returns the original string if the pivot"
                 " is an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "");
-        AG_TEST_ASSERT (ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s, s2));
+}
 
 AG_TEST_INIT(split_03, "ag_string_split() returns an empty string if both the"
                 " string and the pivot are empty") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "");
-        AG_TEST_ASSERT (ag_string_eq(s2, ""));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, ""));
+}
 
 
 AG_TEST_INIT(split_04, "ag_string_split() returns an empty string if the pivot is"
                 " not found") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "xyz");
-        AG_TEST_ASSERT (ag_string_empty(s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_empty(s2));
+}
 
 
 AG_TEST_INIT(split_05, "ag_string_split() returns an empty string if both the"
                 " string and pivot are the same") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, s);
-        AG_TEST_ASSERT (ag_string_empty(s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_empty(s2));
+}
 
 
 AG_TEST_INIT(split_06, "ag_string_split() returns the left side of the pivot if it"
                 " exists in an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, " wo");
-        AG_TEST_ASSERT (ag_string_eq(s2, "Hello,"));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, "Hello,"));
+}
 
 
 AG_TEST_INIT(split_07, "ag_string_split() returns the left side of the pivot if it"
                 " exists in a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "या");
-        AG_TEST_ASSERT (ag_string_eq(s2, "नमस्ते दुनि"));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, "नमस्ते दुनि"));
+}
 
 
 /*
@@ -732,56 +732,56 @@ AG_TEST_INIT(split_right_01, "ag_string_split_right() returns an empty string if
                 " applied on an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, " wo");
-        AG_TEST_ASSERT (ag_string_empty(s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_empty(s2));
+}
 
 
 AG_TEST_INIT(split_right_02, "ag_string_split_right() returns the original string"
                 " if the pivot is an empty string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, "");
-        AG_TEST_ASSERT (ag_string_eq(s, s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s, s2));
+}
 
 
 AG_TEST_INIT(split_right_03, "ag_string_split_right() returns an empty string if"
                 " both the string and the pivot are empty") {
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "");
-        AG_TEST_ASSERT (ag_string_eq(s2, ""));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, ""));
+}
 
 
 AG_TEST_INIT(split_right_04, "ag_string_split_right() returns an empty string if"
                 " the pivot is not found") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, "xyz");
-        AG_TEST_ASSERT (ag_string_empty(s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_empty(s2));
+}
 
 
 AG_TEST_INIT(split_right_05, "ag_string_split_right() returns an empty string if"
                 " both the string and pivot are the same") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, s);
-        AG_TEST_ASSERT (ag_string_empty(s2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_empty(s2));
+}
 
 
 AG_TEST_INIT(split_right_06, "ag_string_split_right() returns the right side of"
                 " the pivot if it exists in an ASCII string") {
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, " w");
-        AG_TEST_ASSERT (ag_string_eq(s2, "orld!"));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, "orld!"));
+}
 
 
 AG_TEST_INIT(split_right_07, "ag_string_split() returns the right side of the"
                 " pivot if it exists in a Unicode string") {
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, "स्ते");
-        AG_TEST_ASSERT (ag_string_eq(s2, " दुनिया!"));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(s2, " दुनिया!"));
+}
 
 
 extern ag_test_suite *test_suite_string(void)

--- a/test/string.c
+++ b/test/string.c
@@ -491,58 +491,78 @@ AG_TEST_CASE(gt_02,
 }
 
 
-AG_TEST_CASE(gt_03, "ag_string_gt() returns true when comparing a string with an"
-                " empty string") {
+AG_TEST_CASE(gt_03,
+    "ag_string_gt() returns true when comparing a string with an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_gt(s2, s));
 }
 
 
-AG_TEST_CASE(gt_04, "ag_string_gt() returns false when comparing an ASCII string"
-                " that is lexicographically less than another string") {
+AG_TEST_CASE(gt_04,
+    "ag_string_gt() returns false when comparing an ASCII string that is"
+    " lexicographically less than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (!ag_string_gt(s, s2));
 }
 
 
-AG_TEST_CASE(gt_05, "ag_string_gt() returns false when comparing an ASCII string"
-                " that is lexicographically equal to another string") {
+AG_TEST_CASE(gt_05,
+    "ag_string_gt() returns false when comparing an ASCII string that is"
+    " lexicographically equal to another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (!ag_string_gt(s, s2));
 }
 
 
-AG_TEST_CASE(gt_06, "ag_string_gt() returns true when comparing an ASCII string"
-                " that is lexicographically greater than another string") {
+AG_TEST_CASE(gt_06,
+    "ag_string_gt() returns true when comparing an ASCII string that is"
+    " lexicographically greater than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Goodbye, world!");
         AG_AUTO(ag_string) *s2 = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_gt(s2, s));
 }
 
 
-AG_TEST_CASE(gt_07, "ag_string_gt() returns false when comparing a Unicode string"
-                " that is lexicographically less than another string") {
+AG_TEST_CASE(gt_07,
+    "ag_string_gt() returns false when comparing a Unicode string that is"
+    " lexicographically less than another string") 
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
+
         AG_TEST (!ag_string_gt(s2, s));
 }
 
 
-AG_TEST_CASE(gt_08, "ag_string_gt() returns false when comparing a Unicode string"
-                " that is lexicographically equal to another string") {
+AG_TEST_CASE(gt_08,
+    "ag_string_gt() returns false when comparing a Unicode string that is"
+    " lexicographically equal to another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_copy(s);
+
         AG_TEST (!ag_string_gt(s2, s));
 }
 
 
-AG_TEST_CASE(gt_09, "ag_string_gt() returns true when comparing a Unicode string"
-                " that is lexicographically greater than another string") {
+AG_TEST_CASE(gt_09,
+    "ag_string_gt() returns true when comparing a Unicode string that is"
+    " lexicographically greater than another string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_new("अभिषेक बहुत बुरा गाता है।");
+
         AG_TEST (ag_string_gt(s, s2));
 }
 
@@ -553,20 +573,26 @@ AG_TEST_CASE(gt_09, "ag_string_gt() returns true when comparing a Unicode string
  */
 
 
-AG_TEST_CASE(empty_01, "ag_string_empty() returns true for an empty string") {
+AG_TEST_CASE(empty_01, "ag_string_empty() returns true for an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
+
         AG_TEST (ag_string_empty(s));
 }
 
 
-AG_TEST_CASE(empty_02, "ag_string_empty() returns false for an ASCII string") {
+AG_TEST_CASE(empty_02, "ag_string_empty() returns false for an ASCII string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
+
         AG_TEST (!ag_string_empty(s));
 }
 
 
-AG_TEST_CASE(empty_03, "ag_string_empty() returns false for a Unicode string") {
+AG_TEST_CASE(empty_03, "ag_string_empty() returns false for a Unicode string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
+
         AG_TEST (!ag_string_empty(s));
 }
 
@@ -581,20 +607,26 @@ AG_TEST_CASE(empty_03, "ag_string_empty() returns false for a Unicode string") {
  */
 
 
-AG_TEST_CASE(len_01, "ag_string_len() returns 0 for an empty string") {
+AG_TEST_CASE(len_01, "ag_string_len() returns 0 for an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
+
         AG_TEST (!ag_string_len(s));
 }
 
 
-AG_TEST_CASE(len_02, "ag_string_len() returns the length of an ASCII string") {
+AG_TEST_CASE(len_02, "ag_string_len() returns the length of an ASCII string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_len(s) == 13);
 }
 
 
-AG_TEST_CASE(len_03, "ag_string_len() returns the length of a Unicode string") {
+AG_TEST_CASE(len_03, "ag_string_len() returns the length of a Unicode string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
+
         AG_TEST (ag_string_len(s) == 14);
 }
 
@@ -605,8 +637,10 @@ AG_TEST_CASE(len_03, "ag_string_len() returns the length of a Unicode string") {
  */
 
 
-AG_TEST_CASE(sz_01, "ag_string_sz() returns 1 for an empty string") {
+AG_TEST_CASE(sz_01, "ag_string_sz() returns 1 for an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
+
         AG_TEST (ag_string_sz(s) == 1);
 }
 
@@ -617,8 +651,10 @@ AG_TEST_CASE(sz_02, "ag_string_sz() determines the size of an ASCII string") {
 }
 
 
-AG_TEST_CASE(sz_03, "ag_string_sz() determines the size of Unicode string") {
+AG_TEST_CASE(sz_03, "ag_string_sz() determines the size of Unicode string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
+
         AG_TEST (ag_string_sz(s) == 39);
 }
 
@@ -629,8 +665,10 @@ AG_TEST_CASE(sz_03, "ag_string_sz() determines the size of Unicode string") {
  */
 
 
-AG_TEST_CASE(refc_01, "ag_string_refc() returns 1 for a single instance") {
+AG_TEST_CASE(refc_01, "ag_string_refc() returns 1 for a single instance")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
+
         AG_TEST (ag_string_refc(s) == 1);
 }
 
@@ -643,11 +681,13 @@ AG_TEST_CASE(refc_02, "ag_string_refc() detects incremented reference counts") {
 }
 
 
-AG_TEST_CASE(refc_03, "ag_string_refc() detects decremented reference counts") {
+AG_TEST_CASE(refc_03, "ag_string_refc() detects decremented reference counts")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         ag_string *s2 = ag_string_copy(s);
         ag_string_release(&s2);
         AG_AUTO(ag_string) *s3 = ag_string_copy(s);
+
         AG_TEST (ag_string_refc(s) == 2);
 }
 
@@ -658,57 +698,77 @@ AG_TEST_CASE(refc_03, "ag_string_refc() detects decremented reference counts") {
  */
 
 
-AG_TEST_CASE(has_01, "ag_string_has() returns true when both needle and haystack"
-                " are empty strings") {
-        AG_AUTO(ag_string) *h = ag_string_new_empty(), *n = ag_string_new_empty();
+AG_TEST_CASE(has_01,
+    "ag_string_has() returns true when both needle and haystack are empty"
+    " strings")
+{
+        AG_AUTO(ag_string) *h = ag_string_new_empty(), 
+            *n = ag_string_new_empty();
+
         AG_TEST (ag_string_has(h, n));
 }
 
 
-AG_TEST_CASE(has_02, "ag_string_has() returns false when haystack is empty and"
-                " needle is not") {
+AG_TEST_CASE(has_02, 
+    "ag_string_has() returns false when haystack is empty and needle is not")
+{
         AG_AUTO(ag_string) *h = ag_string_new_empty(),
-                        *n = ag_string_new("Hello, world!");
+            *n = ag_string_new("Hello, world!");
+
         AG_TEST (!ag_string_has(h, n));
 }
 
 
-AG_TEST_CASE(has_03, "ag_string_has() returns false when haystack is not empty and"
-                " needle is") {
+AG_TEST_CASE(has_03,
+    "ag_string_has() returns false when haystack is not empty and needle is")
+{
         AG_AUTO(ag_string) *h = ag_string_new("Hello, world!"), 
-                        *n = ag_string_new_empty();
+            *n = ag_string_new_empty();
+
         AG_TEST (!ag_string_has(h, n));
 }
 
 
-AG_TEST_CASE(has_04, "ag_string_has() returns true if it finds an ASCII needle in"
-                " an ASCII haystack") {
+AG_TEST_CASE(has_04,
+    "ag_string_has() returns true if it finds an ASCII needle in an ASCII"
+    " haystack")
+{
         AG_AUTO(ag_string) *h = ag_string_new("Hello, world!"),
-                        *n = ag_string_new("o, wo");
+            *n = ag_string_new("o, wo");
+
         AG_TEST (ag_string_has(h, n));
 }
 
 
-AG_TEST_CASE(has_05, "ag_string_has() returns false if it doesn't find an ASCII"
-                " needle in an ASCII haystack") {
+AG_TEST_CASE(has_05,
+    "ag_string_has() returns false if it doesn't find an ASCII needle in an"
+    " ASCII haystack")
+{
         AG_AUTO(ag_string) *h = ag_string_new("Hello, world!"), 
-                        *n = ag_string_new("o, w!");
+            *n = ag_string_new("o, w!");
+
         AG_TEST (!ag_string_has(h, n));
 }
 
 
-AG_TEST_CASE(has_06, "ag_string_has() returns true if it finds a Unicode needle in"
-                " a Unicode haystack") {
+AG_TEST_CASE(has_06,
+    "ag_string_has() returns true if it finds a Unicode needle in a Unicode"
+    " haystack")
+{
         AG_AUTO(ag_string) *h = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *n = ag_string_new("ते दुनि");
+
         AG_TEST (ag_string_has(h, n));
 }
 
 
-AG_TEST_CASE(has_07, "ag_string_has() returns false if it doesn't find a Unicode"
-                " needle in a Unicode haystack") {
+AG_TEST_CASE(has_07,
+    "ag_string_has() returns false if it doesn't find a Unicode needle in a"
+    " Unicode haystack")
+{
         AG_AUTO(ag_string) *h = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *n = ag_string_new("तेदुनि");
+
         AG_TEST (!ag_string_has(h, n));
 }
 
@@ -723,45 +783,59 @@ AG_TEST_CASE(has_07, "ag_string_has() returns false if it doesn't find a Unicode
  */
 
 
-AG_TEST_CASE(lower_01, "ag_string_lower() has no effect on an empty string") {
+AG_TEST_CASE(lower_01, "ag_string_lower() has no effect on an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_lower(s);
+
         AG_TEST (ag_string_eq(s, s2));
 }
 
 
-AG_TEST_CASE(lower_02, "ag_string_lower() converts an ASCII string to lowercase") {
+AG_TEST_CASE(lower_02,
+    "ag_string_lower() converts an ASCII string to lowercase")
+{
         AG_AUTO(ag_string) *s = ag_string_new("HElLo, WOrlD!");
         AG_AUTO(ag_string) *s2 = ag_string_lower(s);
+
         AG_TEST (ag_string_eq(s2, "hello, world!"));
 }
 
 
-AG_TEST_CASE(upper_01, "ag_string_upper() has no effect on an empty string") {
+AG_TEST_CASE(upper_01, "ag_string_upper() has no effect on an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_upper(s);
+
         AG_TEST (ag_string_eq(s, s2));
 }
 
 
-AG_TEST_CASE(upper_02, "ag_string_upper() converts an ASCII string to uppercase") {
+AG_TEST_CASE(upper_02,
+    "ag_string_upper() converts an ASCII string to uppercase")
+{
         AG_AUTO(ag_string) *s = ag_string_new("heLlO, woRLd!");
         AG_AUTO(ag_string) *s2 = ag_string_upper(s);
+
         AG_TEST (ag_string_eq(s2, "HELLO, WORLD!"));
 }
 
 
-AG_TEST_CASE(proper_01, "ag_string_proper() has no effect on an empty string") {
+AG_TEST_CASE(proper_01, "ag_string_proper() has no effect on an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_proper(s);
+
         AG_TEST (ag_string_eq(s, s2));
 }
 
 
-AG_TEST_CASE(proper_02, "ag_string_proper() converts an ASCII string to proper"
-                " case") {
+AG_TEST_CASE(proper_02,
+    "ag_string_proper() converts an ASCII string to proper case")
+{
         AG_AUTO(ag_string) *s = ag_string_new("tHIS isN'T.iN pRopER cASe.");
         AG_AUTO(ag_string) *s2 = ag_string_proper(s);
+
         AG_TEST (ag_string_eq(s2, "This Isn't.In Proper Case."));
 }
 
@@ -772,57 +846,76 @@ AG_TEST_CASE(proper_02, "ag_string_proper() converts an ASCII string to proper"
  */
 
 
-AG_TEST_CASE(split_01, "ag_string_split() returns an empty string if applied on an"
-                " empty string") {
+AG_TEST_CASE(split_01,
+    "ag_string_split() returns an empty string if applied on an empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split(s, " wo");
+
         AG_TEST (ag_string_empty(s2));
 }
 
 
-AG_TEST_CASE(split_02, "ag_string_split() returns the original string if the pivot"
-                " is an empty string") {
+AG_TEST_CASE(split_02,
+    "ag_string_split() returns the original string if the pivot is an empty"
+    " string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "");
+
         AG_TEST (ag_string_eq(s, s2));
 }
 
-AG_TEST_CASE(split_03, "ag_string_split() returns an empty string if both the"
-                " string and the pivot are empty") {
+AG_TEST_CASE(split_03,
+    "ag_string_split() returns an empty string if both the string and the pivot"
+    " are empty") 
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "");
+
         AG_TEST (ag_string_eq(s2, ""));
 }
 
 
-AG_TEST_CASE(split_04, "ag_string_split() returns an empty string if the pivot is"
-                " not found") {
+AG_TEST_CASE(split_04,
+    "ag_string_split() returns an empty string if the pivot is not found")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "xyz");
+
         AG_TEST (ag_string_empty(s2));
 }
 
 
-AG_TEST_CASE(split_05, "ag_string_split() returns an empty string if both the"
-                " string and pivot are the same") {
+AG_TEST_CASE(split_05,
+    "ag_string_split() returns an empty string if both the string and pivot are"
+    " the same") 
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, s);
+
         AG_TEST (ag_string_empty(s2));
 }
 
 
-AG_TEST_CASE(split_06, "ag_string_split() returns the left side of the pivot if it"
-                " exists in an ASCII string") {
+AG_TEST_CASE(split_06,
+    "ag_string_split() returns the left side of the pivot if it exists in an"
+    " ASCII string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, " wo");
+
         AG_TEST (ag_string_eq(s2, "Hello,"));
 }
 
 
-AG_TEST_CASE(split_07, "ag_string_split() returns the left side of the pivot if it"
-                " exists in a Unicode string") {
+AG_TEST_CASE(split_07,
+    "ag_string_split() returns the left side of the pivot if it exists in a"
+    " Unicode string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "या");
+
         AG_TEST (ag_string_eq(s2, "नमस्ते दुनि"));
 }
 
@@ -833,58 +926,78 @@ AG_TEST_CASE(split_07, "ag_string_split() returns the left side of the pivot if 
  */
 
 
-AG_TEST_CASE(split_right_01, "ag_string_split_right() returns an empty string if"
-                " applied on an empty string") {
+AG_TEST_CASE(split_right_01,
+    "ag_string_split_right() returns an empty string if applied on an empty"
+    " string")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, " wo");
+
         AG_TEST (ag_string_empty(s2));
 }
 
 
-AG_TEST_CASE(split_right_02, "ag_string_split_right() returns the original string"
-                " if the pivot is an empty string") {
+AG_TEST_CASE(split_right_02,
+    "ag_string_split_right() returns the original string if the pivot is an"
+    " empty string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, "");
+
         AG_TEST (ag_string_eq(s, s2));
 }
 
 
-AG_TEST_CASE(split_right_03, "ag_string_split_right() returns an empty string if"
-                " both the string and the pivot are empty") {
+AG_TEST_CASE(split_right_03,
+    "ag_string_split_right() returns an empty string if both the string and the"
+    " pivot are empty")
+{
         AG_AUTO(ag_string) *s = ag_string_new_empty();
         AG_AUTO(ag_string) *s2 = ag_string_split(s, "");
+
         AG_TEST (ag_string_eq(s2, ""));
 }
 
 
-AG_TEST_CASE(split_right_04, "ag_string_split_right() returns an empty string if"
-                " the pivot is not found") {
+AG_TEST_CASE(split_right_04,
+    "ag_string_split_right() returns an empty string if the pivot is not found")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, "xyz");
+
         AG_TEST (ag_string_empty(s2));
 }
 
 
-AG_TEST_CASE(split_right_05, "ag_string_split_right() returns an empty string if"
-                " both the string and pivot are the same") {
+AG_TEST_CASE(split_right_05,
+    "ag_string_split_right() returns an empty string if both the string and"
+    " pivot are the same")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, s);
+
         AG_TEST (ag_string_empty(s2));
 }
 
 
-AG_TEST_CASE(split_right_06, "ag_string_split_right() returns the right side of"
-                " the pivot if it exists in an ASCII string") {
+AG_TEST_CASE(split_right_06,
+    "ag_string_split_right() returns the right side of the pivot if it exists"
+    " in an ASCII string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, " w");
+
         AG_TEST (ag_string_eq(s2, "orld!"));
 }
 
 
-AG_TEST_CASE(split_right_07, "ag_string_split() returns the right side of the"
-                " pivot if it exists in a Unicode string") {
+AG_TEST_CASE(split_right_07,
+    "ag_string_split() returns the right side of the pivot if it exists in a"
+    " Unicode string")
+{
         AG_AUTO(ag_string) *s = ag_string_new("नमस्ते दुनिया!");
         AG_AUTO(ag_string) *s2 = ag_string_split_right(s, "स्ते");
+
         AG_TEST (ag_string_eq(s2, " दुनिया!"));
 }
 
@@ -892,44 +1005,96 @@ AG_TEST_CASE(split_right_07, "ag_string_split() returns the right side of the"
 extern ag_test_suite *test_suite_string(void)
 {
         ag_test *test[] = {
-                new_01, new_02, new_03, new_empty_01, new_fmt_01, new_fmt_02,
-                new_fmt_03, copy_01, copy_02, copy_03, copy_04, release_01,
-                release_02, release_03, release_04, cmp_01, cmp_02, cmp_03,
-                cmp_04, cmp_05, cmp_06, cmp_07, cmp_08, cmp_09, lt_01, lt_02,
-                lt_03, lt_04, lt_05, lt_06, lt_07, lt_08, lt_09, eq_01, eq_02,
-                eq_03, eq_04, eq_05, eq_06, eq_07, eq_08, eq_09, gt_01, gt_02,
-                gt_03, gt_04, gt_05, gt_06, gt_07, gt_08, gt_09, empty_01,
-                empty_02, empty_03, len_01, len_02, len_03, sz_01, sz_02, sz_03,
-                refc_01, refc_02, refc_03, has_01, has_02, has_03, has_04,
-                has_05, has_06, has_07, lower_01, lower_02, upper_01, upper_02,
-                proper_01, proper_02, split_01, split_02, split_03, split_04,
-                split_05, split_06, split_07, split_right_01, split_right_02,
-                split_right_03, split_right_04, split_right_05, split_right_06,
+                new_01,         new_02,         new_03,
+                new_empty_01,
+                new_fmt_01,     new_fmt_02,     new_fmt_03,
+                copy_01,        copy_02,        copy_03, 
+                copy_04,
+                release_01,     release_02,     release_03,
+                release_04,
+                cmp_01,         cmp_02,         cmp_03,
+                cmp_04,         cmp_05,         cmp_06,
+                cmp_07,         cmp_08,         cmp_09,
+                lt_01,          lt_02,          lt_03,
+                lt_04,          lt_05,          lt_06,
+                lt_07,          lt_08,          lt_09, 
+                eq_01,          eq_02,          eq_03,
+                eq_04,          eq_05,          eq_06,
+                eq_07,          eq_08,          eq_09,
+                gt_01,          gt_02,          gt_03,
+                gt_04,          gt_05,          gt_06,
+                gt_07,          gt_08,          gt_09,
+                empty_01,       empty_02,       empty_03, 
+                len_01,         len_02,         len_03, 
+                sz_01,          sz_02,          sz_03,
+                refc_01,        refc_02,        refc_03, 
+                has_01,         has_02,         has_03,
+                has_04,         has_05,         has_06, 
+                has_07,
+                lower_01,       lower_02,
+                upper_01,       upper_02,
+                proper_01,      proper_02,
+                split_01,       split_02,       split_03,
+                split_04,       split_05,       split_06, 
+                split_07,
+                split_right_01, split_right_02, split_right_03,
+                split_right_04, split_right_05, split_right_06,
                 split_right_07,
         };
 
         const char *desc[] = {
-                new_01_desc, new_02_desc, new_03_desc, new_empty_01_desc,
-                new_fmt_01_desc, new_fmt_02_desc, new_fmt_03_desc, copy_01_desc,
-                copy_02_desc, copy_03_desc, copy_04_desc, release_01_desc,
-                release_02_desc, release_03_desc, release_04_desc, cmp_01_desc,
-                cmp_02_desc, cmp_03_desc, cmp_04_desc, cmp_05_desc, cmp_06_desc,
-                cmp_07_desc, cmp_08_desc, cmp_09_desc, lt_01_desc, lt_02_desc,
-                lt_03_desc, lt_04_desc, lt_05_desc, lt_06_desc, lt_07_desc,
-                lt_08_desc, lt_09_desc, eq_01_desc, eq_02_desc, eq_03_desc,
-                eq_04_desc, eq_05_desc, eq_06_desc, eq_07_desc, eq_08_desc,
-                eq_09_desc, gt_01_desc, gt_02_desc, gt_03_desc, gt_04_desc,
-                gt_05_desc, gt_06_desc, gt_07_desc, gt_08_desc, gt_09_desc,
-                empty_01_desc, empty_02_desc, empty_03_desc, len_01_desc,
-                len_02_desc, len_03_desc, sz_01_desc, sz_02_desc, sz_03_desc,
-                refc_01_desc, refc_02_desc, refc_03_desc, has_01_desc,
-                has_02_desc, has_03_desc, has_04_desc, has_05_desc, has_06_desc,
-                has_07_desc, lower_01_desc, lower_02_desc, upper_01_desc,
-                upper_02_desc, proper_01_desc, proper_02_desc, split_01_desc,
-                split_02_desc, split_03_desc, split_04_desc, split_05_desc,
-                split_06_desc, split_07_desc, split_right_01_desc,
-                split_right_02_desc, split_right_03_desc, split_right_04_desc,
-                split_right_05_desc, split_right_06_desc, split_right_07_desc,
+                new_01_desc,            new_02_desc,
+                new_03_desc, 
+                new_empty_01_desc,
+                new_fmt_01_desc,        new_fmt_02_desc,
+                new_fmt_03_desc,        copy_01_desc,
+                copy_02_desc,           copy_03_desc,
+                copy_04_desc,
+                release_01_desc,        release_02_desc,
+                release_03_desc,        release_04_desc,
+                cmp_01_desc,            cmp_02_desc, 
+                cmp_03_desc,            cmp_04_desc, 
+                cmp_05_desc,            cmp_06_desc,
+                cmp_07_desc,            cmp_08_desc, 
+                cmp_09_desc, 
+                lt_01_desc,             lt_02_desc,
+                lt_03_desc,             lt_04_desc, 
+                lt_05_desc,             lt_06_desc, 
+                lt_07_desc,             lt_08_desc, 
+                lt_09_desc, 
+                eq_01_desc,             eq_02_desc, 
+                eq_03_desc,             eq_04_desc, 
+                eq_05_desc,             eq_06_desc, 
+                eq_07_desc,             eq_08_desc,
+                eq_09_desc, 
+                gt_01_desc,             gt_02_desc, 
+                gt_03_desc,             gt_04_desc,                
+                gt_05_desc,             gt_06_desc, 
+                gt_07_desc,             gt_08_desc, 
+                gt_09_desc,
+                empty_01_desc,          empty_02_desc, 
+                empty_03_desc, 
+                len_01_desc,            len_02_desc, 
+                len_03_desc, 
+                sz_01_desc,             sz_02_desc, 
+                sz_03_desc,
+                refc_01_desc,           refc_02_desc, 
+                refc_03_desc, 
+                has_01_desc,            has_02_desc, 
+                has_03_desc,            has_04_desc, 
+                has_05_desc,            has_06_desc,
+                has_07_desc, 
+                lower_01_desc,          lower_02_desc, 
+                upper_01_desc,          upper_02_desc, 
+                proper_01_desc,         proper_02_desc, 
+                split_01_desc,          split_02_desc, 
+                split_03_desc,          split_04_desc, 
+                split_05_desc,          split_06_desc, 
+                split_07_desc, 
+                split_right_01_desc,    split_right_02_desc, 
+                split_right_03_desc,    split_right_04_desc,
+                split_right_05_desc,    split_right_06_desc,
+                split_right_07_desc,
         };
 
         ag_test_suite *ctx = ag_test_suite_new("ag_string interface");

--- a/test/test.h
+++ b/test/test.h
@@ -9,6 +9,7 @@ extern ag_test_suite    *test_suite_memblock(void);
 extern ag_test_suite    *test_suite_string(void);
 extern ag_test_suite    *test_suite_object(void);
 extern ag_test_suite    *test_suite_value(void);
+extern ag_test_suite    *test_suite_list(void);
 
 
 #endif /* !__ARGENT_TEST_H__ */

--- a/test/value.c
+++ b/test/value.c
@@ -2,13 +2,17 @@
 
 
 struct object_payload {
-    int x;
-    int y;
+        int     x;
+        int     y;
+        
 };
+
 
 #define OBJECT_TYPEID ((ag_typeid)1)
 
-static enum ag_cmp object_cmp(const ag_object *lhs, const ag_object *rhs)
+
+static enum ag_cmp 
+object_cmp(const ag_object *lhs, const ag_object *rhs)
 {
     const struct object_payload *p1 = ag_object_payload(lhs);
     const struct object_payload *p2 = ag_object_payload(rhs);
@@ -19,7 +23,9 @@ static enum ag_cmp object_cmp(const ag_object *lhs, const ag_object *rhs)
     return AG_CMP_LT;
 }
 
-static inline void object_register(void)
+
+static inline void 
+object_register(void)
 {
     struct ag_object_vtable vt = {
             .clone = NULL, .release = NULL, .cmp = object_cmp,
@@ -31,353 +37,498 @@ static inline void object_register(void)
 }
 
 
-static ag_object *object_sample(void)
+static ag_object *
+object_sample(void)
 {
     struct object_payload *p = ag_memblock_new(sizeof *p);
     p->x = 555;
     p->y = 666;
+
     return ag_object_new(OBJECT_TYPEID, p);
 }
 
 
-static inline ag_value *object_sample_value(void)
+static inline ag_value *
+object_sample_value(void)
 {
     AG_AUTO(ag_object) *o = object_sample();
+
     return ag_value_new_object(o);
 }
 
 
-AG_TEST_CASE(int_new, "ag_value_new_int() creates a new int value") {
+AG_TEST_CASE(int_new, "ag_value_new_int() creates a new int value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(-123456);
+
         AG_TEST (v && ag_value_int(v) == -123456);
 }
 
-AG_TEST_CASE(int_copy, "ag_value_copy() copies an int value") {
+
+AG_TEST_CASE(int_copy, "ag_value_copy() copies an int value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(-1029394);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
+
         AG_TEST (ag_value_int(v) == ag_value_int(cp));
 }
 
-AG_TEST_CASE(int_type_int, "ag_value_type_int() is true for an int value") {
+
+AG_TEST_CASE(int_type_int, "ag_value_type_int() is true for an int value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(11111);
+
         AG_TEST (v && ag_value_type_int(v));
 }
 
-AG_TEST_CASE(int_type_uint, "ag_value_type_uint() is false for a uint value") {
+
+AG_TEST_CASE(int_type_uint, "ag_value_type_uint() is false for a uint value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(-1111);
+
         AG_TEST (v && !ag_value_type_uint(v));
 }
 
+
 AG_TEST_CASE(int_type_float,
-    "ag_value_type_float() is false for a float value") {
+    "ag_value_type_float() is false for a float value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(1111);
+
         AG_TEST (v && !ag_value_type_float(v));
 }
 
+
 AG_TEST_CASE(int_type_string,
-    "ag_value_type_string() is false for a string value") {
+    "ag_value_type_string() is false for a string value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(-987654321);
+
         AG_TEST (v && !ag_value_type_string(v));
 }
 
+
 AG_TEST_CASE(int_type_object,
-    "ag_value_type_object() is false for an object value") {
+    "ag_value_type_object() is false for an object value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(987654321);
+
         AG_TEST (v && !ag_value_type_object(v));
 }
 
-AG_TEST_CASE(int_lt_1, "ag_value_lt() returns true for -123 < 123") {
+
+AG_TEST_CASE(int_lt_1, "ag_value_lt() returns true for -123 < 123") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
+
         AG_TEST (ag_value_lt(v1, v2));
 }
 
-AG_TEST_CASE(int_lt_2, "ag_value_lt() returns false for -123 < -123") {
+
+AG_TEST_CASE(int_lt_2, "ag_value_lt() returns false for -123 < -123") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
+
         AG_TEST (!ag_value_lt(v, v));
 }
 
-AG_TEST_CASE(int_lt_3, "ag_value_lt() returns false for 123 < -123") {
+
+AG_TEST_CASE(int_lt_3, "ag_value_lt() returns false for 123 < -123") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_int(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(-123);
+
         AG_TEST (!ag_value_lt(v1, v2));
 }
 
-AG_TEST_CASE(int_eq_1, "ag_value_eq() returns true for -123 == -123") {
+
+AG_TEST_CASE(int_eq_1, "ag_value_eq() returns true for -123 == -123") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
+
         AG_TEST (ag_value_eq(v, v));
 }
 
-AG_TEST_CASE(int_eq_2, "ag_value_eq() returns false for -123 == 123") {
+
+AG_TEST_CASE(int_eq_2, "ag_value_eq() returns false for -123 == 123") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
+
         AG_TEST (!ag_value_eq(v1, v2));
 }
 
-AG_TEST_CASE(int_gt_1, "ag_value_gt() returns true for 123 > -123") {
+
+AG_TEST_CASE(int_gt_1, "ag_value_gt() returns true for 123 > -123") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_int(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(-123);
+
         AG_TEST (ag_value_gt(v1, v2));
 }
 
-AG_TEST_CASE(int_gt_2, "ag_value_gt() returns false for -123 > -123") {
+
+AG_TEST_CASE(int_gt_2, "ag_value_gt() returns false for -123 > -123") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
+
         AG_TEST (!ag_value_gt(v, v));
 }
 
-AG_TEST_CASE(int_gt_3, "ag_value_gt() returns false for -123 > 123") {
+
+AG_TEST_CASE(int_gt_3, "ag_value_gt() returns false for -123 > 123") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
+
         AG_TEST (!ag_value_gt(v1, v2));
 }
 
 
 
 
-AG_TEST_CASE(uint_new, "ag_value_new_uint() creates a new uint value") {
+AG_TEST_CASE(uint_new, "ag_value_new_uint() creates a new uint value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(123456);
+
         AG_TEST (v && ag_value_uint(v) == 123456);
 }
 
 
-AG_TEST_CASE(uint_copy, "ag_value_copy() copies a uint value") {
+AG_TEST_CASE(uint_copy, "ag_value_copy() copies a uint value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(1029394);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
+
         AG_TEST (ag_value_uint(v) == ag_value_uint(cp));
 }
 
-AG_TEST_CASE(uint_type_int, "ag_value_type_int() is false for a uint value") {
+
+AG_TEST_CASE(uint_type_int, "ag_value_type_int() is false for a uint value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(11111);
+
         AG_TEST (v && !ag_value_type_int(v));
 }
 
-AG_TEST_CASE(uint_type_uint, "ag_value_type_uint() is true for a uint value") {
+
+AG_TEST_CASE(uint_type_uint, "ag_value_type_uint() is true for a uint value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(701115);
+
         AG_TEST (v && ag_value_type_uint(v));
 }
 
+
 AG_TEST_CASE(uint_type_float,
-    "ag_value_type_float() is false for a uint value") {
+    "ag_value_type_float() is false for a uint value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(97324);
+
         AG_TEST (v && !ag_value_type_float(v));
 }
 
+
 AG_TEST_CASE(uint_type_string,
-    "ag_value_type_string() is false for a uint value") {
+    "ag_value_type_string() is false for a uint value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(987654321);
+
         AG_TEST (v && !ag_value_type_string(v));
 }
 
+
 AG_TEST_CASE(uint_type_object,
-    "ag_value_type_object() is false for a uint value") {
+    "ag_value_type_object() is false for a uint value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(108);
+
         AG_TEST (v && !ag_value_type_object(v));
 }
 
-AG_TEST_CASE(uint_lt_1, "ag_value_lt() returns true for 123 < 124") {
+
+AG_TEST_CASE(uint_lt_1, "ag_value_lt() returns true for 123 < 124") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
+
         AG_TEST (ag_value_lt(v1, v2));
 }
 
-AG_TEST_CASE(uint_lt_2, "ag_value_lt() returns false for 123 < 123") {
+
+AG_TEST_CASE(uint_lt_2, "ag_value_lt() returns false for 123 < 123") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
+
         AG_TEST (!ag_value_lt(v, v));
 }
 
-AG_TEST_CASE(uint_lt_3, "ag_value_lt() returns false for 124 < 123") {
+
+AG_TEST_CASE(uint_lt_3, "ag_value_lt() returns false for 124 < 123") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(124);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(123);
+
         AG_TEST (!ag_value_lt(v1, v2));
 }
 
-AG_TEST_CASE(uint_eq_1, "ag_value_eq() returns true for 123 == 123") {
+
+AG_TEST_CASE(uint_eq_1, "ag_value_eq() returns true for 123 == 123") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
+
         AG_TEST (ag_value_eq(v, v));
 }
+
 
 AG_TEST_CASE(uint_eq_2,"ag_value_eq() returns false for 123 == 124") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
+
         AG_TEST (!ag_value_eq(v1, v2));
 }
 
-AG_TEST_CASE(uint_gt_1, "ag_value_gt() returns true for 124 > 123") {
+
+AG_TEST_CASE(uint_gt_1, "ag_value_gt() returns true for 124 > 123") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(124);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(123);
+
         AG_TEST (ag_value_gt(v1, v2));
 }
 
-AG_TEST_CASE(uint_gt_2, "ag_value_gt() returns false for 123 > 123") {
+
+AG_TEST_CASE(uint_gt_2, "ag_value_gt() returns false for 123 > 123") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
+
         AG_TEST (!ag_value_gt(v, v));
 }
 
-AG_TEST_CASE(uint_gt_3, "ag_value_gt() returns false for 123 > 124") {
+
+AG_TEST_CASE(uint_gt_3, "ag_value_gt() returns false for 123 > 124") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
+
         AG_TEST (!ag_value_gt(v1, v2));
 }
 
 
 
-AG_TEST_CASE(float_new, "ag_value_new_float() creates a new float value") {
+
+AG_TEST_CASE(float_new, "ag_value_new_float() creates a new float value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(-123.456);
+
         AG_TEST (v && ag_value_float(v) == -123.456);
 }
 
 
-AG_TEST_CASE(float_copy, "ag_value_copy() copies a float value") {
+AG_TEST_CASE(float_copy, "ag_value_copy() copies a float value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
+
         AG_TEST (ag_value_float(v) == ag_value_float(cp));
 }
 
 
-AG_TEST_CASE(float_type_int, "ag_value_type_int() is false for a float value") {
+AG_TEST_CASE(float_type_int, "ag_value_type_int() is false for a float value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(-123456.789);
+
         AG_TEST (v && !ag_value_type_int(v));
 }
 
 
 AG_TEST_CASE(float_type_uint, 
-    "ag_value_type_uint() is false for a float value") {
+    "ag_value_type_uint() is false for a float value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(123456.789);
+
         AG_TEST (v && !ag_value_type_uint(v));
 }
 
 
 AG_TEST_CASE(float_type_float,
-    "ag_value_type_float() is true for a float value") {
+    "ag_value_type_float() is true for a float value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(-789.123456);
+
         AG_TEST (v && ag_value_type_float(v));
 }
 
 
 AG_TEST_CASE(float_type_string,
-    "ag_value_type_string() is false for a float value") {
+    "ag_value_type_string() is false for a float value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(789.123456);
+
         AG_TEST (v && !ag_value_type_string(v));
 }
 
 
 AG_TEST_CASE(float_type_object,
-    "ag_value_type_object is false for a float value") {
+    "ag_value_type_object is false for a float value") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(-9876.5433);
+
         AG_TEST (v && !ag_value_type_object(v));
 }
 
 
-AG_TEST_CASE(float_lt_1, "ag_value_lt() returns true for 123.456 < 123.4567") {
+AG_TEST_CASE(float_lt_1, "ag_value_lt() returns true for 123.456 < 123.4567") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(124.4567);
+
         AG_TEST (ag_value_lt(v1, v2));
 }
 
 
-AG_TEST_CASE(float_lt_2, "ag_value_lt() returns false for 123.456 < 123.456") {
+AG_TEST_CASE(float_lt_2, "ag_value_lt() returns false for 123.456 < 123.456") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(123.456);
+
         AG_TEST (!ag_value_lt(v, v));
 }
 
 
-AG_TEST_CASE(float_lt_3, "ag_value_lt() returns false for 123.4567 < 123.456") {
+AG_TEST_CASE(float_lt_3, "ag_value_lt() returns false for 123.4567 < 123.456") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.4567);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.456);
+
         AG_TEST (!ag_value_lt(v1, v2));
 }
 
 
 AG_TEST_CASE(float_eq_1,
-    "ag_value_eq() returns true for -123.4567 == -123.4567") {
+    "ag_value_eq() returns true for -123.4567 == -123.4567") 
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(-123.4567);
+
         AG_TEST (ag_value_eq(v, v));
 }
 
 
 AG_TEST_CASE(float_eq_2,
-    "ag_value_eq() returns false for -123.456 == -123.4567") {
+    "ag_value_eq() returns false for -123.456 == -123.4567") 
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_float(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.4567);
+
         AG_TEST (!ag_value_eq(v1, v2));
 }
 
 
-AG_TEST_CASE(float_gt_1, "ag_value_gt() returns true for 123.4567 > 123.456") {
+AG_TEST_CASE(float_gt_1, "ag_value_gt() returns true for 123.4567 > 123.456")
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.4567);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.456);
+
         AG_TEST (ag_value_gt(v1, v2));
 }
 
 
 AG_TEST_CASE(float_gt_2,
-    "ag_value_gt() returns false for 123.4567 > 123.4567") {
+    "ag_value_gt() returns false for 123.4567 > 123.4567")
+{
         AG_AUTO(ag_value) *v = ag_value_new_float(123.4567);
+
         AG_TEST (!ag_value_gt(v, v));
 }
 
 
-AG_TEST_CASE(float_gt_3, "ag_value_gt() returns false for 123.456 > 123.4567") {
+AG_TEST_CASE(float_gt_3, "ag_value_gt() returns false for 123.456 > 123.4567")
+{
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.4567);
+
         AG_TEST (!ag_value_gt(v1, v2));
 }
 
 
 
 
-static inline ag_value *string_sample_ascii(void)
+static inline ag_value *
+string_sample_ascii(void)
 {
     AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
+
     return ag_value_new_string(s);
 }
 
-static inline ag_value *string_sample_unicode(void)
+static inline ag_value *
+string_sample_unicode(void)
 {
     AG_AUTO(ag_string) *s = ag_string_new("Привет, мир!");
+
     return ag_value_new_string(s);
 }
 
 
-AG_TEST_CASE(string_new, "ag_value_new_string() creates a new string value") {
+AG_TEST_CASE(string_new, "ag_value_new_string() creates a new string value")
+{
         AG_AUTO(ag_value) *v = string_sample_ascii();
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
+
         AG_TEST (v && ag_string_eq(ag_value_string(v), s));
 }
 
-AG_TEST_CASE(string_copy, "ag_value_copy() copies a string value") {
+
+AG_TEST_CASE(string_copy, "ag_value_copy() copies a string value")
+{
         AG_AUTO(ag_value) *v = string_sample_unicode();
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
+
         AG_TEST (ag_string_eq(ag_value_string(v), ag_value_string(cp)));
 }
 
+
 AG_TEST_CASE(string_type_int,
-    "ag_value_type_int() is false for a string value") {
+    "ag_value_type_int() is false for a string value")
+{
         AG_AUTO(ag_value) *v = string_sample_ascii();
+
         AG_TEST (!ag_value_type_int(v));
 }
+
 
 AG_TEST_CASE(string_type_uint,
-    "ag_value_type_uint() is false for a string value") {
+    "ag_value_type_uint() is false for a string value")
+{
         AG_AUTO(ag_value) *v = string_sample_unicode();
+
         AG_TEST (!ag_value_type_int(v));
 }
 
+
 AG_TEST_CASE(string_type_float,
-    "ag_value_type_float() is false for a string value") {
+    "ag_value_type_float() is false for a string value")
+{
         AG_AUTO(ag_value) *v = string_sample_ascii();
+
         AG_TEST (!ag_value_type_float(v));
 }
 
+
 AG_TEST_CASE(string_type_string,
-    "ag_value_type_string() is true for a string value") {
+    "ag_value_type_string() is true for a string value")
+{
         AG_AUTO(ag_value) *v = string_sample_unicode();
+
         AG_TEST (ag_value_type_string(v));
 }
 
+
 AG_TEST_CASE(string_type_object,
-    "ag_value_type_object() is false for a string value") {
+    "ag_value_type_object() is false for a string value")
+{
         AG_AUTO(ag_value) *v = string_sample_ascii();
+
         AG_TEST (!ag_value_type_object(v));
 }
 
@@ -385,48 +536,67 @@ AG_TEST_CASE(string_type_object,
 
 
 
-AG_TEST_CASE(object_new, "ag_value_new_object() creates a new object value") {
+AG_TEST_CASE(object_new, "ag_value_new_object() creates a new object value")
+{
         AG_AUTO(ag_object) *o = object_sample();
         AG_AUTO(ag_value) *v = object_sample_value();
+
         AG_TEST (v && ag_object_eq(ag_value_object(o), o));
 }
 
-AG_TEST_CASE(object_copy, "ag_value_copy() copies an object value") {
+
+AG_TEST_CASE(object_copy, "ag_value_copy() copies an object value")
+{
         AG_AUTO(ag_value) *v = object_sample_value();
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
+
         AG_TEST (ag_object_eq(ag_value_object(v), ag_value_object(cp)));
 }
 
+
 AG_TEST_CASE(object_type_int,
-    "ag_value_type_int() is false for an object value") {
+    "ag_value_type_int() is false for an object value")
+{
         AG_AUTO(ag_value) *v = object_sample_value();
+
         AG_TEST (!ag_value_type_int(v));
 }
 
+
 AG_TEST_CASE(object_type_uint,
-    "ag_value_type_uint() is false for an object value") {
+    "ag_value_type_uint() is false for an object value")
+{
         AG_AUTO(ag_value) *v = object_sample_value();
+
         AG_TEST (!ag_value_type_uint(v));
 }
 
+
 AG_TEST_CASE(object_type_float,
-    "ag_value_type_float() is false for an object value") {
+    "ag_value_type_float() is false for an object value")
+{
         AG_AUTO(ag_value) *v = object_sample_value();
+
         AG_TEST (!ag_value_type_float(v));
 }
 
+
 AG_TEST_CASE(object_type_string,
-    "ag_value_type_string() is false for an object value") {
+    "ag_value_type_string() is false for an object value")
+{
         AG_AUTO(ag_value) *v = object_sample_value();
+
         AG_TEST (!ag_value_type_string(v));
 }
 
+
 AG_TEST_CASE(object_type_object,
-    "ag_value_type_object() is true for an object value") {
+    "ag_value_type_object() is true for an object value")
+{
         AG_AUTO(ag_value) *v = object_sample_value();
+
         AG_TEST (ag_value_type_object(v));
 }
-
 
 
 
@@ -506,48 +676,3 @@ test_suite_value(void)
         return ctx;
 }
 
-
-
-#if 0
-
-#include "../src/api.h"
-#include "./test.h"
-
-
-
-
-
-
-
-
-
-
-
-static void object_test(void)
-{
-
-    object_register();
-
-}
-
-
-/*******************************************************************************
- *                                  TEST SUITE
- */
-
-
-extern void ag_test_value(void)
-{
-    printf("===============================================================\n");
-    printf("Starting dynamic type interface test suite...\n\n");
-
-    int_test();
-    uint_test();
-    float_test();
-    string_test();
-    object_test();
-
-    printf("\n");
-}
-
-#endif

--- a/test/value.c
+++ b/test/value.c
@@ -47,85 +47,85 @@ static inline ag_value *object_sample_value(void)
 }
 
 
-AG_TEST_INIT(int_new, "ag_value_new_int() creates a new int value") {
+AG_TEST_CASE(int_new, "ag_value_new_int() creates a new int value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123456);
         AG_TEST (v && ag_value_int(v) == -123456);
 }
 
-AG_TEST_INIT(int_copy, "ag_value_copy() copies an int value") {
+AG_TEST_CASE(int_copy, "ag_value_copy() copies an int value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-1029394);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
         AG_TEST (ag_value_int(v) == ag_value_int(cp));
 }
 
-AG_TEST_INIT(int_type_int, "ag_value_type_int() is true for an int value") {
+AG_TEST_CASE(int_type_int, "ag_value_type_int() is true for an int value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(11111);
         AG_TEST (v && ag_value_type_int(v));
 }
 
-AG_TEST_INIT(int_type_uint, "ag_value_type_uint() is false for a uint value") {
+AG_TEST_CASE(int_type_uint, "ag_value_type_uint() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-1111);
         AG_TEST (v && !ag_value_type_uint(v));
 }
 
-AG_TEST_INIT(int_type_float,
+AG_TEST_CASE(int_type_float,
     "ag_value_type_float() is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(1111);
         AG_TEST (v && !ag_value_type_float(v));
 }
 
-AG_TEST_INIT(int_type_string,
+AG_TEST_CASE(int_type_string,
     "ag_value_type_string() is false for a string value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-987654321);
         AG_TEST (v && !ag_value_type_string(v));
 }
 
-AG_TEST_INIT(int_type_object,
+AG_TEST_CASE(int_type_object,
     "ag_value_type_object() is false for an object value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(987654321);
         AG_TEST (v && !ag_value_type_object(v));
 }
 
-AG_TEST_INIT(int_lt_1, "ag_value_lt() returns true for -123 < 123") {
+AG_TEST_CASE(int_lt_1, "ag_value_lt() returns true for -123 < 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
         AG_TEST (ag_value_lt(v1, v2));
 }
 
-AG_TEST_INIT(int_lt_2, "ag_value_lt() returns false for -123 < -123") {
+AG_TEST_CASE(int_lt_2, "ag_value_lt() returns false for -123 < -123") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
         AG_TEST (!ag_value_lt(v, v));
 }
 
-AG_TEST_INIT(int_lt_3, "ag_value_lt() returns false for 123 < -123") {
+AG_TEST_CASE(int_lt_3, "ag_value_lt() returns false for 123 < -123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(-123);
         AG_TEST (!ag_value_lt(v1, v2));
 }
 
-AG_TEST_INIT(int_eq_1, "ag_value_eq() returns true for -123 == -123") {
+AG_TEST_CASE(int_eq_1, "ag_value_eq() returns true for -123 == -123") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
         AG_TEST (ag_value_eq(v, v));
 }
 
-AG_TEST_INIT(int_eq_2, "ag_value_eq() returns false for -123 == 123") {
+AG_TEST_CASE(int_eq_2, "ag_value_eq() returns false for -123 == 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
         AG_TEST (!ag_value_eq(v1, v2));
 }
 
-AG_TEST_INIT(int_gt_1, "ag_value_gt() returns true for 123 > -123") {
+AG_TEST_CASE(int_gt_1, "ag_value_gt() returns true for 123 > -123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(-123);
         AG_TEST (ag_value_gt(v1, v2));
 }
 
-AG_TEST_INIT(int_gt_2, "ag_value_gt() returns false for -123 > -123") {
+AG_TEST_CASE(int_gt_2, "ag_value_gt() returns false for -123 > -123") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
         AG_TEST (!ag_value_gt(v, v));
 }
 
-AG_TEST_INIT(int_gt_3, "ag_value_gt() returns false for -123 > 123") {
+AG_TEST_CASE(int_gt_3, "ag_value_gt() returns false for -123 > 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
         AG_TEST (!ag_value_gt(v1, v2));
@@ -134,86 +134,86 @@ AG_TEST_INIT(int_gt_3, "ag_value_gt() returns false for -123 > 123") {
 
 
 
-AG_TEST_INIT(uint_new, "ag_value_new_uint() creates a new uint value") {
+AG_TEST_CASE(uint_new, "ag_value_new_uint() creates a new uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123456);
         AG_TEST (v && ag_value_uint(v) == 123456);
 }
 
 
-AG_TEST_INIT(uint_copy, "ag_value_copy() copies a uint value") {
+AG_TEST_CASE(uint_copy, "ag_value_copy() copies a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(1029394);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
         AG_TEST (ag_value_uint(v) == ag_value_uint(cp));
 }
 
-AG_TEST_INIT(uint_type_int, "ag_value_type_int() is false for a uint value") {
+AG_TEST_CASE(uint_type_int, "ag_value_type_int() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(11111);
         AG_TEST (v && !ag_value_type_int(v));
 }
 
-AG_TEST_INIT(uint_type_uint, "ag_value_type_uint() is true for a uint value") {
+AG_TEST_CASE(uint_type_uint, "ag_value_type_uint() is true for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(701115);
         AG_TEST (v && ag_value_type_uint(v));
 }
 
-AG_TEST_INIT(uint_type_float,
+AG_TEST_CASE(uint_type_float,
     "ag_value_type_float() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(97324);
         AG_TEST (v && !ag_value_type_float(v));
 }
 
-AG_TEST_INIT(uint_type_string,
+AG_TEST_CASE(uint_type_string,
     "ag_value_type_string() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(987654321);
         AG_TEST (v && !ag_value_type_string(v));
 }
 
-AG_TEST_INIT(uint_type_object,
+AG_TEST_CASE(uint_type_object,
     "ag_value_type_object() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(108);
         AG_TEST (v && !ag_value_type_object(v));
 }
 
-AG_TEST_INIT(uint_lt_1, "ag_value_lt() returns true for 123 < 124") {
+AG_TEST_CASE(uint_lt_1, "ag_value_lt() returns true for 123 < 124") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
         AG_TEST (ag_value_lt(v1, v2));
 }
 
-AG_TEST_INIT(uint_lt_2, "ag_value_lt() returns false for 123 < 123") {
+AG_TEST_CASE(uint_lt_2, "ag_value_lt() returns false for 123 < 123") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
         AG_TEST (!ag_value_lt(v, v));
 }
 
-AG_TEST_INIT(uint_lt_3, "ag_value_lt() returns false for 124 < 123") {
+AG_TEST_CASE(uint_lt_3, "ag_value_lt() returns false for 124 < 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(124);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(123);
         AG_TEST (!ag_value_lt(v1, v2));
 }
 
-AG_TEST_INIT(uint_eq_1, "ag_value_eq() returns true for 123 == 123") {
+AG_TEST_CASE(uint_eq_1, "ag_value_eq() returns true for 123 == 123") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
         AG_TEST (ag_value_eq(v, v));
 }
 
-AG_TEST_INIT(uint_eq_2,"ag_value_eq() returns false for 123 == 124") {
+AG_TEST_CASE(uint_eq_2,"ag_value_eq() returns false for 123 == 124") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
         AG_TEST (!ag_value_eq(v1, v2));
 }
 
-AG_TEST_INIT(uint_gt_1, "ag_value_gt() returns true for 124 > 123") {
+AG_TEST_CASE(uint_gt_1, "ag_value_gt() returns true for 124 > 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(124);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(123);
         AG_TEST (ag_value_gt(v1, v2));
 }
 
-AG_TEST_INIT(uint_gt_2, "ag_value_gt() returns false for 123 > 123") {
+AG_TEST_CASE(uint_gt_2, "ag_value_gt() returns false for 123 > 123") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
         AG_TEST (!ag_value_gt(v, v));
 }
 
-AG_TEST_INIT(uint_gt_3, "ag_value_gt() returns false for 123 > 124") {
+AG_TEST_CASE(uint_gt_3, "ag_value_gt() returns false for 123 > 124") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
         AG_TEST (!ag_value_gt(v1, v2));
@@ -221,81 +221,81 @@ AG_TEST_INIT(uint_gt_3, "ag_value_gt() returns false for 123 > 124") {
 
 
 
-AG_TEST_INIT(float_new, "ag_value_new_float() creates a new float value") {
+AG_TEST_CASE(float_new, "ag_value_new_float() creates a new float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-123.456);
         AG_TEST (v && ag_value_float(v) == -123.456);
 }
 
 
-AG_TEST_INIT(float_copy, "ag_value_copy() copies a float value") {
+AG_TEST_CASE(float_copy, "ag_value_copy() copies a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
         AG_TEST (ag_value_float(v) == ag_value_float(cp));
 }
 
 
-AG_TEST_INIT(float_type_int, "ag_value_type_int() is false for a float value") {
+AG_TEST_CASE(float_type_int, "ag_value_type_int() is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-123456.789);
         AG_TEST (v && !ag_value_type_int(v));
 }
 
 
-AG_TEST_INIT(float_type_uint, 
+AG_TEST_CASE(float_type_uint, 
     "ag_value_type_uint() is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(123456.789);
         AG_TEST (v && !ag_value_type_uint(v));
 }
 
 
-AG_TEST_INIT(float_type_float,
+AG_TEST_CASE(float_type_float,
     "ag_value_type_float() is true for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-789.123456);
         AG_TEST (v && ag_value_type_float(v));
 }
 
 
-AG_TEST_INIT(float_type_string,
+AG_TEST_CASE(float_type_string,
     "ag_value_type_string() is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(789.123456);
         AG_TEST (v && !ag_value_type_string(v));
 }
 
 
-AG_TEST_INIT(float_type_object,
+AG_TEST_CASE(float_type_object,
     "ag_value_type_object is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-9876.5433);
         AG_TEST (v && !ag_value_type_object(v));
 }
 
 
-AG_TEST_INIT(float_lt_1, "ag_value_lt() returns true for 123.456 < 123.4567") {
+AG_TEST_CASE(float_lt_1, "ag_value_lt() returns true for 123.456 < 123.4567") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(124.4567);
         AG_TEST (ag_value_lt(v1, v2));
 }
 
 
-AG_TEST_INIT(float_lt_2, "ag_value_lt() returns false for 123.456 < 123.456") {
+AG_TEST_CASE(float_lt_2, "ag_value_lt() returns false for 123.456 < 123.456") {
         AG_AUTO(ag_value) *v = ag_value_new_float(123.456);
         AG_TEST (!ag_value_lt(v, v));
 }
 
 
-AG_TEST_INIT(float_lt_3, "ag_value_lt() returns false for 123.4567 < 123.456") {
+AG_TEST_CASE(float_lt_3, "ag_value_lt() returns false for 123.4567 < 123.456") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.4567);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.456);
         AG_TEST (!ag_value_lt(v1, v2));
 }
 
 
-AG_TEST_INIT(float_eq_1,
+AG_TEST_CASE(float_eq_1,
     "ag_value_eq() returns true for -123.4567 == -123.4567") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-123.4567);
         AG_TEST (ag_value_eq(v, v));
 }
 
 
-AG_TEST_INIT(float_eq_2,
+AG_TEST_CASE(float_eq_2,
     "ag_value_eq() returns false for -123.456 == -123.4567") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.4567);
@@ -303,21 +303,21 @@ AG_TEST_INIT(float_eq_2,
 }
 
 
-AG_TEST_INIT(float_gt_1, "ag_value_gt() returns true for 123.4567 > 123.456") {
+AG_TEST_CASE(float_gt_1, "ag_value_gt() returns true for 123.4567 > 123.456") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.4567);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.456);
         AG_TEST (ag_value_gt(v1, v2));
 }
 
 
-AG_TEST_INIT(float_gt_2,
+AG_TEST_CASE(float_gt_2,
     "ag_value_gt() returns false for 123.4567 > 123.4567") {
         AG_AUTO(ag_value) *v = ag_value_new_float(123.4567);
         AG_TEST (!ag_value_gt(v, v));
 }
 
 
-AG_TEST_INIT(float_gt_3, "ag_value_gt() returns false for 123.456 > 123.4567") {
+AG_TEST_CASE(float_gt_3, "ag_value_gt() returns false for 123.456 > 123.4567") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.4567);
         AG_TEST (!ag_value_gt(v1, v2));
@@ -339,43 +339,43 @@ static inline ag_value *string_sample_unicode(void)
 }
 
 
-AG_TEST_INIT(string_new, "ag_value_new_string() creates a new string value") {
+AG_TEST_CASE(string_new, "ag_value_new_string() creates a new string value") {
         AG_AUTO(ag_value) *v = string_sample_ascii();
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
         AG_TEST (v && ag_string_eq(ag_value_string(v), s));
 }
 
-AG_TEST_INIT(string_copy, "ag_value_copy() copies a string value") {
+AG_TEST_CASE(string_copy, "ag_value_copy() copies a string value") {
         AG_AUTO(ag_value) *v = string_sample_unicode();
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
         AG_TEST (ag_string_eq(ag_value_string(v), ag_value_string(cp)));
 }
 
-AG_TEST_INIT(string_type_int,
+AG_TEST_CASE(string_type_int,
     "ag_value_type_int() is false for a string value") {
         AG_AUTO(ag_value) *v = string_sample_ascii();
         AG_TEST (!ag_value_type_int(v));
 }
 
-AG_TEST_INIT(string_type_uint,
+AG_TEST_CASE(string_type_uint,
     "ag_value_type_uint() is false for a string value") {
         AG_AUTO(ag_value) *v = string_sample_unicode();
         AG_TEST (!ag_value_type_int(v));
 }
 
-AG_TEST_INIT(string_type_float,
+AG_TEST_CASE(string_type_float,
     "ag_value_type_float() is false for a string value") {
         AG_AUTO(ag_value) *v = string_sample_ascii();
         AG_TEST (!ag_value_type_float(v));
 }
 
-AG_TEST_INIT(string_type_string,
+AG_TEST_CASE(string_type_string,
     "ag_value_type_string() is true for a string value") {
         AG_AUTO(ag_value) *v = string_sample_unicode();
         AG_TEST (ag_value_type_string(v));
 }
 
-AG_TEST_INIT(string_type_object,
+AG_TEST_CASE(string_type_object,
     "ag_value_type_object() is false for a string value") {
         AG_AUTO(ag_value) *v = string_sample_ascii();
         AG_TEST (!ag_value_type_object(v));
@@ -385,43 +385,43 @@ AG_TEST_INIT(string_type_object,
 
 
 
-AG_TEST_INIT(object_new, "ag_value_new_object() creates a new object value") {
+AG_TEST_CASE(object_new, "ag_value_new_object() creates a new object value") {
         AG_AUTO(ag_object) *o = object_sample();
         AG_AUTO(ag_value) *v = object_sample_value();
         AG_TEST (v && ag_object_eq(ag_value_object(o), o));
 }
 
-AG_TEST_INIT(object_copy, "ag_value_copy() copies an object value") {
+AG_TEST_CASE(object_copy, "ag_value_copy() copies an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
         AG_TEST (ag_object_eq(ag_value_object(v), ag_value_object(cp)));
 }
 
-AG_TEST_INIT(object_type_int,
+AG_TEST_CASE(object_type_int,
     "ag_value_type_int() is false for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
         AG_TEST (!ag_value_type_int(v));
 }
 
-AG_TEST_INIT(object_type_uint,
+AG_TEST_CASE(object_type_uint,
     "ag_value_type_uint() is false for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
         AG_TEST (!ag_value_type_uint(v));
 }
 
-AG_TEST_INIT(object_type_float,
+AG_TEST_CASE(object_type_float,
     "ag_value_type_float() is false for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
         AG_TEST (!ag_value_type_float(v));
 }
 
-AG_TEST_INIT(object_type_string,
+AG_TEST_CASE(object_type_string,
     "ag_value_type_string() is false for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
         AG_TEST (!ag_value_type_string(v));
 }
 
-AG_TEST_INIT(object_type_object,
+AG_TEST_CASE(object_type_object,
     "ag_value_type_object() is true for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
         AG_TEST (ag_value_type_object(v));

--- a/test/value.c
+++ b/test/value.c
@@ -4,14 +4,14 @@
 struct object_payload {
         int     x;
         int     y;
-        
+
 };
 
 
 #define OBJECT_TYPEID ((ag_typeid)1)
 
 
-static enum ag_cmp 
+static enum ag_cmp
 object_cmp(const ag_object *lhs, const ag_object *rhs)
 {
     const struct object_payload *p1 = ag_object_payload(lhs);
@@ -24,12 +24,12 @@ object_cmp(const ag_object *lhs, const ag_object *rhs)
 }
 
 
-static inline void 
+static inline void
 object_register(void)
 {
     struct ag_object_vtable vt = {
             .clone = NULL, .release = NULL, .cmp = object_cmp,
-            .valid = NULL, .sz = NULL,      .len = NULL, 
+            .valid = NULL, .sz = NULL,      .len = NULL,
             .hash = NULL,  .str = NULL,
     };
 
@@ -57,7 +57,7 @@ object_sample_value(void)
 }
 
 
-AG_TEST_CASE(int_new, "ag_value_new_int() creates a new int value") 
+AG_TEST_CASE(int_new, "ag_value_new_int() creates a new int value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123456);
 
@@ -65,7 +65,7 @@ AG_TEST_CASE(int_new, "ag_value_new_int() creates a new int value")
 }
 
 
-AG_TEST_CASE(int_copy, "ag_value_copy() copies an int value") 
+AG_TEST_CASE(int_copy, "ag_value_copy() copies an int value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(-1029394);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
@@ -74,7 +74,7 @@ AG_TEST_CASE(int_copy, "ag_value_copy() copies an int value")
 }
 
 
-AG_TEST_CASE(int_type_int, "ag_value_type_int() is true for an int value") 
+AG_TEST_CASE(int_type_int, "ag_value_type_int() is true for an int value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(11111);
 
@@ -82,7 +82,7 @@ AG_TEST_CASE(int_type_int, "ag_value_type_int() is true for an int value")
 }
 
 
-AG_TEST_CASE(int_type_uint, "ag_value_type_uint() is false for a uint value") 
+AG_TEST_CASE(int_type_uint, "ag_value_type_uint() is false for a uint value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(-1111);
 
@@ -91,7 +91,7 @@ AG_TEST_CASE(int_type_uint, "ag_value_type_uint() is false for a uint value")
 
 
 AG_TEST_CASE(int_type_float,
-    "ag_value_type_float() is false for a float value") 
+    "ag_value_type_float() is false for a float value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(1111);
 
@@ -100,7 +100,7 @@ AG_TEST_CASE(int_type_float,
 
 
 AG_TEST_CASE(int_type_string,
-    "ag_value_type_string() is false for a string value") 
+    "ag_value_type_string() is false for a string value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(-987654321);
 
@@ -109,7 +109,7 @@ AG_TEST_CASE(int_type_string,
 
 
 AG_TEST_CASE(int_type_object,
-    "ag_value_type_object() is false for an object value") 
+    "ag_value_type_object() is false for an object value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(987654321);
 
@@ -117,7 +117,7 @@ AG_TEST_CASE(int_type_object,
 }
 
 
-AG_TEST_CASE(int_lt_1, "ag_value_lt() returns true for -123 < 123") 
+AG_TEST_CASE(int_lt_1, "ag_value_lt() returns true for -123 < 123")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
@@ -126,7 +126,7 @@ AG_TEST_CASE(int_lt_1, "ag_value_lt() returns true for -123 < 123")
 }
 
 
-AG_TEST_CASE(int_lt_2, "ag_value_lt() returns false for -123 < -123") 
+AG_TEST_CASE(int_lt_2, "ag_value_lt() returns false for -123 < -123")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
 
@@ -134,7 +134,7 @@ AG_TEST_CASE(int_lt_2, "ag_value_lt() returns false for -123 < -123")
 }
 
 
-AG_TEST_CASE(int_lt_3, "ag_value_lt() returns false for 123 < -123") 
+AG_TEST_CASE(int_lt_3, "ag_value_lt() returns false for 123 < -123")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(-123);
@@ -143,7 +143,7 @@ AG_TEST_CASE(int_lt_3, "ag_value_lt() returns false for 123 < -123")
 }
 
 
-AG_TEST_CASE(int_eq_1, "ag_value_eq() returns true for -123 == -123") 
+AG_TEST_CASE(int_eq_1, "ag_value_eq() returns true for -123 == -123")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
 
@@ -151,7 +151,7 @@ AG_TEST_CASE(int_eq_1, "ag_value_eq() returns true for -123 == -123")
 }
 
 
-AG_TEST_CASE(int_eq_2, "ag_value_eq() returns false for -123 == 123") 
+AG_TEST_CASE(int_eq_2, "ag_value_eq() returns false for -123 == 123")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
@@ -160,7 +160,7 @@ AG_TEST_CASE(int_eq_2, "ag_value_eq() returns false for -123 == 123")
 }
 
 
-AG_TEST_CASE(int_gt_1, "ag_value_gt() returns true for 123 > -123") 
+AG_TEST_CASE(int_gt_1, "ag_value_gt() returns true for 123 > -123")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(-123);
@@ -169,7 +169,7 @@ AG_TEST_CASE(int_gt_1, "ag_value_gt() returns true for 123 > -123")
 }
 
 
-AG_TEST_CASE(int_gt_2, "ag_value_gt() returns false for -123 > -123") 
+AG_TEST_CASE(int_gt_2, "ag_value_gt() returns false for -123 > -123")
 {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
 
@@ -177,7 +177,7 @@ AG_TEST_CASE(int_gt_2, "ag_value_gt() returns false for -123 > -123")
 }
 
 
-AG_TEST_CASE(int_gt_3, "ag_value_gt() returns false for -123 > 123") 
+AG_TEST_CASE(int_gt_3, "ag_value_gt() returns false for -123 > 123")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
@@ -188,7 +188,7 @@ AG_TEST_CASE(int_gt_3, "ag_value_gt() returns false for -123 > 123")
 
 
 
-AG_TEST_CASE(uint_new, "ag_value_new_uint() creates a new uint value") 
+AG_TEST_CASE(uint_new, "ag_value_new_uint() creates a new uint value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123456);
 
@@ -196,7 +196,7 @@ AG_TEST_CASE(uint_new, "ag_value_new_uint() creates a new uint value")
 }
 
 
-AG_TEST_CASE(uint_copy, "ag_value_copy() copies a uint value") 
+AG_TEST_CASE(uint_copy, "ag_value_copy() copies a uint value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(1029394);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
@@ -205,7 +205,7 @@ AG_TEST_CASE(uint_copy, "ag_value_copy() copies a uint value")
 }
 
 
-AG_TEST_CASE(uint_type_int, "ag_value_type_int() is false for a uint value") 
+AG_TEST_CASE(uint_type_int, "ag_value_type_int() is false for a uint value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(11111);
 
@@ -213,7 +213,7 @@ AG_TEST_CASE(uint_type_int, "ag_value_type_int() is false for a uint value")
 }
 
 
-AG_TEST_CASE(uint_type_uint, "ag_value_type_uint() is true for a uint value") 
+AG_TEST_CASE(uint_type_uint, "ag_value_type_uint() is true for a uint value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(701115);
 
@@ -222,7 +222,7 @@ AG_TEST_CASE(uint_type_uint, "ag_value_type_uint() is true for a uint value")
 
 
 AG_TEST_CASE(uint_type_float,
-    "ag_value_type_float() is false for a uint value") 
+    "ag_value_type_float() is false for a uint value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(97324);
 
@@ -231,7 +231,7 @@ AG_TEST_CASE(uint_type_float,
 
 
 AG_TEST_CASE(uint_type_string,
-    "ag_value_type_string() is false for a uint value") 
+    "ag_value_type_string() is false for a uint value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(987654321);
 
@@ -240,7 +240,7 @@ AG_TEST_CASE(uint_type_string,
 
 
 AG_TEST_CASE(uint_type_object,
-    "ag_value_type_object() is false for a uint value") 
+    "ag_value_type_object() is false for a uint value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(108);
 
@@ -248,7 +248,7 @@ AG_TEST_CASE(uint_type_object,
 }
 
 
-AG_TEST_CASE(uint_lt_1, "ag_value_lt() returns true for 123 < 124") 
+AG_TEST_CASE(uint_lt_1, "ag_value_lt() returns true for 123 < 124")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
@@ -257,7 +257,7 @@ AG_TEST_CASE(uint_lt_1, "ag_value_lt() returns true for 123 < 124")
 }
 
 
-AG_TEST_CASE(uint_lt_2, "ag_value_lt() returns false for 123 < 123") 
+AG_TEST_CASE(uint_lt_2, "ag_value_lt() returns false for 123 < 123")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
 
@@ -265,7 +265,7 @@ AG_TEST_CASE(uint_lt_2, "ag_value_lt() returns false for 123 < 123")
 }
 
 
-AG_TEST_CASE(uint_lt_3, "ag_value_lt() returns false for 124 < 123") 
+AG_TEST_CASE(uint_lt_3, "ag_value_lt() returns false for 124 < 123")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(124);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(123);
@@ -274,7 +274,7 @@ AG_TEST_CASE(uint_lt_3, "ag_value_lt() returns false for 124 < 123")
 }
 
 
-AG_TEST_CASE(uint_eq_1, "ag_value_eq() returns true for 123 == 123") 
+AG_TEST_CASE(uint_eq_1, "ag_value_eq() returns true for 123 == 123")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
 
@@ -290,7 +290,7 @@ AG_TEST_CASE(uint_eq_2,"ag_value_eq() returns false for 123 == 124") {
 }
 
 
-AG_TEST_CASE(uint_gt_1, "ag_value_gt() returns true for 124 > 123") 
+AG_TEST_CASE(uint_gt_1, "ag_value_gt() returns true for 124 > 123")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(124);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(123);
@@ -299,7 +299,7 @@ AG_TEST_CASE(uint_gt_1, "ag_value_gt() returns true for 124 > 123")
 }
 
 
-AG_TEST_CASE(uint_gt_2, "ag_value_gt() returns false for 123 > 123") 
+AG_TEST_CASE(uint_gt_2, "ag_value_gt() returns false for 123 > 123")
 {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
 
@@ -307,7 +307,7 @@ AG_TEST_CASE(uint_gt_2, "ag_value_gt() returns false for 123 > 123")
 }
 
 
-AG_TEST_CASE(uint_gt_3, "ag_value_gt() returns false for 123 > 124") 
+AG_TEST_CASE(uint_gt_3, "ag_value_gt() returns false for 123 > 124")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
@@ -318,7 +318,7 @@ AG_TEST_CASE(uint_gt_3, "ag_value_gt() returns false for 123 > 124")
 
 
 
-AG_TEST_CASE(float_new, "ag_value_new_float() creates a new float value") 
+AG_TEST_CASE(float_new, "ag_value_new_float() creates a new float value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_float(-123.456);
 
@@ -326,7 +326,7 @@ AG_TEST_CASE(float_new, "ag_value_new_float() creates a new float value")
 }
 
 
-AG_TEST_CASE(float_copy, "ag_value_copy() copies a float value") 
+AG_TEST_CASE(float_copy, "ag_value_copy() copies a float value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
@@ -335,7 +335,7 @@ AG_TEST_CASE(float_copy, "ag_value_copy() copies a float value")
 }
 
 
-AG_TEST_CASE(float_type_int, "ag_value_type_int() is false for a float value") 
+AG_TEST_CASE(float_type_int, "ag_value_type_int() is false for a float value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_float(-123456.789);
 
@@ -343,8 +343,8 @@ AG_TEST_CASE(float_type_int, "ag_value_type_int() is false for a float value")
 }
 
 
-AG_TEST_CASE(float_type_uint, 
-    "ag_value_type_uint() is false for a float value") 
+AG_TEST_CASE(float_type_uint,
+    "ag_value_type_uint() is false for a float value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_float(123456.789);
 
@@ -353,7 +353,7 @@ AG_TEST_CASE(float_type_uint,
 
 
 AG_TEST_CASE(float_type_float,
-    "ag_value_type_float() is true for a float value") 
+    "ag_value_type_float() is true for a float value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_float(-789.123456);
 
@@ -362,7 +362,7 @@ AG_TEST_CASE(float_type_float,
 
 
 AG_TEST_CASE(float_type_string,
-    "ag_value_type_string() is false for a float value") 
+    "ag_value_type_string() is false for a float value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_float(789.123456);
 
@@ -371,7 +371,7 @@ AG_TEST_CASE(float_type_string,
 
 
 AG_TEST_CASE(float_type_object,
-    "ag_value_type_object is false for a float value") 
+    "ag_value_type_object is false for a float value")
 {
         AG_AUTO(ag_value) *v = ag_value_new_float(-9876.5433);
 
@@ -379,7 +379,7 @@ AG_TEST_CASE(float_type_object,
 }
 
 
-AG_TEST_CASE(float_lt_1, "ag_value_lt() returns true for 123.456 < 123.4567") 
+AG_TEST_CASE(float_lt_1, "ag_value_lt() returns true for 123.456 < 123.4567")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(124.4567);
@@ -388,7 +388,7 @@ AG_TEST_CASE(float_lt_1, "ag_value_lt() returns true for 123.456 < 123.4567")
 }
 
 
-AG_TEST_CASE(float_lt_2, "ag_value_lt() returns false for 123.456 < 123.456") 
+AG_TEST_CASE(float_lt_2, "ag_value_lt() returns false for 123.456 < 123.456")
 {
         AG_AUTO(ag_value) *v = ag_value_new_float(123.456);
 
@@ -396,7 +396,7 @@ AG_TEST_CASE(float_lt_2, "ag_value_lt() returns false for 123.456 < 123.456")
 }
 
 
-AG_TEST_CASE(float_lt_3, "ag_value_lt() returns false for 123.4567 < 123.456") 
+AG_TEST_CASE(float_lt_3, "ag_value_lt() returns false for 123.4567 < 123.456")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.4567);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.456);
@@ -406,7 +406,7 @@ AG_TEST_CASE(float_lt_3, "ag_value_lt() returns false for 123.4567 < 123.456")
 
 
 AG_TEST_CASE(float_eq_1,
-    "ag_value_eq() returns true for -123.4567 == -123.4567") 
+    "ag_value_eq() returns true for -123.4567 == -123.4567")
 {
         AG_AUTO(ag_value) *v = ag_value_new_float(-123.4567);
 
@@ -415,7 +415,7 @@ AG_TEST_CASE(float_eq_1,
 
 
 AG_TEST_CASE(float_eq_2,
-    "ag_value_eq() returns false for -123.456 == -123.4567") 
+    "ag_value_eq() returns false for -123.456 == -123.4567")
 {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.4567);
@@ -612,23 +612,23 @@ test_suite_value(void)
                 int_type_object, int_lt_1,       int_lt_2,
                 int_lt_3,        int_eq_1,       int_eq_2,
                 int_gt_1,        int_gt_2,       int_gt_3,
-                
+
                 uint_new,         uint_copy,       uint_type_int,
                 uint_type_uint,   uint_type_float, uint_type_string,
                 uint_type_object, uint_lt_1,       uint_lt_2,
                 uint_lt_3,        uint_eq_1,       uint_eq_2,
                 uint_gt_1,        uint_gt_2,       uint_gt_3,
-    
+
                 float_new,         float_copy,      float_type_int,
                 float_type_uint,   float_type_float,float_type_string,
                 float_type_object, float_lt_1,      float_lt_2,
                 float_lt_3,        float_eq_1,      float_eq_2,
                 float_gt_1,        float_gt_2,      float_gt_3,
-    
+
                 string_new,         string_copy,       string_type_int,
                 string_type_uint,   string_type_float, string_type_string,
                 string_type_object,
-    
+
                 object_new,         object_copy,       object_type_int,
                 object_type_uint,   object_type_float, object_type_string,
                 object_type_object,
@@ -640,8 +640,8 @@ test_suite_value(void)
                 int_type_object_desc, int_lt_1_desc,       int_lt_2_desc,
                 int_lt_3_desc,        int_eq_1_desc,       int_eq_2_desc,
                 int_gt_1_desc,        int_gt_2_desc,       int_gt_3_desc,
-                
-                uint_new_desc,         uint_copy_desc, 
+
+                uint_new_desc,         uint_copy_desc,
                 uint_type_int_desc,    uint_type_uint_desc,
                 uint_type_float_desc,  uint_type_string_desc,
                 uint_type_object_desc, uint_lt_1_desc,
@@ -649,7 +649,7 @@ test_suite_value(void)
                 uint_eq_1_desc,        uint_eq_2_desc,
                 uint_gt_1_desc,        uint_gt_2_desc,
                 uint_gt_3_desc,
-                
+
                 float_new_desc,         float_copy_desc,
                 float_type_int_desc,    float_type_uint_desc,
                 float_type_float_desc,  float_type_string_desc,
@@ -658,14 +658,14 @@ test_suite_value(void)
                 float_eq_1_desc,        float_eq_2_desc,
                 float_gt_1_desc,        float_gt_2_desc,
                 float_gt_3_desc,
-                
+
                 string_new_desc,         string_copy_desc,
-                string_type_int_desc,    string_type_uint_desc,  
+                string_type_int_desc,    string_type_uint_desc,
                 string_type_float_desc,  string_type_string_desc,
                 string_type_object_desc,
-                
+
                 object_new_desc,         object_copy_desc,
-                object_type_int_desc,    object_type_uint_desc,   
+                object_type_int_desc,    object_type_uint_desc,
                 object_type_float_desc,  object_type_string_desc,
                 object_type_object_desc,
         };

--- a/test/value.c
+++ b/test/value.c
@@ -49,279 +49,279 @@ static inline ag_value *object_sample_value(void)
 
 AG_TEST_INIT(int_new, "ag_value_new_int() creates a new int value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123456);
-        AG_TEST_ASSERT (v && ag_value_int(v) == -123456);
-} AG_TEST_EXIT();
+        AG_TEST (v && ag_value_int(v) == -123456);
+}
 
 AG_TEST_INIT(int_copy, "ag_value_copy() copies an int value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-1029394);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
-        AG_TEST_ASSERT (ag_value_int(v) == ag_value_int(cp));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_int(v) == ag_value_int(cp));
+}
 
 AG_TEST_INIT(int_type_int, "ag_value_type_int() is true for an int value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(11111);
-        AG_TEST_ASSERT (v && ag_value_type_int(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && ag_value_type_int(v));
+}
 
 AG_TEST_INIT(int_type_uint, "ag_value_type_uint() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-1111);
-        AG_TEST_ASSERT (v && !ag_value_type_uint(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_uint(v));
+}
 
 AG_TEST_INIT(int_type_float,
     "ag_value_type_float() is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(1111);
-        AG_TEST_ASSERT (v && !ag_value_type_float(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_float(v));
+}
 
 AG_TEST_INIT(int_type_string,
     "ag_value_type_string() is false for a string value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-987654321);
-        AG_TEST_ASSERT (v && !ag_value_type_string(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_string(v));
+}
 
 AG_TEST_INIT(int_type_object,
     "ag_value_type_object() is false for an object value") {
         AG_AUTO(ag_value) *v = ag_value_new_int(987654321);
-        AG_TEST_ASSERT (v && !ag_value_type_object(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_object(v));
+}
 
 AG_TEST_INIT(int_lt_1, "ag_value_lt() returns true for -123 < 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
-        AG_TEST_ASSERT (ag_value_lt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_lt(v1, v2));
+}
 
 AG_TEST_INIT(int_lt_2, "ag_value_lt() returns false for -123 < -123") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
-        AG_TEST_ASSERT (!ag_value_lt(v, v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_lt(v, v));
+}
 
 AG_TEST_INIT(int_lt_3, "ag_value_lt() returns false for 123 < -123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(-123);
-        AG_TEST_ASSERT (!ag_value_lt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_lt(v1, v2));
+}
 
 AG_TEST_INIT(int_eq_1, "ag_value_eq() returns true for -123 == -123") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
-        AG_TEST_ASSERT (ag_value_eq(v, v));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_eq(v, v));
+}
 
 AG_TEST_INIT(int_eq_2, "ag_value_eq() returns false for -123 == 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
-        AG_TEST_ASSERT (!ag_value_eq(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_eq(v1, v2));
+}
 
 AG_TEST_INIT(int_gt_1, "ag_value_gt() returns true for 123 > -123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(-123);
-        AG_TEST_ASSERT (ag_value_gt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_gt(v1, v2));
+}
 
 AG_TEST_INIT(int_gt_2, "ag_value_gt() returns false for -123 > -123") {
         AG_AUTO(ag_value) *v = ag_value_new_int(-123);
-        AG_TEST_ASSERT (!ag_value_gt(v, v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_gt(v, v));
+}
 
 AG_TEST_INIT(int_gt_3, "ag_value_gt() returns false for -123 > 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_int(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_int(123);
-        AG_TEST_ASSERT (!ag_value_gt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_gt(v1, v2));
+}
 
 
 
 
 AG_TEST_INIT(uint_new, "ag_value_new_uint() creates a new uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123456);
-        AG_TEST_ASSERT (v && ag_value_uint(v) == 123456);
-} AG_TEST_EXIT();
+        AG_TEST (v && ag_value_uint(v) == 123456);
+}
 
 
 AG_TEST_INIT(uint_copy, "ag_value_copy() copies a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(1029394);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
-        AG_TEST_ASSERT (ag_value_uint(v) == ag_value_uint(cp));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_uint(v) == ag_value_uint(cp));
+}
 
 AG_TEST_INIT(uint_type_int, "ag_value_type_int() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(11111);
-        AG_TEST_ASSERT (v && !ag_value_type_int(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_int(v));
+}
 
 AG_TEST_INIT(uint_type_uint, "ag_value_type_uint() is true for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(701115);
-        AG_TEST_ASSERT (v && ag_value_type_uint(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && ag_value_type_uint(v));
+}
 
 AG_TEST_INIT(uint_type_float,
     "ag_value_type_float() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(97324);
-        AG_TEST_ASSERT (v && !ag_value_type_float(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_float(v));
+}
 
 AG_TEST_INIT(uint_type_string,
     "ag_value_type_string() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(987654321);
-        AG_TEST_ASSERT (v && !ag_value_type_string(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_string(v));
+}
 
 AG_TEST_INIT(uint_type_object,
     "ag_value_type_object() is false for a uint value") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(108);
-        AG_TEST_ASSERT (v && !ag_value_type_object(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_object(v));
+}
 
 AG_TEST_INIT(uint_lt_1, "ag_value_lt() returns true for 123 < 124") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
-        AG_TEST_ASSERT (ag_value_lt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_lt(v1, v2));
+}
 
 AG_TEST_INIT(uint_lt_2, "ag_value_lt() returns false for 123 < 123") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
-        AG_TEST_ASSERT (!ag_value_lt(v, v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_lt(v, v));
+}
 
 AG_TEST_INIT(uint_lt_3, "ag_value_lt() returns false for 124 < 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(124);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(123);
-        AG_TEST_ASSERT (!ag_value_lt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_lt(v1, v2));
+}
 
 AG_TEST_INIT(uint_eq_1, "ag_value_eq() returns true for 123 == 123") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
-        AG_TEST_ASSERT (ag_value_eq(v, v));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_eq(v, v));
+}
 
 AG_TEST_INIT(uint_eq_2,"ag_value_eq() returns false for 123 == 124") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
-        AG_TEST_ASSERT (!ag_value_eq(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_eq(v1, v2));
+}
 
 AG_TEST_INIT(uint_gt_1, "ag_value_gt() returns true for 124 > 123") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(124);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(123);
-        AG_TEST_ASSERT (ag_value_gt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_gt(v1, v2));
+}
 
 AG_TEST_INIT(uint_gt_2, "ag_value_gt() returns false for 123 > 123") {
         AG_AUTO(ag_value) *v = ag_value_new_uint(123);
-        AG_TEST_ASSERT (!ag_value_gt(v, v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_gt(v, v));
+}
 
 AG_TEST_INIT(uint_gt_3, "ag_value_gt() returns false for 123 > 124") {
         AG_AUTO(ag_value) *v1 = ag_value_new_uint(123);
         AG_AUTO(ag_value) *v2 = ag_value_new_uint(124);
-        AG_TEST_ASSERT (!ag_value_gt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_gt(v1, v2));
+}
 
 
 
 AG_TEST_INIT(float_new, "ag_value_new_float() creates a new float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-123.456);
-        AG_TEST_ASSERT (v && ag_value_float(v) == -123.456);
-} AG_TEST_EXIT();
+        AG_TEST (v && ag_value_float(v) == -123.456);
+}
 
 
 AG_TEST_INIT(float_copy, "ag_value_copy() copies a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
-        AG_TEST_ASSERT (ag_value_float(v) == ag_value_float(cp));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_float(v) == ag_value_float(cp));
+}
 
 
 AG_TEST_INIT(float_type_int, "ag_value_type_int() is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-123456.789);
-        AG_TEST_ASSERT (v && !ag_value_type_int(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_int(v));
+}
 
 
 AG_TEST_INIT(float_type_uint, 
     "ag_value_type_uint() is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(123456.789);
-        AG_TEST_ASSERT (v && !ag_value_type_uint(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_uint(v));
+}
 
 
 AG_TEST_INIT(float_type_float,
     "ag_value_type_float() is true for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-789.123456);
-        AG_TEST_ASSERT (v && ag_value_type_float(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && ag_value_type_float(v));
+}
 
 
 AG_TEST_INIT(float_type_string,
     "ag_value_type_string() is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(789.123456);
-        AG_TEST_ASSERT (v && !ag_value_type_string(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_string(v));
+}
 
 
 AG_TEST_INIT(float_type_object,
     "ag_value_type_object is false for a float value") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-9876.5433);
-        AG_TEST_ASSERT (v && !ag_value_type_object(v));
-} AG_TEST_EXIT();
+        AG_TEST (v && !ag_value_type_object(v));
+}
 
 
 AG_TEST_INIT(float_lt_1, "ag_value_lt() returns true for 123.456 < 123.4567") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(124.4567);
-        AG_TEST_ASSERT (ag_value_lt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_lt(v1, v2));
+}
 
 
 AG_TEST_INIT(float_lt_2, "ag_value_lt() returns false for 123.456 < 123.456") {
         AG_AUTO(ag_value) *v = ag_value_new_float(123.456);
-        AG_TEST_ASSERT (!ag_value_lt(v, v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_lt(v, v));
+}
 
 
 AG_TEST_INIT(float_lt_3, "ag_value_lt() returns false for 123.4567 < 123.456") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.4567);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.456);
-        AG_TEST_ASSERT (!ag_value_lt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_lt(v1, v2));
+}
 
 
 AG_TEST_INIT(float_eq_1,
     "ag_value_eq() returns true for -123.4567 == -123.4567") {
         AG_AUTO(ag_value) *v = ag_value_new_float(-123.4567);
-        AG_TEST_ASSERT (ag_value_eq(v, v));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_eq(v, v));
+}
 
 
 AG_TEST_INIT(float_eq_2,
     "ag_value_eq() returns false for -123.456 == -123.4567") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(-123);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.4567);
-        AG_TEST_ASSERT (!ag_value_eq(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_eq(v1, v2));
+}
 
 
 AG_TEST_INIT(float_gt_1, "ag_value_gt() returns true for 123.4567 > 123.456") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.4567);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.456);
-        AG_TEST_ASSERT (ag_value_gt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_gt(v1, v2));
+}
 
 
 AG_TEST_INIT(float_gt_2,
     "ag_value_gt() returns false for 123.4567 > 123.4567") {
         AG_AUTO(ag_value) *v = ag_value_new_float(123.4567);
-        AG_TEST_ASSERT (!ag_value_gt(v, v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_gt(v, v));
+}
 
 
 AG_TEST_INIT(float_gt_3, "ag_value_gt() returns false for 123.456 > 123.4567") {
         AG_AUTO(ag_value) *v1 = ag_value_new_float(123.456);
         AG_AUTO(ag_value) *v2 = ag_value_new_float(123.4567);
-        AG_TEST_ASSERT (!ag_value_gt(v1, v2));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_gt(v1, v2));
+}
 
 
 
@@ -342,44 +342,44 @@ static inline ag_value *string_sample_unicode(void)
 AG_TEST_INIT(string_new, "ag_value_new_string() creates a new string value") {
         AG_AUTO(ag_value) *v = string_sample_ascii();
         AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
-        AG_TEST_ASSERT (v && ag_string_eq(ag_value_string(v), s));
-} AG_TEST_EXIT();
+        AG_TEST (v && ag_string_eq(ag_value_string(v), s));
+}
 
 AG_TEST_INIT(string_copy, "ag_value_copy() copies a string value") {
         AG_AUTO(ag_value) *v = string_sample_unicode();
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
-        AG_TEST_ASSERT (ag_string_eq(ag_value_string(v), ag_value_string(cp)));
-} AG_TEST_EXIT();
+        AG_TEST (ag_string_eq(ag_value_string(v), ag_value_string(cp)));
+}
 
 AG_TEST_INIT(string_type_int,
     "ag_value_type_int() is false for a string value") {
         AG_AUTO(ag_value) *v = string_sample_ascii();
-        AG_TEST_ASSERT (!ag_value_type_int(v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_type_int(v));
+}
 
 AG_TEST_INIT(string_type_uint,
     "ag_value_type_uint() is false for a string value") {
         AG_AUTO(ag_value) *v = string_sample_unicode();
-        AG_TEST_ASSERT (!ag_value_type_int(v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_type_int(v));
+}
 
 AG_TEST_INIT(string_type_float,
     "ag_value_type_float() is false for a string value") {
         AG_AUTO(ag_value) *v = string_sample_ascii();
-        AG_TEST_ASSERT (!ag_value_type_float(v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_type_float(v));
+}
 
 AG_TEST_INIT(string_type_string,
     "ag_value_type_string() is true for a string value") {
         AG_AUTO(ag_value) *v = string_sample_unicode();
-        AG_TEST_ASSERT (ag_value_type_string(v));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_type_string(v));
+}
 
 AG_TEST_INIT(string_type_object,
     "ag_value_type_object() is false for a string value") {
         AG_AUTO(ag_value) *v = string_sample_ascii();
-        AG_TEST_ASSERT (!ag_value_type_object(v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_type_object(v));
+}
 
 
 
@@ -388,44 +388,44 @@ AG_TEST_INIT(string_type_object,
 AG_TEST_INIT(object_new, "ag_value_new_object() creates a new object value") {
         AG_AUTO(ag_object) *o = object_sample();
         AG_AUTO(ag_value) *v = object_sample_value();
-        AG_TEST_ASSERT (v && ag_object_eq(ag_value_object(o), o));
-} AG_TEST_EXIT();
+        AG_TEST (v && ag_object_eq(ag_value_object(o), o));
+}
 
 AG_TEST_INIT(object_copy, "ag_value_copy() copies an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
         AG_AUTO(ag_value) *cp = ag_value_copy(v);
-        AG_TEST_ASSERT (ag_object_eq(ag_value_object(v), ag_value_object(cp)));
-} AG_TEST_EXIT();
+        AG_TEST (ag_object_eq(ag_value_object(v), ag_value_object(cp)));
+}
 
 AG_TEST_INIT(object_type_int,
     "ag_value_type_int() is false for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
-        AG_TEST_ASSERT (!ag_value_type_int(v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_type_int(v));
+}
 
 AG_TEST_INIT(object_type_uint,
     "ag_value_type_uint() is false for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
-        AG_TEST_ASSERT (!ag_value_type_uint(v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_type_uint(v));
+}
 
 AG_TEST_INIT(object_type_float,
     "ag_value_type_float() is false for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
-        AG_TEST_ASSERT (!ag_value_type_float(v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_type_float(v));
+}
 
 AG_TEST_INIT(object_type_string,
     "ag_value_type_string() is false for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
-        AG_TEST_ASSERT (!ag_value_type_string(v));
-} AG_TEST_EXIT();
+        AG_TEST (!ag_value_type_string(v));
+}
 
 AG_TEST_INIT(object_type_object,
     "ag_value_type_object() is true for an object value") {
         AG_AUTO(ag_value) *v = object_sample_value();
-        AG_TEST_ASSERT (ag_value_type_object(v));
-} AG_TEST_EXIT();
+        AG_TEST (ag_value_type_object(v));
+}
 
 
 


### PR DESCRIPTION
The generic list interface has been rewritten to use values instead of objects as the encapsulated data type. The new interface comprises of the following types and functions.

## Types
  - `ag_list`
  - `ag_list_iterator`
  - `ag_list_iterator_mutable`

## Functions
  - `__ag_list_register__()`
  - `ag_list_new()`
  - `ag_list_copy()`
  - `ag_list_clone()`
  - `ag_list_release()`
  - `ag_list_cmp()`
  - `ag_list_lt()`
  - `ag_list_eq()`
  - `ag_list_gt()`
  - `ag_list_empty()`
  - `ag_list_typeid()`
  - `ag_list_uuid()`
  - `ag_list_valid()`
  - `ag_list_sz()`
  - `ag_list_refc()`
  - `ag_list_len()`
  - `ag_list_hash()`
  - `ag_list_str()`
  - `ag_list_get()`
  - `ag_list_get_at()`
  - `ag_list_map()`
  - `ag_list_set()`
  - `ag_list_set_at()`
  - `ag_list_map_mutable()`
  - `ag_list_start()`
  - `ag_list_next()`
  - `ag_list_push()`

While developing the list interface, it became necessary to introduce the following functions to the value interface:
  - `ag_value_hash()`
  - `ag_value_len()`
  - `ag_value_sz()`
  - `ag_value_valid()`

`ag_value_hash()` gets the hash of the encapsulated type, `ag_value_len()` gets the length of the value, `ag_value_sz()` gets the size in bytes of the value, and `ag_value_valid()` checks whether a value is valid.

An opportunity was also found on how to simplify the testing interface. The earlier `AG_TEST_INIT()`, `AG_TEST_EXIT()` and `AG_TEST_ASSERT()` macros have been replaced with the `AG_TEST()` and `AG_TEST_CASE()` macros.

This pull request closes #53.