### PR TITLE
Add regex support to string interface

### DIFF
--- a/include/erno.h
+++ b/include/erno.h
@@ -37,6 +37,8 @@
  * standards. We adopt the convention that negative error codes are reserved for
  * use by the Argent Library, and positive ones by client code.
  */
+
+
 typedef int ag_erno;
 
 
@@ -45,8 +47,11 @@ typedef int ag_erno;
  * Library. Apart from AG_ERNO_NULL, all of these error codes are negative to
  * distinguish them from error codes used by client code.
  */
+
+
 #define AG_ERNO_NULL    ((ag_erno) 0)
 #define AG_ERNO_MBLOCK  ((ag_erno) -1)
+#define AG_ERNO_REGEX   ((ag_erno) -2)
 
 
 /* 
@@ -54,8 +59,11 @@ typedef int ag_erno;
  * above error codes. These symbolic constants are used in conjunction with the
  * AG_ERNO_MSG() macro defined below to generate a captioned error string.
  */
-#define AG_ERNO_NULL_MSG   "no error has occurred"
-#define AG_ERNO_MBLOCK_MSG "failed to allocate memory block"
+
+
+#define AG_ERNO_NULL_MSG        "no error has occurred"
+#define AG_ERNO_MBLOCK_MSG      "failed to allocate memory block"
+#define AG_ERNO_REGEX_MSG       "failed to process regular expression"
 
 
 /*
@@ -66,6 +74,8 @@ typedef int ag_erno;
  * example, calling AG_ERNO_MSG(AG_ERNO_MBLOCK) will lead to the generation of
  * the captioned error string "AG_ERNO_MBLOCK: failed to allocate memory block".
  */
+
+
 #define AG_ERNO_MSG(p) #p ": " p##_MSG
 
 

