### PR TITLE
Setup code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ dkms.conf
 *.toc
 *.xml
 
+# Code coverage
+*.gcda
+*.gcno
+
 # Development environment
 /bld
 tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt update
   - sudo apt install uuid-dev
   - sudo apt install valgrind
-  - sudo apt install gcov
+  - sudo apt install gcovr
 
 script:
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ before_install:
   - sudo apt update
   - sudo apt install uuid-dev
   - sudo apt install valgrind
-  - sudo apt install gcovr
+  - pip install --user cpp-coveralls
 
 script:
-  - make check
+  -  ./configure --enable-gcov make check
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - coveralls --gcov-options '\lp'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - pip install --user cpp-coveralls
 
 script:
-  -  ./configure --enable-gcov make check
+  -  make check
 
 after_success:
   - coveralls --gcov-options '\lp'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ before_install:
   - sudo apt update
   - sudo apt install uuid-dev
   - sudo apt install valgrind
+  - sudo apt install gcov
 
 script:
   - make check
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ check: $(BIN_TEST)
 
 clean:
 	rm -rfv $(DIR_BLD) $(DOC_TMP)
+	rm *.gcno *.gcda
 
 
 .PHONY: all doc clean

--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,17 @@ check: $(BIN_TEST)
 		$(BIN_TEST)
 	tail $(BIN_TEST).vglog
 
+coverage:
+	gcovr -r .
+
+
 clean:
 	rm -rfv $(DIR_BLD) $(DOC_TMP)
 	rm *.gcno *.gcda
 
+tidy:
+	rm *.gcno *.gcda
 
-.PHONY: all doc clean
+
+.PHONY: all doc clean tidy coverage
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ OBJ_LIB = $(patsubst $(DIR_LIB)/%.c, $(DIR_BLD)/%.o, $(SRC_LIB))
 BIN_LIB = bld/libargent.so
 
 CCC = ccache $(CC)
-CFLAGS = -fPIC -g -Wall -Wextra -I $(shell pg_config --includedir)
+CFLAGS = -fPIC -g --coverage -O0 -Wall -Wextra -I $(shell pg_config --includedir)
 LDFLAGS = -rdynamic -L $(shell pg_config --libdir) -lpq -luuid -ldl
 
 
@@ -51,7 +51,7 @@ $(BIN_LIB): $(OBJ_LIB) | $(DIR_BLD)
 	$(LINK.c) -shared $^ -o $@
 
 $(BIN_TEST): $(SRC_TEST) $(BIN_LIB) | $(DIR_BLD)
