### PR TITLE
Add Cirrus CI support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,6 @@ freebsd_instance:
 task:
   install_script:
     pkg update &&
-    pkg upgrade -y &&
     pkg install -y gmake postgresql12-server postgresql12-client valgrind-devel
-  script: gmake test
+  script: gmake check
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-freebsd_instace:
+freebsd_instance:
   image_family: freebsd-12-1
 
 task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,6 +2,9 @@ freebsd_instance:
   image_family: freebsd-12-1
 
 task:
-  install_script: pkg install -y gmake
+  install_script:
+    pkg update
+    pkg upgrade
+    pkg install -y gmake postgresql12-server postgresql12-client
   script: gmake test
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,8 +3,8 @@ freebsd_instance:
 
 task:
   install_script:
-    pkg update
-    pkg upgrade
+    pkg update &&
+    pkg upgrade &&
     pkg install -y gmake postgresql12-server postgresql12-client
   script: gmake test
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,6 +2,6 @@ freebsd_instace:
   image_family: freebsd-12-1
 
 task:
-  install_scrpt: pkg install -y gmake
+  install_script: pkg install -y gmake
   script: gmake test
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,7 @@
+freebsd_instace:
+  image_family: freebsd-12-1
+
+task:
+  install_scrpt: pkg install -y gmake
+  script: gmake test
+

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,7 @@ freebsd_instance:
 task:
   install_script:
     pkg update &&
-    pkg install -y gmake postgresql12-server postgresql12-client valgrind-devel
+    pkg install -y gmake e2fsprogs-libuuid postgresql12-server 
+    postgresql12-client valgrind-devel
   script: gmake check
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ freebsd_instance:
 task:
   install_script:
     pkg update &&
-    pkg install -y gmake ccache e2fsprogs-libuuid postgresql12-server 
-    postgresql12-client valgrind-devel
+    pkg install -y gmake ccache e2fsprogs-libuuid postgresql12-server
+    postgresql12-client postgresql-libpgeasy valgrind-devel
   script: gmake check
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ freebsd_instance:
 task:
   install_script:
     pkg update &&
-    pkg upgrade &&
-    pkg install -y gmake postgresql12-server postgresql12-client
+    pkg upgrade -y &&
+    pkg install -y gmake postgresql12-server postgresql12-client valgrind-devel
   script: gmake test
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ freebsd_instance:
 task:
   install_script:
     pkg update &&
-    pkg install -y gmake e2fsprogs-libuuid postgresql12-server 
+    pkg install -y gmake ccache e2fsprogs-libuuid postgresql12-server 
     postgresql12-client valgrind-devel
   script: gmake check
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ $(BIN_LIB): $(OBJ_LIB) | $(DIR_BLD)
 	$(LINK.c) -shared $^ -o $@
 
 $(BIN_TEST): $(SRC_TEST) $(BIN_LIB) | $(DIR_BLD)
-	$(LINK.c) $^ -o $@
+	$(CCC) $^ $(LDFLAGS) -o $@
 
 $(DIR_BLD)/%.o: $(DIR_LIB)/%.c | $(DIR_BLD)
 	$(COMPILE.c) $^ -o $@

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BIN_LIB = bld/libargent.so
 
 CCC = ccache $(CC)
 CFLAGS = -fPIC -g -Wall -Wextra -I $(shell pg_config --includedir)
-LDFLAGS = -shared -rdynamic -L $(shell pg_config --libdir) -lpq -luuid -ldl
+LDFLAGS = -rdynamic -L $(shell pg_config --libdir) -lpq -luuid -ldl
 
 
 
@@ -51,7 +51,7 @@ $(BIN_LIB): $(OBJ_LIB) | $(DIR_BLD)
 	$(LINK.c) -shared $^ -o $@
 
 $(BIN_TEST): $(SRC_TEST) $(BIN_LIB) | $(DIR_BLD)
-	$(CCC) -rdynamic $^ -lpq -luuid -ldl -o $@
+	$(LINK.c) $^ -o $@
 
 $(DIR_BLD)/%.o: $(DIR_LIB)/%.c | $(DIR_BLD)
 	$(COMPILE.c) $^ -o $@

--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
 - `git clone https://github.com/achakravarti/argent.git`
 - `make`
 - `make check`