--- a/include/exception.h
+++ b/include/exception.h
@@ -59,6 +59,15 @@ struct ag_exception {
 typedef void (ag_exception_handler)(const struct ag_exception *, void *);
 
 
+struct ag_exception_regex {
+        const char      *str;
+        const char      *regex;
+};
+
+
+extern void     ag_exception_regex_hnd(const struct ag_exception *, void *);
+                
+
 /*
  * The exception registry maintains a list of exception messages and handlers
  * associated with each error code of both the Argent Library and client code.

--- a/include/exception.h
+++ b/include/exception.h
@@ -59,12 +59,18 @@ struct ag_exception {
 typedef void (ag_exception_handler)(const struct ag_exception *, void *);
 
 
+struct ag_exception_memblock {
+        size_t  sz;
+        size_t  align;
+};
+
 struct ag_exception_regex {
         const char      *str;
         const char      *regex;
 };
 
 
+extern void     ag_exception_memblock_hnd(const struct ag_exception *, void *);
 extern void     ag_exception_regex_hnd(const struct ag_exception *, void *);
 
 

--- a/include/exception.h
+++ b/include/exception.h
@@ -59,9 +59,17 @@ struct ag_exception {
 typedef void (ag_exception_handler)(const struct ag_exception *, void *);
 
 
+/*
+ * The following structures are used to pass exception-related data to their
+ * corresponding exception handlers. The ag_exception_memblock struct holds the
+ * exception data related to AG_ERNO_MEMBLOCK, and the ag_exception_regex struct
+ * holds exception data related to AG_ERNO_REGEX.
+ */
+
+
 struct ag_exception_memblock {
-        size_t  sz;
-        size_t  align;
+        size_t  sz;     /* Memory block size      */
+        size_t  align;  /* Memory block alignment */
 };
 
 
@@ -70,6 +78,13 @@ struct ag_exception_regex {
         const char      *regex;         /* Regex to apply                   */
         int              ecode;         /* Regex interal error code         */
 };
+
+
+/*
+ * Define the exception handlers used to handle the errors raised by the Argent
+ * Library. ag_exception_memblock_hnd() handles the AG_ERNO_MEMBLOCK exception,
+ * and ag_exception_regex_hnd() handles the AG_ERNO_REGEX exception.
+ */
 
 
 extern void     ag_exception_memblock_hnd(const struct ag_exception *, void *);

--- a/include/exception.h
+++ b/include/exception.h
@@ -64,9 +64,11 @@ struct ag_exception_memblock {
         size_t  align;
 };
 
+
 struct ag_exception_regex {
-        const char      *str;
-        const char      *regex;
+        const char      *str;           /* String on which regex is applied */
+        const char      *regex;         /* Regex to apply                   */
+        int              ecode;         /* Regex interal error code         */
 };
 
 

--- a/include/exception.h
+++ b/include/exception.h
@@ -44,10 +44,10 @@
  * avoid relying on the heap.
  */
 struct ag_exception {
-        ag_erno     erno; /* Error code.                       */
-        const char *func; /* Function where error occurred.    */
-        const char *file; /* File where error occured.         */
-        size_t      line; /* Line number where error occurred. */
+        ag_erno          erno;  /* Error code.                       */
+        const char      *func;  /* Function where error occurred.    */
+        const char      *file;  /* File where error occured.         */
+        size_t           line;  /* Line number where error occurred. */
 };
 
 
@@ -74,16 +74,21 @@ extern void     ag_exception_regex_hnd(const struct ag_exception *, void *);
  * The following functions manage the instantiation and destruction of the
  * exception registry, and *must* be called at program startup and termination.
  */
-extern void ag_exception_registry_init(size_t);
-extern void ag_exception_registry_exit(void);
+
+
+extern void     ag_exception_registry_init(size_t);
+extern void     ag_exception_registry_exit(void);
 
 /*
  * The following functions are the accessors for the exception registry,
  * returning the exception message and handler associated with a given error
  * code.
  */
-extern const char *ag_exception_registry_msg(ag_erno);
-extern ag_exception_handler *ag_exception_registry_hnd(ag_erno);
+
+
+extern const char               *ag_exception_registry_msg(ag_erno);
+extern ag_exception_handler     *ag_exception_registry_hnd(ag_erno);
+
 
 /*
  * The `ag_exception_registry_set()` function is the only mutator for the
@@ -92,8 +97,10 @@ extern ag_exception_handler *ag_exception_registry_hnd(ag_erno);
  * previous values, and passing a NULL pointer for the handler causes the
  * default unhandled exception handler to be set.
  */
-extern void ag_exception_registry_set(ag_erno, const char *,
-                ag_exception_handler *);
+
+
+extern void     ag_exception_registry_set(ag_erno, const char *,
+                    ag_exception_handler *);
 
 
 /*
@@ -108,25 +115,28 @@ extern void ag_exception_registry_set(ag_erno, const char *,
  * AG_ASSERT_STR() asserts that a string is valid, i.e., it is a valid pointer
  * and it is not an empty string.
  */
+
+
 #ifndef NDEBUG
 #       define AG_ASSERT(p) do {                                             \
                 if (AG_UNLIKELY (!(p))) {                                    \
                         printf("[!] assertion failed: %s [%s(), %s:%d]\n",   \
-                                        #p, __func__, __FILE__, __LINE__);   \
+                            #p, __func__, __FILE__, __LINE__);               \
                         ag_log_debug("assertion failed: %s [%s(), %s:%d]\n", \
-                                        #p, __func__, __FILE__, __LINE__);   \
+                            #p, __func__, __FILE__, __LINE__);               \
                         abort();                                             \
                 }                                                            \
         } while (0)
 
+
         #define AG_ASSERT_PTR(p) do {                                        \
                 if (AG_UNLIKELY (!(p))) {                                    \
                         printf("[!] assertion failed: %s must not be null"   \
-                               " [%s(), %s:%d]\n", #p, __func__, __FILE__,   \
-                               __LINE__);                                    \
+                            " [%s(), %s:%d]\n", #p,                          \
+                            __func__, __FILE__, __LINE__);                   \
                         ag_log_debug("assertion failed: %s must not be null" \
-                                     " [%s(), %s:%d]\n", #p, __func__,       \
-                                     __FILE__, __LINE__);                    \
+                            " [%s(), %s:%d]\n", #p,                          \
+                             __func__, __FILE__, __LINE__);                  \
                         abort();                                             \
                 }                                                            \
         } while (0)