-	$(CCC) $^ $(LDFLAGS) -o $@
+	$(CCC) -g --coverage -O0 $^ $(LDFLAGS) -o $@
 
 $(DIR_BLD)/%.o: $(DIR_LIB)/%.c | $(DIR_BLD)
 	$(COMPILE.c) $^ -o $@

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
 - [Building](#building)
 
 
-## Building [![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic)
+## Building [![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic) [![Coverage Status](https://coveralls.io/repos/github/achakravarti/argent/badge.svg?branch=master)](https://coveralls.io/github/achakravarti/argent?branch=master)
 - `git clone https://github.com/achakravarti/argent.git`
 - `make`
 - `make check`

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 
 
 ### Installing
-    - `git clone https://github.com/achakravarti/argent.git`
-    - `make`
+  - `git clone https://github.com/achakravarti/argent.git`
+  - `make`
 
 
 ## Running the Tests  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,68 @@
 # Argent Library
 > Infrastructure for building web services
 
+
+
+## Summary
+  - [Getting Started](#getting-started)
+  - [Runing the tests](#running-the-tests)
+  - [Deployment](#deployment)
+  - [Built With](#built-with)
+  - [Contributing](#contributing)
+  - [Versioning](#versioning)
+  - [Authors](#authors)
+  - [License](#license)
+  - [Acknowledgments](#acknowledgments)
+
+
+## Getting Started[![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent?branch=master) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic)  
+
+
+### Prerequisites
+
+
+### Installing
+    - `git clone https://github.com/achakravarti/argent.git`
+    - `make`
+
+
+## Running the Tests [![Coverage Status](https://coveralls.io/repos/github/achakravarti/argent/badge.svg?branch=master)](https://coveralls.io/github/achakravarti/argent?branch=master)
+  - `make test`
+  - `make check`
+  - `make coverage`
+
+
+## Built With
+  - Vim
+  - GCC
+  - Clang
+  - Arch Linux
+  - FreeBSD
+  - Ubuntu
+  - Git
+  - LaTeX
+  - GCov
+  - GCovr
+  - GitHub
+  - Travis-CI
+  - Cirrus CI
+  - Coveralls
+
+## Contributing
+Contributions are welcome!
+
+
+## Versioning
+The Argent Library uses Semantic Versioning. The following tagged versions are
+available:
+  - v0.1.0
+  - v0.2.0
+
+
+## Authors
+  - Abhishek Chakravarti <abhishek@taranjali.org>
+
+
 ## License [![GitHub license](https://img.shields.io/github/license/achakravarti/argent.svg)](https://github.com/achakravarti/argent/blob/master/LICENSE)
 
 Copyright (C) 2020 Abhishek Chakravarti  
@@ -22,18 +84,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
 
 
-## Contents
-- [License](#license)
-- [Building](#building)
-
-
-## Building [![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent?branch=master) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic) [![Coverage Status](https://coveralls.io/repos/github/achakravarti/argent/badge.svg?branch=master)](https://coveralls.io/github/achakravarti/argent?branch=master)
-- `git clone https://github.com/achakravarti/argent.git`
-- `make`
-- `make check`
-
-
-## Supporters
+## Acknowledgments
 A warm thank you to all those who have shown interest in the Argent Library!
 
 [![Stargazers repo roster for @achakravarti/argent](https://reporoster.com/stars/achakravarti/argent)](https://github.com/achakravarti/argent/stargazers)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Argent Library
+# Argent Library  
+[![GitHub forks](https://img.shields.io/github/forks/achakravarti/argent.svg?style=social&label=Fork&maxAge=2592000)](https://github.com/achakravarti/argent/network/)
+[![GitHub stars](https://img.shields.io/github/stars/achakravarti/argent.svg?style=social&label=Star&maxAge=2592000)](https://github.com/achakravarti/argent/stargazers/)
+[![GitHub watchers](https://img.shields.io/github/watchers/achakravarti/argent.svg?style=social&label=Watch&maxAge=2592000)](https://github.com/achakravarti/argent/watchers/)
+
 > Infrastructure for building web services
 
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@
   - Make
 
 
-## Versioning
+## Versioning  
+[![GitHub tag](https://img.shields.io/github/tag/achakravarti/argent.svg)](https://github.com/achakravarti/argent/tags/)
+
 The Argent Library uses Semantic Versioning. The following tagged versions are
 available:
   - v0.2.0

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
   - [Acknowledgments](#acknowledgments)
 
 
-## Getting Started [![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent?branch=master) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic)  
+## Getting Started  
+[![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent?branch=master) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic)  
 
 
 ### Prerequisites
@@ -25,7 +26,9 @@
     - `make`
 
 
-## Running the Tests [![Coverage Status](https://coveralls.io/repos/github/achakravarti/argent/badge.svg?branch=master)](https://coveralls.io/github/achakravarti/argent?branch=master)
+## Running the Tests  
+[![Coverage Status](https://coveralls.io/repos/github/achakravarti/argent/badge.svg?branch=master)](https://coveralls.io/github/achakravarti/argent?branch=master)
+
   - `make test`
   - `make check`
   - `make coverage`
@@ -56,13 +59,16 @@ available:
   - v0.1.0
 
 
-## Contributors  [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](http://makeapullrequest.com) [![GitHub contributors](https://img.shields.io/github/contributors/achakravarti/argent.svg)](https://github.com/achakravarti/argent/graphs/contributors/)
+## Contributors  
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](http://makeapullrequest.com) [![GitHub contributors](https://img.shields.io/github/contributors/achakravarti/argent.svg)](https://github.com/achakravarti/argent/graphs/contributors/)
+
 Contributions are welcome!
 
   - Abhishek Chakravarti <abhishek@taranjali.org>
 
 
-## License [![GitHub license](https://img.shields.io/github/license/achakravarti/argent.svg)](https://github.com/achakravarti/argent/blob/master/LICENSE)
+## License 
+[![GitHub license](https://img.shields.io/github/license/achakravarti/argent.svg)](https://github.com/achakravarti/argent/blob/master/LICENSE)
 
 Copyright (C) 2020 Abhishek Chakravarti  
 <abhishek@taranjali.org>

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@
   - [Runing the tests](#running-the-tests)
   - [Deployment](#deployment)
   - [Built With](#built-with)
-  - [Contributing](#contributing)
   - [Versioning](#versioning)
-  - [Authors](#authors)
+  - [Contributors](#contributors)
   - [License](#license)
   - [Acknowledgments](#acknowledgments)
 
 
-## Getting Started[![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent?branch=master) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic)  
+## Getting Started [![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent?branch=master) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic)  
 
 
 ### Prerequisites
@@ -47,19 +46,19 @@
   - Travis-CI
   - Cirrus CI
   - Coveralls
-
-## Contributing
-Contributions are welcome!
+  - Make
 
 
 ## Versioning
 The Argent Library uses Semantic Versioning. The following tagged versions are
 available:
-  - v0.1.0
   - v0.2.0
+  - v0.1.0
 
 
-## Authors
+## Contributors  [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](http://makeapullrequest.com) [![GitHub contributors](https://img.shields.io/github/contributors/achakravarti/argent.svg)](https://github.com/achakravarti/argent/graphs/contributors/)
+Contributions are welcome!
+
   - Abhishek Chakravarti <abhishek@taranjali.org>
 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
 - [Building](#building)
 
 
-## Building [![Build Status](https://travis-ci.com/achakravarti/argent.svg)](https://travis-ci.com/achakravarti/argent) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic) [![Coverage Status](https://coveralls.io/repos/github/achakravarti/argent/badge.svg)](https://coveralls.io/github/achakravarti/argent)
+## Building [![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent?branch=master) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic) [![Coverage Status](https://coveralls.io/repos/github/achakravarti/argent/badge.svg?branch=master)](https://coveralls.io/github/achakravarti/argent?branch=master)
 - `git clone https://github.com/achakravarti/argent.git`
 - `make`
 - `make check`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can contact Abhishek Chakravarti at <abhishek@taranjali.org>.
 - [Building](#building)
 
 
-## Building [![Build Status](https://travis-ci.com/achakravarti/argent.svg?branch=master)](https://travis-ci.com/achakravarti/argent) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic) [![Coverage Status](https://coveralls.io/repos/github/achakravarti/argent/badge.svg?branch=master)](https://coveralls.io/github/achakravarti/argent?branch=master)
+## Building [![Build Status](https://travis-ci.com/achakravarti/argent.svg)](https://travis-ci.com/achakravarti/argent) ![Cirrus CI - Base Branch Build Status](https://img.shields.io/cirrus/github/achakravarti/argent?style=plastic) [![Coverage Status](https://coveralls.io/repos/github/achakravarti/argent/badge.svg)](https://coveralls.io/github/achakravarti/argent)
 - `git clone https://github.com/achakravarti/argent.git`
 - `make`
 - `make check`


### PR DESCRIPTION
Code coverage is now available for the Argent Library. The build flags have been modified to include the `--coverage -g -O0` flags, and the `coverage` and `tidy` build targets have been added. Coveralls has been integrated with Travis CI so that code coverage is also automated and displayed as a badge in the `README.md` file.

The Readme file has also been improved, but still remains incomplete.

This PR closes #59.