+
+
+## Supporters
+A warm thank you to all those who have shown interest in the Argent Library!
+
+[![Stargazers repo roster for @achakravarti/argent](https://reporoster.com/stars/achakravarti/argent)](https://github.com/achakravarti/argent/stargazers)
+

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
 - [Building](#building)
 
 
-## Building [![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent)
+## Building [![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic)
 - `git clone https://github.com/achakravarti/argent.git`
 - `make`
 - `make check`

--- a/src/memblock.c
+++ b/src/memblock.c
@@ -1,6 +1,8 @@
 #include "../include/argent.h"
 
-#include <malloc.h>
+#ifdef __linux__
+#       include <malloc.h>
+#endif
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/memblock.c
+++ b/src/memblock.c
@@ -1,6 +1,8 @@
 #include "../include/argent.h"
 
-#ifdef __linux__
+#ifdef __FreeBSD__
+#       include <malloc_np.h>
+#else
 #       include <malloc.h>
 #endif
 #include <stdarg.h>

--- a/src/test-harness.c
+++ b/src/test-harness.c
@@ -67,24 +67,6 @@ node_new(const ag_test_suite *ts)
 
 
 /*
- * node_copy(): create deep copy of test suite list node.
- *
- * @ctx: contextual test suite list node.
- *
- * Return: copy of @ctx.
- */
-static inline struct node *
-node_copy(const struct node *ctx)
-{
-        struct node *n = ag_memblock_new(sizeof *n);
-        n->ts = ag_test_suite_copy(ctx->ts);
-        n->nxt = ctx->nxt;
-
-        return (n);
-}
-
-
-/*
  * node_free(): free test suite list node.
  *
  * @ctx: contextual test suite list node.

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -1,6 +1,11 @@
 #include "../include/argent.h"
 
-#include <uuid/uuid.h>
+#ifdef __FreeBSD__
+#       include <uuid.h>
+#else
+#       include <uuid/uuid.h>
+#endif
+
 
 struct ag_uuid {
         uuid_t  uuid;

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -1,10 +1,6 @@
 #include "../include/argent.h"
 
-#ifdef __FreeBSD__
-#       include <uuid.h>
-#else
-#       include <uuid/uuid.h>
-#endif
+#include <uuid/uuid.h>
 
 
 struct ag_uuid {

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -113,7 +113,7 @@ ag_uuid_str(const ag_uuid *ctx)
 {
         AG_ASSERT_PTR (ctx);
 
-        char bfr[37];
+        char bfr[UUID_STR_LEN];
         uuid_unparse_upper(ctx->uuid, bfr);
 
         return (ag_string_new(bfr));

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -8,6 +8,12 @@ struct ag_uuid {
 };
 
 
+/* Required for FreeBSD */
+#ifndef UUID_STR_LEN
+#       define UUID_STR_LEN 37
+#endif
+
+
 extern inline bool      ag_uuid_lt(const ag_uuid *, const ag_uuid *);
 extern inline bool      ag_uuid_eq(const ag_uuid *, const ag_uuid *);
 extern inline bool      ag_uuid_gt(const ag_uuid *, const ag_uuid *);

--- a/src/value.c
+++ b/src/value.c
@@ -8,17 +8,11 @@
  */
 
 
-#define MASK_TAG ((uintptr_t)(8 - 1))
-#define MASK_PTR (~MASK_TAG)
+#define MASK_TAG        ((uintptr_t)(8 - 1))
+#define MASK_PTR        (~MASK_TAG)
 
-#define SHIFT_UINT ((uintptr_t)1)
-#define SHIFT_INT ((uintptr_t)3)
-
-
-static inline bool tag_check(const ag_value *ctx, uintptr_t tag)
-{
-    return ((uintptr_t)ctx & tag) == tag;
-}
+#define SHIFT_UINT      ((uintptr_t)1)
+#define SHIFT_INT       ((uintptr_t)3)
 
 
 extern inline bool      ag_value_lt(const ag_value *, const ag_value *);

--- a/test/runner.c
+++ b/test/runner.c
@@ -2,7 +2,6 @@
 #include "../include/argent.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The Argent Library now defines build rules for Cirrus CI in the `.cirrus.yml` file. The Cirrus CI build is used to run the automated tests on a FreeBSD VM. The `UUID_STR_LEN` symbolic constant is now used in `ag_uuid_str()` for better code readability, and a little thank you note has been added to the `README`.

This PR closes #58.