@@ -163,6 +173,7 @@ extern void ag_exception_registry_set(ag_erno, const char *,
  * with the exception metadata.
  */
 
+
 #define AG_REQUIRE(p, e) do {                                   \
         if (AG_UNLIKELY (!(p))) {                               \
                 printf("[!] %d [%s(), %s:%d]: %s\n",            \
@@ -181,6 +192,7 @@ extern void ag_exception_registry_set(ag_erno, const char *,
         }                                                       \
 } while (0)
 
+
 #define AG_REQUIRE_OPT(p, e, o) do {                            \
         if (AG_UNLIKELY (!(p))) {                               \
                 printf("[!] %d [%s(), %s:%d]: %s\n",            \
@@ -198,7 +210,6 @@ extern void ag_exception_registry_set(ag_erno, const char *,
                 ag_exception_registry_hnd((e))(&_x_, (o));      \
         }                                                       \
 } while (0)
-
 
 
 #ifdef __cplusplus

--- a/include/exception.h
+++ b/include/exception.h
@@ -66,7 +66,7 @@ struct ag_exception_regex {
 
 
 extern void     ag_exception_regex_hnd(const struct ag_exception *, void *);
-                
+
 
 /*
  * The exception registry maintains a list of exception messages and handlers
@@ -130,7 +130,7 @@ extern void ag_exception_registry_set(ag_erno, const char *,
                         abort();                                             \
                 }                                                            \
         } while (0)
-        
+
 
         #define AG_ASSERT_STR(str) do {                                      \
                 if (AG_UNLIKELY (!(str && *str))) {                          \
@@ -149,17 +149,28 @@ extern void ag_exception_registry_set(ag_erno, const char *,
 #       define AG_ASSERT_STR(s)
 #endif
 
+
 /*
- * The `AG_REQUIRE()` and `AG_REQUIRE_OPT()` macros are used to check whether a
- * given predicate is true, and if not, signal an appropriate error code. The
- * exception handler associated with the error code is automatically invoked and
- * passed the exception metadata. `AG_REQUIRE_OPT()` allows optional exception
- * data to be passed along to the exception handler along with the exception
- * metadata.
+ * The AG_REQUIRE() and AG_REQUIRE_OPT() macros are used to check whether a
+ * given predicate is true, and if not, signal an appropriate error code.
+ *
+ * The exception handler associated with the error code is automatically invoked
+ * and passed the exception metadata. Before the exception handler is called, we
+ * print and log the exception location metadata.
+ *
+ * AG_REQUIRE_OPT() behaves identically to AG_REQUIRE(), except that it allows
+ * optional exception data to be passed along to the exception handler along
+ * with the exception metadata.
  */
 
 #define AG_REQUIRE(p, e) do {                                   \
         if (AG_UNLIKELY (!(p))) {                               \
+                printf("[!] %d [%s(), %s:%d]: %s\n",            \
+                    (e), __func__, __FILE__, __LINE__,          \
+                    ag_exception_registry_msg(e));              \
+                ag_log_err("%d [%s(), %s:%d]: %s",              \
+                    (e), __func__, __FILE__, __LINE__,          \
+                    ag_exception_registry_msg(e));              \
                 struct ag_exception _x_ = {                     \
                         .erno = (e),                            \
                         .func = __func__,                       \
@@ -172,6 +183,12 @@ extern void ag_exception_registry_set(ag_erno, const char *,
 
 #define AG_REQUIRE_OPT(p, e, o) do {                            \
         if (AG_UNLIKELY (!(p))) {                               \
+                printf("[!] %d [%s(), %s:%d]: %s\n",            \
+                    (e), __func__, __FILE__, __LINE__,          \
+                    ag_exception_registry_msg(e));              \
+                ag_log_err("%d [%s(), %s:%d]: %s",              \
+                    (e), __func__, __FILE__, __LINE__,          \
+                    ag_exception_registry_msg(e));              \
                 struct ag_exception _x_ = {                     \
                         .erno = (e),                            \
                         .func = __func__,                       \

--- a/include/memblock.h
+++ b/include/memblock.h
@@ -9,15 +9,6 @@
 #include "./string.h"
 
 
-
-struct ag_memblock_exception {
-        size_t sz;
-        size_t align;
-};
-
-
-extern void ag_memblock_exception_handler(const struct ag_exception *, void *);
-
 typedef void ag_memblock;
 
 extern ag_memblock *ag_memblock_new(size_t);

--- a/include/string.h
+++ b/include/string.h
@@ -114,6 +114,17 @@ ag_string_gt(const ag_string *ctx, const char *cmp)
 }
 
 
+/*
+ * Declare the prototypes for the string accessor functions. ag_string_len()
+ * determines the lexicograpchical length of a string, ag_string_sz() gets the
+ * size in bytes of a string, ag_string_refc() returns the current reference
+ * count of a string, ag_string_has() checks whether a string contains a given
+ * substring, and ag_string_match() checks whether a string matches a given
+ * POSIX-style regular expression. ag_string_empty() checks whether a string is
+ * empty, i.e., whether its length is zero.
+ */
+
+
 extern size_t   ag_string_len(const ag_string *);
 extern size_t   ag_string_sz(const ag_string *);
 extern size_t   ag_string_refc(const ag_string *);
@@ -121,12 +132,20 @@ extern bool     ag_string_has(const ag_string *, const char *);
 extern bool     ag_string_match(const ag_string *, const char *);
 
 
-
 inline bool
 ag_string_empty(const ag_string *ctx)
 {
         return ag_string_sz(ctx) == 1;
 }
+
+
+/*
+ * Declare the prototypes for the string mutator functionsx. ag_string_lower(),
+ * ag_string_upper() and ag_string_proper() return, respectively, the lowercase,
+ * uppercase and proper case forms of a given string. ag_string_split() and
+ * ag_string_split_right() split a string around a given pivot and return,
+ * respectively, the left hand and right sides.
+ */
 
 
 extern ag_string        *ag_string_lower(const ag_string *);

--- a/include/string.h
+++ b/include/string.h
@@ -77,6 +77,19 @@ ag_string_new_empty(void)
 }
 
 
+/*
+ * Declare the prototypes for the string comparison interface. The most
+ * important comparison function is ag_string_cmp(), the other three simply
+ * being convenience wrappers around the former.
+ *
+ * All four comparison functions compare a dynamic string against another string
+ * which may either be dynamic or static. ag_string_cmp() returns an ag_cmp enum
+ * value indicating the result of the comparison; ag_string_lt(), ag_string_eq()
+ * and ag_string_gt() return a Boolean value indicating whether or not the
+ * contextual string is, respectively, less than, equal to, or greater than the
+ * comparison string.
+ */
+
 extern enum ag_cmp      ag_string_cmp(const ag_string *,  const char *);
 
 
@@ -105,6 +118,7 @@ extern size_t   ag_string_len(const ag_string *);
 extern size_t   ag_string_sz(const ag_string *);
 extern size_t   ag_string_refc(const ag_string *);
 extern bool     ag_string_has(const ag_string *, const char *);
+extern bool     ag_string_match(const ag_string *, const char *);
 
 
 

--- a/src/exception-handler.c
+++ b/src/exception-handler.c
@@ -4,17 +4,14 @@
 extern void
 ag_exception_regex_hnd(const struct ag_exception *ex, void *opt)
 {
-        struct ag_exception_regex *x = opt;
-        
-        printf("[!] %d [%s(), %s:%lu]: %s\n", ex->erno, ex->func, ex->file,
-            ex->line, ag_exception_registry_msg(ex->erno));
-        
-        ag_log_err("%d [%s(), %s:%lu]: %s", ex->erno, ex->func, ex->file,
-            ex->line, ag_exception_registry_msg(ex->erno));
+        (void)ex;
 
+        struct ag_exception_regex *o = opt;
         const char *msg = "[!] string = %s, regex = %s\n";
-        printf(msg, x->str, x->regex);
-        ag_log_err(msg, x->str, x->regex);
+
+        printf(msg, o->str, o->regex);
+        printf("\n");
+        ag_log_err(msg, o->str, o->regex);
 
         ag_exit(EXIT_FAILURE);
 }

--- a/src/exception-handler.c
+++ b/src/exception-handler.c
@@ -1,5 +1,7 @@
 #include "../include/argent.h"
 
+#include <regex.h>
+
         
 extern void
 ag_exception_memblock_hnd(const struct ag_exception *ex, void *opt)
@@ -27,11 +29,62 @@ ag_exception_regex_hnd(const struct ag_exception *ex, void *opt)
         (void)ex;
 
         struct ag_exception_regex *o = opt;
-        const char *msg = "[!] string = %s, regex = %s\n";
+        const char *msg = "[!] string = %s, regex = %s, ecode = %d";
 
-        printf(msg, o->str, o->regex);
-        printf("\n");
-        ag_log_err(msg, o->str, o->regex);
+        printf(msg, o->str, o->regex, o->ecode);
+        ag_log_err(msg, o->str, o->regex, o->ecode);
+
+        switch (o->ecode) {
+        case REG_BADBR:
+                msg = "[!] there was an invalid `\\{…\\}` construct in the"
+                    " regular expression";
+                break;
+        case REG_BADPAT:
+                msg = "[!] there was a syntax error in the regular expression";
+                break;
+        case REG_BADRPT:
+                msg = "[!] a repetition operator such as ‘?’ or ‘*’ appeared in"
+                    " a bad position";
+                break;
+        case REG_ECOLLATE:
+                msg = "[!] the regular expression referred to an invalid"
+                    " collating element";
+                break;
+        case REG_ECTYPE:
+                msg = "[!] the regular expression referred to an invalid"
+                    " character class name";
+                break;
+        case REG_EESCAPE:
+                msg = "[!] the regular expression ended with `\\’";
+                break;
+        case REG_ESUBREG:
+                msg = "[!] there was an invalid number in the ‘\\digit’"
+                    " construct";
+                break;
+        case REG_EBRACK:
+                msg = "[!] there were unbalanced square brackets in the regular"
+                    " expression";
+                break;
+        case REG_EPAREN:
+                msg = "[!] an extended regular expression had unbalanced"
+                    " parentheses, or a basic regular expression had unbalanced"
+                    " ‘\\(’ and ‘\\)’";
+                break;
+        case REG_EBRACE:
+                msg = "[!] the regular expression had unbalanced ‘\\{’ and"
+                    " ‘\\}’";
+                break;
+        case REG_ERANGE:
+                msg = "[!] one of the endpoints in a range expression was"
+                    " invalid";
+                break;
+        case REG_ESPACE:
+        default:
+                msg = "[!] regcomp ran out of memory";
+        }
+
+        printf("\n%s\n", msg);
+        ag_log_err(msg);
 
         ag_exit(EXIT_FAILURE);
 }

--- a/src/exception-handler.c
+++ b/src/exception-handler.c
@@ -1,5 +1,25 @@
 #include "../include/argent.h"
 
+        
+extern void
+ag_exception_memblock_hnd(const struct ag_exception *ex, void *opt)
+{
+        (void)ex;
+        struct ag_exception_memblock *o = opt;
+
+        if (o->align) {
+                printf("[!] requested %lu bytes alignmed to %lu bytes\n",
+                    o->sz, o->align);
+                ag_log_err("requested %lu bytes aligned to %lu bytes",
+                    o->sz, o->align);
+        } else {
+                printf("[!] requested %lu bytes\n", o->sz);
+                ag_log_err("requested %lu bytes", o->sz);
+        }
+
+        ag_exit(EXIT_FAILURE);
+}
+
 
 extern void
 ag_exception_regex_hnd(const struct ag_exception *ex, void *opt)

--- a/src/exception-handler.c
+++ b/src/exception-handler.c
@@ -1,0 +1,22 @@
+#include "../include/argent.h"
+
+
+extern void
+ag_exception_regex_hnd(const struct ag_exception *ex, void *opt)
+{
+        struct ag_exception_regex *x = opt;
+        
+        printf("[!] %d [%s(), %s:%lu]: %s\n", ex->erno, ex->func, ex->file,
+            ex->line, ag_exception_registry_msg(ex->erno));
+        
+        ag_log_err("%d [%s(), %s:%lu]: %s", ex->erno, ex->func, ex->file,
+            ex->line, ag_exception_registry_msg(ex->erno));
+
+        const char *msg = "[!] string = %s, regex = %s\n";
+        printf(msg, x->str, x->regex);
+        ag_log_err(msg, x->str, x->regex);
+
+        ag_exit(EXIT_FAILURE);
+}
+
+

--- a/src/manager.c
+++ b/src/manager.c
@@ -19,6 +19,11 @@ ag_init(void)
                         .msg = AG_ERNO_MSG(AG_ERNO_MBLOCK),
                         .hnd = &ag_memblock_exception_handler
                 },
+                {
+                        .erno = AG_ERNO_REGEX, 
+                        .msg = AG_ERNO_MSG(AG_ERNO_REGEX),
+                        .hnd = &ag_exception_regex_hnd,
+                },
         };
 
         ag_exception_registry_init(32);

--- a/src/manager.c
+++ b/src/manager.c
@@ -17,7 +17,7 @@ ag_init(void)
                 {
                         .erno = AG_ERNO_MBLOCK, 
                         .msg = AG_ERNO_MSG(AG_ERNO_MBLOCK),
-                        .hnd = &ag_memblock_exception_handler
+                        .hnd = &ag_exception_memblock_hnd
                 },
                 {
                         .erno = AG_ERNO_REGEX, 

--- a/src/memblock.c
+++ b/src/memblock.c
@@ -37,22 +37,17 @@ meta_refc(const ag_memblock *ctx)
 extern void
 ag_memblock_exception_handler(const struct ag_exception *ex, void *opt)
 {
-        struct ag_memblock_exception *x = (struct ag_memblock_exception *) opt;
+        (void)ex;
+        struct ag_memblock_exception *o = opt;
 
-        printf("[!] %d [%s(), %s:%lu]: %s\n", ex->erno, ex->func, ex->file,
-            ex->line, ag_exception_registry_msg(ex->erno));
-        
-        ag_log_err("%d [%s(), %s:%lu]: %s", ex->erno, ex->func, ex->file,
-            ex->line, ag_exception_registry_msg(ex->erno));
-
-        if (x->align) {
+        if (o->align) {
                 printf("[!] requested %lu bytes alignmed to %lu bytes\n",
-                    x->sz, x->align);
-                ag_log_err("requested %lu bytes aligned to %lu bytes", x->sz,
-                    x->align);
+                    o->sz, o->align);
+                ag_log_err("requested %lu bytes aligned to %lu bytes",
+                    o->sz, o->align);
         } else {
-                printf("[!] requested %lu bytes\n", x->sz);
-                ag_log_err("requested %lu bytes", x->sz);
+                printf("[!] requested %lu bytes\n", o->sz);
+                ag_log_err("requested %lu bytes", o->sz);
         }
 
         ag_exit(EXIT_FAILURE);

--- a/src/memblock.c
+++ b/src/memblock.c
@@ -34,37 +34,13 @@ meta_refc(const ag_memblock *ctx)
 }
 
 
-extern void
-ag_memblock_exception_handler(const struct ag_exception *ex, void *opt)
-{
-        (void)ex;
-        struct ag_memblock_exception *o = opt;
-
-        if (o->align) {
-                printf("[!] requested %lu bytes alignmed to %lu bytes\n",
-                    o->sz, o->align);
-                ag_log_err("requested %lu bytes aligned to %lu bytes",
-                    o->sz, o->align);
-        } else {
-                printf("[!] requested %lu bytes\n", o->sz);
-                ag_log_err("requested %lu bytes", o->sz);
-        }
-
-        ag_exit(EXIT_FAILURE);
-}
-
-
 extern ag_memblock *
 ag_memblock_new(size_t sz)
 {
         AG_ASSERT (is_size_valid(sz));
 
-        struct ag_memblock_exception x = {
-                .sz = sz,
-                .align = 0,
-        };
-
         size_t *ctx = malloc(sizeof(size_t) * 2 + sz);
+        struct ag_exception_memblock x = { .sz = sz, .align = 0i };
         AG_REQUIRE_OPT (ctx, AG_ERNO_MBLOCK, &x);
 
         memset(ctx, 0, sz);
@@ -81,13 +57,10 @@ ag_memblock_new_align(size_t sz, size_t align)
         AG_ASSERT (is_size_valid(sz));
         AG_ASSERT (is_alignment_valid(align));
         
-        struct ag_memblock_exception x = {
-                .sz = sz,
-                .align = align,
-        };
-
         size_t *ctx;
-        (void) posix_memalign((void **)&ctx, align, sizeof(size_t) * 2 + sz);
+        (void)posix_memalign((void **)&ctx, align, sizeof(size_t) * 2 + sz);
+
+        struct ag_exception_memblock x = { .sz = sz, .align = align };
         AG_REQUIRE_OPT (ctx, AG_ERNO_MBLOCK, &x);
         
         memset(ctx, 0, sz);

--- a/src/string.c
+++ b/src/string.c
@@ -24,6 +24,7 @@
 #include "../include/argent.h"
 
 #include <ctype.h>
+#include <regex.h>
 #include <string.h>
 #include <stdarg.h>
 
@@ -183,7 +184,7 @@ ag_string_cmp(const ag_string *ctx,  const char *cmp)
 /*
  * Define the ag_string_has() interface function. This function checks whether a
  * string contains a particular substring.
- * */
+ */
 
 
 extern bool
@@ -196,6 +197,26 @@ ag_string_has(const ag_string *ctx, const char *tgt)
                 return false;
 
         return strstr(ctx, tgt);
+}
+
+
+extern bool
+ag_string_match(const ag_string *ctx, const char *regex)
+{
+        AG_ASSERT_PTR (ctx);
+        AG_ASSERT_PTR (regex);
+
+        if (AG_UNLIKELY (!(*ctx && *regex)))
+                return false;
+
+        regex_t r;
+        int rc = regcomp(&r, regex, 0);
+        AG_REQUIRE (!rc, AG_ERNO_REGEX);
+
+        rc = regexec(&r, ctx, 0, NULL, 0);
+        AG_REQUIRE (!rc || rc == REG_NOMATCH, AG_ERNO_REGEX);
+
+        return !rc;
 }
 
 

--- a/src/string.c
+++ b/src/string.c
@@ -211,10 +211,12 @@ ag_string_match(const ag_string *ctx, const char *regex)
 
         regex_t r;
         int rc = regcomp(&r, regex, 0);
-        AG_REQUIRE (!rc, AG_ERNO_REGEX);
+
+        struct ag_exception_regex x = {.str = ctx, .regex = regex};
+        AG_REQUIRE_OPT (!rc, AG_ERNO_REGEX, &x);
 
         rc = regexec(&r, ctx, 0, NULL, 0);
-        AG_REQUIRE (!rc || rc == REG_NOMATCH, AG_ERNO_REGEX);
+        AG_REQUIRE_OPT (!rc || rc == REG_NOMATCH, AG_ERNO_REGEX, &x);
 
         regfree(&r);
         return !rc;

--- a/src/string.c
+++ b/src/string.c
@@ -216,6 +216,7 @@ ag_string_match(const ag_string *ctx, const char *regex)
         rc = regexec(&r, ctx, 0, NULL, 0);
         AG_REQUIRE (!rc || rc == REG_NOMATCH, AG_ERNO_REGEX);
 
+        regfree(&r);
         return !rc;
 }
 

--- a/src/string.c
+++ b/src/string.c
@@ -200,6 +200,16 @@ ag_string_has(const ag_string *ctx, const char *tgt)
 }
 
 
+/*
+ * Define the ag_string_match() interface function. This function checks whether
+ * a given dynamic string matches the mattern defineed by a POSIX-style regular
+ * expression. In case there is an error in compiling and executing the regular
+ * expression, the AG_ERNO_REGEX exception is signalled.
+ *
+ * See the selected answer on https://stackoverflow.com/questions/1085083/.
+ */
+
+
 extern bool
 ag_string_match(const ag_string *ctx, const char *regex)
 {

--- a/src/string.c
+++ b/src/string.c
@@ -229,10 +229,11 @@ ag_string_match(const ag_string *ctx, const char *regex)
         regex_t r;
         int rc = regcomp(&r, regex, 0);
 
-        struct ag_exception_regex x = {.str = ctx, .regex = regex};
+        struct ag_exception_regex x = {.str = ctx, .regex = regex, .ecode = rc};
         AG_REQUIRE_OPT (!rc, AG_ERNO_REGEX, &x);
 
         rc = regexec(&r, ctx, 0, NULL, 0);
+        x.ecode = rc;
         AG_REQUIRE_OPT (!rc || rc == REG_NOMATCH, AG_ERNO_REGEX, &x);
 
         regfree(&r);

--- a/src/string.c
+++ b/src/string.c
@@ -183,20 +183,23 @@ ag_string_cmp(const ag_string *ctx,  const char *cmp)
 
 /*
  * Define the ag_string_has() interface function. This function checks whether a
- * string contains a particular substring.
+ * string contains a particular substring. This function returns true if the
+ * substring is found in the contextual string, or false otherwise. False is
+ * always returned in the edge cases where either the contextual string or the
+ * substring to find are empty.
  */
 
 
 extern bool
-ag_string_has(const ag_string *ctx, const char *tgt)
+ag_string_has(const ag_string *ctx, const char *sub)
 {
         AG_ASSERT_PTR (ctx);
-        AG_ASSERT_PTR (tgt);
+        AG_ASSERT_PTR (sub);
 
-        if (AG_UNLIKELY (!*tgt && *ctx))
+        if (AG_UNLIKELY (!*sub && *ctx))
                 return false;
 
-        return strstr(ctx, tgt);
+        return strstr(ctx, sub);
 }
 
 
@@ -205,6 +208,10 @@ ag_string_has(const ag_string *ctx, const char *tgt)
  * a given dynamic string matches the mattern defineed by a POSIX-style regular
  * expression. In case there is an error in compiling and executing the regular
  * expression, the AG_ERNO_REGEX exception is signalled.
+ *
+ * This function returns true if the contextual string matches the regular
+ * expression, or false otherwise. In case either the contextual string or the
+ * regual expression are empty, then false is returned.
  *
  * See the selected answer on https://stackoverflow.com/questions/1085083/.
  */

--- a/test/string.c
+++ b/test/string.c
@@ -781,7 +781,43 @@ AG_TEST_CASE("ag_string_has() returns false if it doesn't find a Unicode needle"
 
 
 /*
- * Define the test cases for ag_string_lower(). Not that these test cases are
+ * Define the test cases for ag_string_match(). Note that as of now the test
+ * cases are only provided for empty and ASCII strings.
+ *
+ * TODO: Explore Unicode tests
+ */
+
+
+AG_TEST_CASE("ag_string_match() returns false if applied on an empty string")
+{
+        AG_AUTO(ag_string) *s = ag_string_new_empty();
+        AG_TEST (!ag_string_match(s, "^a[[:alnum:]]"));
+}
+
+
+AG_TEST_CASE("ag_string_match() returns false if the regex is an empty string")
+{
+        AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
+        AG_TEST (!ag_string_match(s, ""));
+}
+
+
+AG_TEST_CASE("ag_string_match() returns true if a regex match is found")
+{
+        AG_AUTO(ag_string) *s = ag_string_new("abc");
+        AG_TEST (ag_string_match(s, "^a[[:alnum:]]"));
+}
+
+
+AG_TEST_CASE("ag_string_match() returns false if a regex match is not found")
+{
+        AG_AUTO(ag_string) *s = ag_string_new("Hello, world!");
+        AG_TEST (!ag_string_match(s, "^a[[:alnum:]]"));
+}
+
+
+/*
+ * Define the test cases for ag_string_lower(). Note that these test cases are
  * only for empty and ASCII strings since ag_string_lower() doesn't support
  * Unicode strings as yet.
  *


### PR DESCRIPTION
The string interface now supports POSIX-style regular expressions through the `ag_string_match()` function. The preliminary test cases seem to indicate that it is working as expected for empty and ASCII strings. No test cases for Unicode strings have been done, and this is left for a later date.

Since the regex engine can fail at runtime, the `ag_exception_regex_hnd()` exception handler has been introduced. Along with this, the existing exception handler for the memory block module has been refactored.

This pull request closes #49.